### PR TITLE
fix: resolve GitHub Actions workflow failures

### DIFF
--- a/.github/workflows/scorecard.yml
+++ b/.github/workflows/scorecard.yml
@@ -20,7 +20,7 @@ jobs:
         with:
           persist-credentials: false
 
-      - uses: ossf/scorecard-action@05b42c624433fc40578a4040d5cf5e36ddca94c0  # v2.4.2
+      - uses: ossf/scorecard-action@v2
         with:
           results_file: results.sarif
           results_format: sarif

--- a/.github/workflows/sonarcloud.yml
+++ b/.github/workflows/sonarcloud.yml
@@ -30,7 +30,7 @@ jobs:
           uv sync --group dev
           uv run pytest --cov-report=xml:coverage.xml
 
-      - uses: SonarSource/sonarqube-scan-action@aa494459d7c39c106cc77b166de8edea56f7a0f1  # v5.0.0
+      - uses: SonarSource/sonarqube-scan-action@v5
         env:
           SONAR_TOKEN: ${{ secrets.SONAR_TOKEN }}
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}


### PR DESCRIPTION
Fixes failing SonarCloud and OpenSSF Scorecard workflows by replacing non-existent commit SHAs with stable version tags.

## Changes
- `SonarSource/sonarqube-scan-action@aa494459... ` → `SonarSource/sonarqube-scan-action@v5`
- `ossf/scorecard-action@05b42c62... ` → `ossf/scorecard-action@v2`

## Why
The workflows were pinned to specific commit SHAs that no longer exist or aren't accessible. Using major version tags allows GitHub Actions to automatically resolve to the latest stable versions.