### PR TITLE
testify: regenerate 005-ci-cd-pipeline BDD assertion timestamp

### DIFF
--- a/specs/005-ci-cd-pipeline/context.json
+++ b/specs/005-ci-cd-pipeline/context.json
@@ -1,7 +1,7 @@
 {
   "testify": {
     "assertion_hash": "38f901f74e86804a01b69839db2f1dcf8e50a998df2f2a0a0c0b9a2b3d4699f0",
-    "generated_at": "2026-03-09T12:06:44Z",
+    "generated_at": "2026-03-09T12:29:18Z",
     "features_dir": "specs/005-ci-cd-pipeline/tests/features",
     "file_count": 6
   }


### PR DESCRIPTION
## Summary

- Regenerate `specs/005-ci-cd-pipeline/context.json` assertion timestamp via `/iikit-04-testify`
- No changes to feature files, step definitions, or production code — assertion hash is unchanged

## Changes

- `specs/005-ci-cd-pipeline/context.json`: updated `generated_at` timestamp (hash unchanged)

## Test plan

- [x] Assertion hash remains `38f901f...` — no spec drift
- [x] No `.feature` files modified
- [x] All existing CI tests unaffected (config-only change)

🤖 Generated with [Claude Code](https://claude.com/claude-code)