### PR TITLE
fix(ci): switch publish workflow to token-based auth

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -54,8 +54,6 @@ jobs:
     runs-on: ubuntu-latest
     timeout-minutes: 10
     environment: testpypi
-    permissions:
-      id-token: write
     steps:
       - uses: actions/download-artifact@d3f86a106a0bac45b974a628896c90dbdf5c8093  # v4
         with:
@@ -64,6 +62,7 @@ jobs:
       - uses: pypa/gh-action-pypi-publish@ed0c53931b1dc9bd32cbe73a98c7f6766f8a527e  # v1.13.0
         with:
           repository-url: https://test.pypi.org/legacy/
+          password: ${{ secrets.TESTPYPI_API_TOKEN }}
 
   validate-testpypi:
     needs: [publish-testpypi, validate-version]
@@ -98,11 +97,11 @@ jobs:
     runs-on: ubuntu-latest
     timeout-minutes: 10
     environment: pypi
-    permissions:
-      id-token: write
     steps:
       - uses: actions/download-artifact@d3f86a106a0bac45b974a628896c90dbdf5c8093  # v4
         with:
           name: dist
           path: dist/
       - uses: pypa/gh-action-pypi-publish@ed0c53931b1dc9bd32cbe73a98c7f6766f8a527e  # v1.13.0
+        with:
+          password: ${{ secrets.PYPI_API_TOKEN }}

--- a/.github/workflows/sonarcloud.yml
+++ b/.github/workflows/sonarcloud.yml
@@ -30,7 +30,7 @@ jobs:
           uv sync --group dev
           uv run pytest --cov-report=xml:coverage.xml
 
-      - uses: SonarSource/sonarqube-scan-action@v6
+      - uses: SonarSource/sonarqube-scan-action@fd88b7d7ccbaefd23d8f36f73b59db7a3d246602  # v6
         env:
           SONAR_TOKEN: ${{ secrets.SONAR_TOKEN }}
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/sonarcloud.yml
+++ b/.github/workflows/sonarcloud.yml
@@ -30,7 +30,7 @@ jobs:
           uv sync --group dev
           uv run pytest --cov-report=xml:coverage.xml
 
-      - uses: SonarSource/sonarqube-scan-action@v5
+      - uses: SonarSource/sonarqube-scan-action@v6
         env:
           SONAR_TOKEN: ${{ secrets.SONAR_TOKEN }}
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -1,0 +1,21 @@
+# Security Policy
+
+## Supported Versions
+
+| Version | Supported |
+| ------- | --------- |
+| latest  | Yes       |
+
+## Reporting a Vulnerability
+
+Please **do not** open a public GitHub issue for security vulnerabilities.
+
+Report vulnerabilities privately via [GitHub Security Advisories](https://github.com/jcbianic/apicurio-serdes/security/advisories/new).
+
+Include as much detail as possible:
+- A description of the vulnerability
+- Steps to reproduce
+- Potential impact
+- Any suggested fixes
+
+You will receive a response within 7 days. If the issue is confirmed, a fix will be prioritised and a CVE requested if appropriate.

--- a/tests/ci/test_publish_workflow.py
+++ b/tests/ci/test_publish_workflow.py
@@ -111,25 +111,37 @@ class TestVersionValidation:
         )
 
 
-class TestOIDCTrustedPublishing:
-    """TS-016: Publication uses OIDC trusted publishing."""
+class TestTokenBasedPublishing:
+    """TS-016: Publication uses token-based auth via API secrets."""
 
-    def test_publish_testpypi_has_id_token_write(
+    def test_publish_testpypi_uses_token_auth(
         self, publish_workflow: dict[str, Any]
     ) -> None:
         job = publish_workflow["jobs"]["publish-testpypi"]
-        perms = job.get("permissions", {})
-        assert perms.get("id-token") == "write", (
-            "publish-testpypi must have id-token: write for OIDC"
+        publish_steps = [
+            s
+            for s in job["steps"]
+            if "pypa/gh-action-pypi-publish" in s.get("uses", "")
+        ]
+        assert publish_steps, "publish-testpypi must use pypa/gh-action-pypi-publish"
+        password = publish_steps[0].get("with", {}).get("password", "")
+        assert "TESTPYPI_API_TOKEN" in password, (
+            "publish-testpypi must use TESTPYPI_API_TOKEN secret for token-based auth"
         )
 
-    def test_publish_pypi_has_id_token_write(
+    def test_publish_pypi_uses_token_auth(
         self, publish_workflow: dict[str, Any]
     ) -> None:
         job = publish_workflow["jobs"]["publish-pypi"]
-        perms = job.get("permissions", {})
-        assert perms.get("id-token") == "write", (
-            "publish-pypi must have id-token: write for OIDC"
+        publish_steps = [
+            s
+            for s in job["steps"]
+            if "pypa/gh-action-pypi-publish" in s.get("uses", "")
+        ]
+        assert publish_steps, "publish-pypi must use pypa/gh-action-pypi-publish"
+        password = publish_steps[0].get("with", {}).get("password", "")
+        assert "PYPI_API_TOKEN" in password, (
+            "publish-pypi must use PYPI_API_TOKEN secret for token-based auth"
         )
 
     def test_publish_testpypi_uses_pypi_publish_action(

--- a/tests/ci/test_readme_badges.py
+++ b/tests/ci/test_readme_badges.py
@@ -15,7 +15,7 @@ class TestReadmeBadges:
         )
 
     def test_codecov_badge_present(self, readme_content: str) -> None:
-        assert "https://codecov.io/" in readme_content, (
+        assert "[![codecov]" in readme_content, (
             "README must contain a Codecov coverage badge"
         )
 

--- a/tests/ci/test_readme_badges.py
+++ b/tests/ci/test_readme_badges.py
@@ -15,7 +15,7 @@ class TestReadmeBadges:
         )
 
     def test_codecov_badge_present(self, readme_content: str) -> None:
-        assert "codecov.io" in readme_content, (
+        assert "https://codecov.io/" in readme_content, (
             "README must contain a Codecov coverage badge"
         )
 


### PR DESCRIPTION
## Summary

- Remove `id-token: write` OIDC permissions from `publish-testpypi` and `publish-pypi` jobs
- Add `password: ${{ secrets.TESTPYPI_API_TOKEN }}` for TestPyPI publish
- Add `password: ${{ secrets.PYPI_API_TOKEN }}` for PyPI publish

## Context

The `v0.1.0` release failed because `publish.yml` used OIDC trusted publishing, but no trusted publisher was configured on test.pypi.org. All previous successful TestPyPI pushes came from `ci.yml`, which already uses token-based auth. This aligns both workflows on the same approach.

## Test plan

- [ ] Verify CI passes on this PR
- [ ] Re-trigger the `v0.1.0` release (or create a new release) to confirm the full publish pipeline succeeds

🤖 Generated with [Claude Code](https://claude.com/claude-code)