### PR TITLE
fix(ci): restore OIDC trusted publishing for TestPyPI and PyPI

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -54,6 +54,9 @@ jobs:
     runs-on: ubuntu-latest
     timeout-minutes: 10
     environment: testpypi
+    permissions:
+      id-token: write
+      contents: read
     steps:
       - uses: actions/download-artifact@d3f86a106a0bac45b974a628896c90dbdf5c8093  # v4
         with:
@@ -62,7 +65,7 @@ jobs:
       - uses: pypa/gh-action-pypi-publish@ed0c53931b1dc9bd32cbe73a98c7f6766f8a527e  # v1.13.0
         with:
           repository-url: https://test.pypi.org/legacy/
-          password: ${{ secrets.TESTPYPI_API_TOKEN }}
+          attestations: true
 
   validate-testpypi:
     needs: [publish-testpypi, validate-version]
@@ -77,6 +80,7 @@ jobs:
             echo "Attempt $attempt: installing apicurio-serdes==${PKG_VERSION} from TestPyPI..."
             if pip install \
               --index-url https://test.pypi.org/simple/ \
+              --extra-index-url https://pypi.org/simple/ \
               --no-deps \
               "apicurio-serdes==${PKG_VERSION}"; then
               echo "Install succeeded on attempt $attempt"
@@ -97,6 +101,9 @@ jobs:
     runs-on: ubuntu-latest
     timeout-minutes: 10
     environment: pypi
+    permissions:
+      id-token: write
+      contents: read
     steps:
       - uses: actions/download-artifact@d3f86a106a0bac45b974a628896c90dbdf5c8093  # v4
         with:
@@ -104,4 +111,4 @@ jobs:
           path: dist/
       - uses: pypa/gh-action-pypi-publish@ed0c53931b1dc9bd32cbe73a98c7f6766f8a527e  # v1.13.0
         with:
-          password: ${{ secrets.PYPI_API_TOKEN }}
+          attestations: true

--- a/tests/ci/test_publish_workflow.py
+++ b/tests/ci/test_publish_workflow.py
@@ -146,9 +146,7 @@ class TestTrustedPublisherAuth:
             "publish-testpypi must not use a password (use OIDC instead)"
         )
 
-    def test_publish_pypi_no_password(
-        self, publish_workflow: dict[str, Any]
-    ) -> None:
+    def test_publish_pypi_no_password(self, publish_workflow: dict[str, Any]) -> None:
         job = publish_workflow["jobs"]["publish-pypi"]
         publish_steps = [
             s

--- a/tests/ci/test_publish_workflow.py
+++ b/tests/ci/test_publish_workflow.py
@@ -111,10 +111,28 @@ class TestVersionValidation:
         )
 
 
-class TestTokenBasedPublishing:
-    """TS-016: Publication uses token-based auth via API secrets."""
+class TestTrustedPublisherAuth:
+    """TS-016: Publication uses OIDC trusted publishing (no API tokens)."""
 
-    def test_publish_testpypi_uses_token_auth(
+    def test_publish_testpypi_uses_oidc_permission(
+        self, publish_workflow: dict[str, Any]
+    ) -> None:
+        job = publish_workflow["jobs"]["publish-testpypi"]
+        permissions = job.get("permissions", {})
+        assert permissions.get("id-token") == "write", (
+            "publish-testpypi must have id-token: write for OIDC trusted publishing"
+        )
+
+    def test_publish_pypi_uses_oidc_permission(
+        self, publish_workflow: dict[str, Any]
+    ) -> None:
+        job = publish_workflow["jobs"]["publish-pypi"]
+        permissions = job.get("permissions", {})
+        assert permissions.get("id-token") == "write", (
+            "publish-pypi must have id-token: write for OIDC trusted publishing"
+        )
+
+    def test_publish_testpypi_no_password(
         self, publish_workflow: dict[str, Any]
     ) -> None:
         job = publish_workflow["jobs"]["publish-testpypi"]
@@ -124,12 +142,11 @@ class TestTokenBasedPublishing:
             if "pypa/gh-action-pypi-publish" in s.get("uses", "")
         ]
         assert publish_steps, "publish-testpypi must use pypa/gh-action-pypi-publish"
-        password = publish_steps[0].get("with", {}).get("password", "")
-        assert "TESTPYPI_API_TOKEN" in password, (
-            "publish-testpypi must use TESTPYPI_API_TOKEN secret for token-based auth"
+        assert "password" not in publish_steps[0].get("with", {}), (
+            "publish-testpypi must not use a password (use OIDC instead)"
         )
 
-    def test_publish_pypi_uses_token_auth(
+    def test_publish_pypi_no_password(
         self, publish_workflow: dict[str, Any]
     ) -> None:
         job = publish_workflow["jobs"]["publish-pypi"]
@@ -139,9 +156,8 @@ class TestTokenBasedPublishing:
             if "pypa/gh-action-pypi-publish" in s.get("uses", "")
         ]
         assert publish_steps, "publish-pypi must use pypa/gh-action-pypi-publish"
-        password = publish_steps[0].get("with", {}).get("password", "")
-        assert "PYPI_API_TOKEN" in password, (
-            "publish-pypi must use PYPI_API_TOKEN secret for token-based auth"
+        assert "password" not in publish_steps[0].get("with", {}), (
+            "publish-pypi must not use a password (use OIDC instead)"
         )
 
     def test_publish_testpypi_uses_pypi_publish_action(


### PR DESCRIPTION
## Summary

- Reverts the `fix/publish-token-auth` approach which incorrectly switched to API token auth
- Restores OIDC trusted publishing as required by TS-016 and the publish-workflow contract
- Adds `--extra-index-url https://pypi.org/simple/` to `validate-testpypi` so pip can resolve dependencies

## Root Cause

The previous fix used `password: ${{ secrets.TESTPYPI_API_TOKEN }}` which:
1. Violated TS-016 — spec mandates OIDC with no stored secrets
2. Disabled Trusted Publishing, causing the "attestations input ignored" warning
3. Required secrets to be configured in GitHub environments (which weren't set up)

## Changes

- `publish-testpypi` and `publish-pypi`: add `permissions: id-token: write` + `contents: read`, remove `password:`, add `attestations: true`
- `validate-testpypi`: add `--extra-index-url https://pypi.org/simple/` (per contract spec)
- Tests: replace `TestTokenBasedPublishing` → `TestTrustedPublisherAuth` asserting OIDC permissions and absence of password

## Required Setup (once, on PyPI/TestPyPI dashboards)

Configure Trusted Publishers for both environments:
- **TestPyPI**: owner=`jcbianic`, repo=`apicurio-serdes`, workflow=`publish.yml`, environment=`testpypi`
- **PyPI**: owner=`jcbianic`, repo=`apicurio-serdes`, workflow=`publish.yml`, environment=`pypi`

## Test plan

- [x] All 20 publish workflow tests pass (`TestTrustedPublisherAuth`, `TestPublishJobChain`, etc.)
- [x] Full test suite passes with 100% coverage
- [ ] Verify Trusted Publisher is configured on TestPyPI dashboard
- [ ] Verify Trusted Publisher is configured on PyPI dashboard

🤖 Generated with [Claude Code](https://claude.com/claude-code)