### PR TITLE
fix(ci): skip existing versions on TestPyPI upload

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -66,6 +66,7 @@ jobs:
         with:
           repository-url: https://test.pypi.org/legacy/
           attestations: true
+          skip-existing: true
 
   validate-testpypi:
     needs: [publish-testpypi, validate-version]

--- a/tests/ci/test_publish_workflow.py
+++ b/tests/ci/test_publish_workflow.py
@@ -146,9 +146,7 @@ class TestTrustedPublisherAuth:
             "publish-testpypi must not use a password (use OIDC instead)"
         )
 
-    def test_publish_pypi_no_password(
-        self, publish_workflow: dict[str, Any]
-    ) -> None:
+    def test_publish_pypi_no_password(self, publish_workflow: dict[str, Any]) -> None:
         job = publish_workflow["jobs"]["publish-pypi"]
         publish_steps = [
             s

--- a/tests/ci/test_publish_workflow.py
+++ b/tests/ci/test_publish_workflow.py
@@ -146,7 +146,9 @@ class TestTrustedPublisherAuth:
             "publish-testpypi must not use a password (use OIDC instead)"
         )
 
-    def test_publish_pypi_no_password(self, publish_workflow: dict[str, Any]) -> None:
+    def test_publish_pypi_no_password(
+        self, publish_workflow: dict[str, Any]
+    ) -> None:
         job = publish_workflow["jobs"]["publish-pypi"]
         publish_steps = [
             s


### PR DESCRIPTION
## Summary
- Adds `skip-existing: true` to the `publish-testpypi` step so re-triggering the publish workflow for an already-uploaded version returns success instead of a `400 Bad Request`
- The production `publish-pypi` step remains strict (no skip) to enforce deliberate version bumps

## Test plan
- [ ] Trigger a release publish — workflow should complete without 400 errors on TestPyPI
- [ ] Confirm the `publish-pypi` step still fails on duplicate version (no `skip-existing`)

🤖 Generated with [Claude Code](https://claude.com/claude-code)