### PR TITLE
fix(ci): disable attestations for TestPyPI upload

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -65,7 +65,7 @@ jobs:
       - uses: pypa/gh-action-pypi-publish@ed0c53931b1dc9bd32cbe73a98c7f6766f8a527e  # v1.13.0
         with:
           repository-url: https://test.pypi.org/legacy/
-          attestations: true
+          attestations: false
           skip-existing: true
 
   validate-testpypi:


### PR DESCRIPTION
## Summary
- Disables attestations on the `publish-testpypi` step (`attestations: false`)
- TestPyPI returns a bare `400 Bad Request` when re-uploading files that already have attestations attached — this error message does not match the "File already exists" string that `skip-existing: true` looks for, so the job fails regardless
- Attestations are only meaningful for production PyPI; the TestPyPI step is a smoke test

## Test plan
- [ ] Re-trigger publish workflow — `publish-testpypi` should skip cleanly when `0.1.0` already exists on TestPyPI
- [ ] Confirm `publish-pypi` still generates and uploads attestations

🤖 Generated with [Claude Code](https://claude.com/claude-code)