### PR TITLE
fix(ci): install package dependencies in TestPyPI smoke test

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -82,7 +82,6 @@ jobs:
             if pip install \
               --index-url https://test.pypi.org/simple/ \
               --extra-index-url https://pypi.org/simple/ \
-              --no-deps \
               "apicurio-serdes==${PKG_VERSION}"; then
               echo "Install succeeded on attempt $attempt"
               break


### PR DESCRIPTION
## Summary
- Removes `--no-deps` from the `validate-testpypi` install step
- `--no-deps` was preventing `httpx` and `fastavro` from being installed, causing the import smoke test to fail with `ModuleNotFoundError: No module named 'httpx'`
- The `--extra-index-url https://pypi.org/simple/` fallback is already in place so pip can resolve all dependencies from production PyPI

## Test plan
- [ ] Trigger publish workflow — `validate-testpypi` smoke test should pass (`import apicurio_serdes` succeeds)

🤖 Generated with [Claude Code](https://claude.com/claude-code)