### PR TITLE
feat(community): add and polish community health documents

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report.md
+++ b/.github/ISSUE_TEMPLATE/bug_report.md
@@ -1,0 +1,30 @@
+---
+name: Bug report
+about: Something is not working as expected
+labels: bug
+---
+
+## Description
+
+<!-- A clear and concise description of the bug. -->
+
+## Steps to reproduce
+
+```python
+# Minimal code snippet that reproduces the problem
+```
+
+## Expected behaviour
+
+<!-- What you expected to happen. -->
+
+## Actual behaviour
+
+<!-- What actually happened. Include the full error message and traceback if applicable. -->
+
+## Environment
+
+- `apicurio-serdes` version:
+- Python version:
+- Apicurio Registry version:
+- Wire format used (`CONFLUENT_PAYLOAD` / `KAFKA_HEADERS`):

--- a/.github/ISSUE_TEMPLATE/bug_report.md
+++ b/.github/ISSUE_TEMPLATE/bug_report.md
@@ -8,10 +8,13 @@ labels: bug
 
 <!-- A clear and concise description of the bug. -->
 
-## Steps to reproduce
+## Minimal reproducer
+
+**A complete, runnable script that demonstrates the issue.** Assume Apicurio Registry is
+running — include any relevant setup (e.g. "using the Docker quickstart from the README").
 
 ```python
-# Minimal code snippet that reproduces the problem
+# Paste a complete, minimal script here
 ```
 
 ## Expected behaviour
@@ -20,11 +23,19 @@ labels: bug
 
 ## Actual behaviour
 
-<!-- What actually happened. Include the full error message and traceback if applicable. -->
+<!-- What actually happened. -->
+
+## Full traceback
+
+```
+# Paste the complete error output here
+```
 
 ## Environment
 
 - `apicurio-serdes` version:
 - Python version:
 - Apicurio Registry version:
-- Wire format used (`CONFLUENT_PAYLOAD` / `KAFKA_HEADERS`):
+- Client: `ApicurioRegistryClient` / `AsyncApicurioRegistryClient`
+- Wire format: `CONFLUENT_PAYLOAD` / `KAFKA_HEADERS`
+- Fresh schema fetch or previously cached:

--- a/.github/ISSUE_TEMPLATE/feature_request.md
+++ b/.github/ISSUE_TEMPLATE/feature_request.md
@@ -1,0 +1,17 @@
+---
+name: Feature request
+about: Suggest an improvement or new capability
+labels: enhancement
+---
+
+## Use case
+
+<!-- Describe the problem you are trying to solve or the workflow you want to enable. -->
+
+## Proposed behaviour
+
+<!-- Describe what you would like apicurio-serdes to do. A code sketch is welcome. -->
+
+## Alternatives considered
+
+<!-- Any other approaches you have tried or thought about. -->

--- a/.github/ISSUE_TEMPLATE/feature_request.md
+++ b/.github/ISSUE_TEMPLATE/feature_request.md
@@ -6,12 +6,32 @@ labels: enhancement
 
 ## Use case
 
-<!-- Describe the problem you are trying to solve or the workflow you want to enable. -->
+Describe the problem you are trying to solve or the workflow you want to enable.
+Is this blocking you in production, or a nice-to-have?
 
 ## Proposed behaviour
 
-<!-- Describe what you would like apicurio-serdes to do. A code sketch is welcome. -->
+What would you like `apicurio-serdes` to do? A code sketch is welcome.
+
+```python
+# Optional: example of the API you have in mind
+```
+
+## Backward compatibility
+
+Does this change affect any of the following?
+
+- Serialized payload format or wire protocol
+- Public API (`__init__.py` exports)
+- Configuration or constructor parameters
+
+If yes, is a deprecation period acceptable?
 
 ## Alternatives considered
 
-<!-- Any other approaches you have tried or thought about. -->
+What have you tried instead? Why was it not suitable?
+
+## Additional context
+
+- `apicurio-serdes` version:
+- Are you currently working around this in production?

--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -1,14 +1,34 @@
 ## Summary
 
-<!-- What does this PR do and why? -->
+<!-- What does this PR do and why? Reference the related issue if applicable. -->
+<!-- Example: "Fixes #123 — schema caching fails when registry returns 304" -->
 
-## Related issue
+## Type of change
 
-<!-- Closes #<issue-number> -->
+- [ ] Bug fix
+- [ ] New feature
+- [ ] Documentation improvement
+- [ ] Refactor (no behaviour change)
+- [ ] Breaking change (requires major version bump)
 
-## Test plan
+## Testing
 
 - [ ] All existing tests pass (`uv run pytest`)
 - [ ] New behaviour is covered by tests
 - [ ] Coverage remains at 100%
-- [ ] Docs updated if behaviour changed (`uv run mkdocs build --strict`)
+- [ ] Both sync and async clients tested (if applicable)
+
+## Code quality
+
+- [ ] Linting passes (`uv run pre-commit run --all-files`)
+- [ ] Type checking passes (`uv run mypy`)
+
+## Documentation
+
+- [ ] Docs build passes (`uv run mkdocs build --strict`)
+- [ ] Docstrings added for any new public API
+- [ ] README updated if this is a user-facing change
+
+## Commits
+
+- [ ] Commit messages follow [Conventional Commits](https://www.conventionalcommits.org/) (`feat:`, `fix:`, `docs:`, `refactor:`)

--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -1,0 +1,14 @@
+## Summary
+
+<!-- What does this PR do and why? -->
+
+## Related issue
+
+<!-- Closes #<issue-number> -->
+
+## Test plan
+
+- [ ] All existing tests pass (`uv run pytest`)
+- [ ] New behaviour is covered by tests
+- [ ] Coverage remains at 100%
+- [ ] Docs updated if behaviour changed (`uv run mkdocs build --strict`)

--- a/CODE_OF_CONDUCT.md
+++ b/CODE_OF_CONDUCT.md
@@ -1,0 +1,31 @@
+# Code of Conduct
+
+## Our Pledge
+
+We as members, contributors, and maintainers pledge to make participation in this project a harassment-free experience for everyone, regardless of age, body size, disability, ethnicity, sex characteristics, gender identity and expression, level of experience, education, socio-economic status, nationality, personal appearance, race, religion, or sexual identity and orientation.
+
+## Our Standards
+
+Examples of behavior that contributes to a positive environment:
+
+- Using welcoming and inclusive language
+- Being respectful of differing viewpoints and experiences
+- Gracefully accepting constructive criticism
+- Focusing on what is best for the community
+- Showing empathy towards other community members
+
+Examples of unacceptable behavior:
+
+- The use of sexualized language or imagery and unwelcome sexual attention or advances
+- Trolling, insulting or derogatory comments, and personal or political attacks
+- Public or private harassment
+- Publishing others' private information without explicit permission
+- Other conduct which could reasonably be considered inappropriate in a professional setting
+
+## Enforcement
+
+Instances of abusive, harassing, or otherwise unacceptable behavior may be reported by opening a [GitHub Security Advisory](https://github.com/jcbianic/apicurio-serdes/security/advisories/new) or contacting the maintainer directly. All complaints will be reviewed and investigated promptly and fairly.
+
+## Attribution
+
+This Code of Conduct is adapted from the [Contributor Covenant](https://www.contributor-covenant.org), version 2.1.

--- a/CODE_OF_CONDUCT.md
+++ b/CODE_OF_CONDUCT.md
@@ -24,7 +24,9 @@ Examples of unacceptable behavior:
 
 ## Enforcement
 
-Instances of abusive, harassing, or otherwise unacceptable behavior may be reported by opening a [GitHub Security Advisory](https://github.com/jcbianic/apicurio-serdes/security/advisories/new) or contacting the maintainer directly. All complaints will be reviewed and investigated promptly and fairly.
+Instances of abusive, harassing, or otherwise unacceptable behavior should be reported directly to the project maintainer at **jcbianic@libon.com**. All complaints will be reviewed and investigated promptly and fairly. The reporter and respondent will be notified of the outcome.
+
+Consequences for violations may include removal of contributions, temporary suspension, or a permanent ban from community spaces, depending on severity.
 
 ## Attribution
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,19 +1,31 @@
 # Contributing to apicurio-serdes
 
-Thank you for your interest in contributing! This guide explains how to get started.
+Thank you for your interest in contributing! Please read this guide before opening an issue or pull request.
 
 ## Ways to contribute
 
-- Report bugs via [GitHub Issues](https://github.com/jcbianic/apicurio-serdes/issues)
-- Suggest features or improvements
-- Submit pull requests for bug fixes or new features
-- Improve documentation
+- Report bugs via [GitHub Issues](https://github.com/jcbianic/apicurio-serdes/issues/new?template=bug_report.md)
+- Suggest features via [GitHub Issues](https://github.com/jcbianic/apicurio-serdes/issues/new?template=feature_request.md)
+- Submit pull requests for bug fixes, new features, or documentation
+- Improve examples or translate documentation
+
+## Response time
+
+This is a maintainer-led open-source project. You can expect:
+
+- **Issues**: initial response within a week
+- **Pull requests**: initial review within two weeks
+- **Security reports**: response within 7 days (see [SECURITY.md](SECURITY.md))
 
 ## Development setup
 
-This project uses [uv](https://docs.astral.sh/uv/) for dependency management.
+This project uses [uv](https://docs.astral.sh/uv/) for dependency management — a fast, modern replacement for pip/venv. If you are new to it:
 
 ```bash
+# Install uv (once)
+curl -LsSf https://astral.sh/uv/install.sh | sh
+
+# Clone and install
 git clone https://github.com/jcbianic/apicurio-serdes.git
 cd apicurio-serdes
 uv sync --group dev
@@ -22,39 +34,63 @@ uv sync --group dev
 ## Running checks locally
 
 ```bash
-# Lint and format
+# Lint and format (ruff via pre-commit)
 uv run pre-commit run --all-files
 
-# Type checking
+# Type checking (strict mypy)
 uv run mypy
 
-# Tests (100% coverage required)
+# Tests — 100% branch coverage is enforced (see philosophy below)
 uv run pytest
 
 # Docs
 uv run mkdocs build --strict
 ```
 
+## Project philosophy
+
+- **100% branch coverage**: Every line and branch in the library must be covered by tests. This is a hard requirement enforced by CI. It ensures that schema caching, wire format switching, and error handling paths are always exercised.
+- **Sync and async parity**: The library exposes both `ApicurioRegistryClient` and `AsyncApicurioRegistryClient`. Any behavioral change must apply to both.
+- **Minimal dependencies**: Core dependencies are `fastavro` and `httpx` only. New runtime dependencies require strong justification.
+- **Stable public API**: Once a version is released, the public surface (`__init__.py` exports) must remain backward-compatible until a major version bump.
+
+## What we welcome
+
+- Bug fixes with a regression test
+- Performance improvements to schema caching or (de)serialization
+- Documentation improvements and additional examples
+- Test coverage for edge cases
+
+## What requires prior discussion
+
+**Open an issue before starting substantial work** to avoid wasted effort:
+
+- New wire formats
+- Changes to the schema caching strategy
+- New runtime dependencies
+- Breaking changes to public APIs
+- New serialization formats (e.g., Protobuf)
+
 ## Pull request process
 
 1. Fork the repository and create a branch from `main`.
-2. Make your changes — all tests must pass and coverage must stay at 100%.
-3. Follow [Conventional Commits](https://www.conventionalcommits.org/) for commit messages (e.g. `feat:`, `fix:`, `docs:`).
-4. Open a pull request against `main`. CI must be green before merging.
+2. Follow [Conventional Commits](https://www.conventionalcommits.org/) for commit messages (`feat:`, `fix:`, `docs:`, `refactor:`).
+3. Ensure all checks pass (`pytest`, `mypy`, `pre-commit`, `mkdocs build`).
+4. Open a pull request against `main`. All CI checks must be green before merging.
 
 ## Reporting bugs
 
-Please use the [bug report template](.github/ISSUE_TEMPLATE/bug_report.md) and include:
+Use the [bug report template](.github/ISSUE_TEMPLATE/bug_report.md). The most useful reports include:
 
-- A clear description of the problem
-- A minimal reproducer (code snippet or steps)
-- Your Python version and `apicurio-serdes` version
-- The Apicurio Registry version you are connecting to
+- A **complete, runnable script** that reproduces the problem
+- Your Python version, `apicurio-serdes` version, and Apicurio Registry version
+- Whether you are using the sync or async client
+- The wire format (`CONFLUENT_PAYLOAD` or `KAFKA_HEADERS`)
 
-## Suggesting features
+## Requesting features
 
-Open a [feature request](.github/ISSUE_TEMPLATE/feature_request.md) describing the use case and the behaviour you'd like to see.
+Use the [feature request template](.github/ISSUE_TEMPLATE/feature_request.md). Describe the use case first — not just the solution.
 
 ## Security vulnerabilities
 
-Please **do not** open a public issue. Report them via [GitHub Security Advisories](https://github.com/jcbianic/apicurio-serdes/security/advisories/new). See [SECURITY.md](SECURITY.md) for details.
+Please **do not** open a public issue. See [SECURITY.md](SECURITY.md).

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,0 +1,60 @@
+# Contributing to apicurio-serdes
+
+Thank you for your interest in contributing! This guide explains how to get started.
+
+## Ways to contribute
+
+- Report bugs via [GitHub Issues](https://github.com/jcbianic/apicurio-serdes/issues)
+- Suggest features or improvements
+- Submit pull requests for bug fixes or new features
+- Improve documentation
+
+## Development setup
+
+This project uses [uv](https://docs.astral.sh/uv/) for dependency management.
+
+```bash
+git clone https://github.com/jcbianic/apicurio-serdes.git
+cd apicurio-serdes
+uv sync --group dev
+```
+
+## Running checks locally
+
+```bash
+# Lint and format
+uv run pre-commit run --all-files
+
+# Type checking
+uv run mypy
+
+# Tests (100% coverage required)
+uv run pytest
+
+# Docs
+uv run mkdocs build --strict
+```
+
+## Pull request process
+
+1. Fork the repository and create a branch from `main`.
+2. Make your changes — all tests must pass and coverage must stay at 100%.
+3. Follow [Conventional Commits](https://www.conventionalcommits.org/) for commit messages (e.g. `feat:`, `fix:`, `docs:`).
+4. Open a pull request against `main`. CI must be green before merging.
+
+## Reporting bugs
+
+Please use the [bug report template](.github/ISSUE_TEMPLATE/bug_report.md) and include:
+
+- A clear description of the problem
+- A minimal reproducer (code snippet or steps)
+- Your Python version and `apicurio-serdes` version
+- The Apicurio Registry version you are connecting to
+
+## Suggesting features
+
+Open a [feature request](.github/ISSUE_TEMPLATE/feature_request.md) describing the use case and the behaviour you'd like to see.
+
+## Security vulnerabilities
+
+Please **do not** open a public issue. Report them via [GitHub Security Advisories](https://github.com/jcbianic/apicurio-serdes/security/advisories/new). See [SECURITY.md](SECURITY.md) for details.

--- a/DEVELOPMENT.md
+++ b/DEVELOPMENT.md
@@ -1,0 +1,11 @@
+# Development and release guide
+
+This document is for project maintainers.
+
+## Cutting a release
+
+1. Update `version` in `pyproject.toml` and `src/apicurio_serdes/_version.py`.
+2. Update `CHANGELOG.md` — move items from `Unreleased` to the new version section.
+3. Commit: `git commit -m "chore: release vX.Y.Z"`.
+4. Push to `main`, then create a GitHub Release with tag `vX.Y.Z`.
+5. The publish workflow runs automatically: TestPyPI → smoke test → PyPI.

--- a/README.md
+++ b/README.md
@@ -62,12 +62,9 @@ WireFormat.CONFLUENT_PAYLOAD
 WireFormat.KAFKA_HEADERS
 ```
 
-## Releasing a new version
+## Contributing
 
-1. Update `version` in `pyproject.toml`.
-2. Commit: `git commit -m "chore: bump version to X.Y.Z"`.
-3. Push, then create a GitHub Release with tag `vX.Y.Z`.
-4. The publish workflow publishes to TestPyPI then PyPI automatically.
+See [CONTRIBUTING.md](CONTRIBUTING.md) for dev setup, coding standards, and how to submit a pull request.
 
 ## License
 


### PR DESCRIPTION
## Summary

Brings the [GitHub community health score](https://github.com/jcbianic/apicurio-serdes/community) from 57% to 100% by adding all missing standard files, then refining them based on a critical review against best practices in the Python OSS ecosystem (httpx, pydantic, ruff).

## Files added / changed

| File | Status | What changed |
|---|---|---|
| `CODE_OF_CONDUCT.md` | New → revised | Contributor Covenant 2.1. Enforcement routes to **maintainer email**, not Security Advisories (which are for vulnerabilities, not CoC violations) |
| `CONTRIBUTING.md` | New → revised | Adds uv primer, project philosophy (100% coverage rationale, sync/async parity), explicit scope boundaries ("what NOT to contribute"), response time SLAs |
| `.github/ISSUE_TEMPLATE/bug_report.md` | New → revised | Added: client type (sync/async), caching context (fresh vs cached), explicit traceback field, guidance on what a "minimal reproducer" means |
| `.github/ISSUE_TEMPLATE/feature_request.md` | New → revised | Added: backward-compatibility question, workaround context, version field |
| `.github/pull_request_template.md` | New → revised | Added: type-of-change checklist, lint + typecheck items, breaking-change flag, Conventional Commits reminder |
| `README.md` | Modified | Replaced maintainer-only release instructions with a Contributing link |
| `DEVELOPMENT.md` | New | Maintainer-facing release guide (version bump → CHANGELOG → tag → publish) |

## What was wrong with v1

The initial draft had two significant errors caught by a critical review:

1. **CODE_OF_CONDUCT** routed Code of Conduct violations to GitHub Security Advisories — a category error. Security Advisories are for embargoed vulnerability reports, not community governance.
2. **pull_request_template** omitted lint and typecheck from the checklist, giving contributors an incomplete picture of CI gates.

## Test plan

- [ ] CI passes
- [ ] Visit [community health profile](https://github.com/jcbianic/apicurio-serdes/community) after merge and confirm 100%
- [ ] Open a test issue to verify templates render correctly

🤖 Generated with [Claude Code](https://claude.com/claude-code)