### PR TITLE
fix: resolve TD-001, TD-003 and add AsyncAvroDeserializer

### DIFF
--- a/src/apicurio_serdes/__init__.py
+++ b/src/apicurio_serdes/__init__.py
@@ -4,6 +4,12 @@ from importlib.metadata import version
 
 from apicurio_serdes._async_client import AsyncApicurioRegistryClient
 from apicurio_serdes._client import ApicurioRegistryClient
+from apicurio_serdes._errors import (
+    DeserializationError,
+    RegistryConnectionError,
+    SchemaNotFoundError,
+    SerializationError,
+)
 from apicurio_serdes.serialization import WireFormat
 
 __version__ = version("apicurio-serdes")
@@ -11,6 +17,10 @@ __version__ = version("apicurio-serdes")
 __all__ = [
     "ApicurioRegistryClient",
     "AsyncApicurioRegistryClient",
+    "DeserializationError",
+    "RegistryConnectionError",
+    "SchemaNotFoundError",
+    "SerializationError",
     "WireFormat",
     "__version__",
 ]

--- a/src/apicurio_serdes/_async_client.py
+++ b/src/apicurio_serdes/_async_client.py
@@ -41,6 +41,7 @@ class AsyncApicurioRegistryClient:
         self.group_id = group_id
         self._http_client = httpx.AsyncClient(base_url=url)
         self._schema_cache: dict[tuple[str, str], CachedSchema] = {}
+        self._id_cache: dict[tuple[str, int], dict[str, Any]] = {}
         self._lock = asyncio.Lock()
         self._closed = False
 
@@ -81,7 +82,7 @@ class AsyncApicurioRegistryClient:
             )
             try:
                 response = await self._http_client.get(endpoint)
-            except httpx.ConnectError as exc:
+            except httpx.TransportError as exc:
                 raise RegistryConnectionError(self.url, exc) from exc
 
             if response.status_code == 404:
@@ -102,6 +103,71 @@ class AsyncApicurioRegistryClient:
             )
             self._schema_cache[cache_key] = cached
             return cached
+
+    async def get_schema_by_global_id(self, global_id: int) -> dict[str, Any]:
+        """Retrieve an Avro schema by its globalId (async).
+
+        Returns a cached result on subsequent calls for the same globalId.
+
+        Args:
+            global_id: The globalId from the wire format header.
+
+        Returns:
+            Parsed Avro schema as a Python dict.
+
+        Raises:
+            SchemaNotFoundError: If no schema exists for this globalId.
+            RegistryConnectionError: If the registry is unreachable.
+            RuntimeError: If the client has been closed.
+        """
+        return await self._get_schema_by_id("globalId", global_id)
+
+    async def get_schema_by_content_id(self, content_id: int) -> dict[str, Any]:
+        """Retrieve an Avro schema by its contentId (async).
+
+        Returns a cached result on subsequent calls for the same contentId.
+
+        Args:
+            content_id: The contentId from the wire format header.
+
+        Returns:
+            Parsed Avro schema as a Python dict.
+
+        Raises:
+            SchemaNotFoundError: If no schema exists for this contentId.
+            RegistryConnectionError: If the registry is unreachable.
+            RuntimeError: If the client has been closed.
+        """
+        return await self._get_schema_by_id("contentId", content_id)
+
+    async def _get_schema_by_id(self, id_type: str, id_value: int) -> dict[str, Any]:
+        """Shared implementation for async ID-based schema lookups."""
+        if self._closed:
+            raise RuntimeError("client is closed")
+        cache_key = (id_type, id_value)
+        if cache_key in self._id_cache:
+            return self._id_cache[cache_key]
+
+        async with self._lock:
+            if cache_key in self._id_cache:
+                return self._id_cache[cache_key]
+
+            endpoint = f"/ids/{id_type}s/{id_value}"
+            try:
+                response = await self._http_client.get(endpoint)
+            except httpx.TransportError as exc:
+                raise RegistryConnectionError(self.url, exc) from exc
+
+            if response.status_code == 404:
+                raise SchemaNotFoundError.from_id(id_type, id_value)
+            try:
+                response.raise_for_status()
+            except httpx.HTTPStatusError as exc:
+                raise RegistryConnectionError(self.url, exc) from exc
+
+            schema: dict[str, Any] = json.loads(response.content)
+            self._id_cache[cache_key] = schema
+            return schema
 
     async def aclose(self) -> None:
         """Close the underlying HTTP connection pool.

--- a/src/apicurio_serdes/_client.py
+++ b/src/apicurio_serdes/_client.py
@@ -101,7 +101,7 @@ class ApicurioRegistryClient:
             )
             try:
                 response = self._http_client.get(endpoint)
-            except httpx.ConnectError as exc:
+            except httpx.TransportError as exc:
                 raise RegistryConnectionError(self.url, exc) from exc
 
             if response.status_code == 404:
@@ -180,7 +180,7 @@ class ApicurioRegistryClient:
             endpoint = f"/ids/{id_type}s/{id_value}"
             try:
                 response = self._http_client.get(endpoint)
-            except httpx.ConnectError as exc:
+            except httpx.TransportError as exc:
                 raise RegistryConnectionError(self.url, exc) from exc
 
             if response.status_code == 404:

--- a/src/apicurio_serdes/avro/__init__.py
+++ b/src/apicurio_serdes/avro/__init__.py
@@ -1,6 +1,7 @@
 """Avro serialization support for apicurio-serdes."""
 
+from apicurio_serdes.avro._async_deserializer import AsyncAvroDeserializer
 from apicurio_serdes.avro._deserializer import AvroDeserializer
 from apicurio_serdes.avro._serializer import AvroSerializer
 
-__all__ = ["AvroDeserializer", "AvroSerializer"]
+__all__ = ["AsyncAvroDeserializer", "AvroDeserializer", "AvroSerializer"]

--- a/src/apicurio_serdes/avro/_async_deserializer.py
+++ b/src/apicurio_serdes/avro/_async_deserializer.py
@@ -1,0 +1,129 @@
+"""Async Avro deserializer with Confluent wire format parsing."""
+
+from __future__ import annotations
+
+import io
+import struct
+from typing import TYPE_CHECKING, Any
+
+import fastavro
+
+from apicurio_serdes._errors import DeserializationError
+
+if TYPE_CHECKING:
+    from collections.abc import Callable
+    from typing import Literal
+
+    from apicurio_serdes._async_client import AsyncApicurioRegistryClient
+    from apicurio_serdes.serialization import SerializationContext
+
+
+class AsyncAvroDeserializer:
+    """Deserializes Confluent-framed Avro bytes to Python dicts (async).
+
+    Non-blocking counterpart to AvroDeserializer. Uses
+    AsyncApicurioRegistryClient for schema resolution, making it
+    suitable for use in fully async services without blocking the
+    event loop.
+
+    Args:
+        registry_client: An AsyncApicurioRegistryClient instance.
+        from_dict: Optional callable that converts the decoded dict
+                   to a domain object. Signature: (data, ctx) -> Any.
+                   When None, the decoded dict is returned directly.
+        use_id: Which registry identifier type the 4-byte wire format
+                field represents. Must match the serializer's use_id
+                setting. Defaults to "contentId".
+
+    Example:
+        ```python
+        from apicurio_serdes import AsyncApicurioRegistryClient
+        from apicurio_serdes.avro import AsyncAvroDeserializer
+        from apicurio_serdes.serialization import SerializationContext, MessageField
+
+        client = AsyncApicurioRegistryClient(
+            url="http://localhost:8080/apis/registry/v3",
+            group_id="com.example.schemas",
+        )
+        deserializer = AsyncAvroDeserializer(registry_client=client)
+        ctx = SerializationContext(topic="user-events", field=MessageField.VALUE)
+
+        async with client:
+            result = await deserializer(raw_bytes, ctx)
+        ```
+    """
+
+    def __init__(
+        self,
+        registry_client: AsyncApicurioRegistryClient,
+        from_dict: Callable[[dict[str, Any], SerializationContext], Any] | None = None,
+        use_id: Literal["globalId", "contentId"] = "contentId",
+    ) -> None:
+        self.registry_client = registry_client
+        self.from_dict = from_dict
+        self.use_id = use_id
+        self._parsed_cache: dict[int, Any] = {}
+
+    async def __call__(self, data: bytes, ctx: SerializationContext) -> Any:
+        """Deserialize Confluent-framed Avro bytes (async).
+
+        Input format:
+          Byte 0:    Magic byte 0x00
+          Bytes 1-4: Schema identifier as 4-byte big-endian unsigned int
+          Bytes 5+:  Avro binary payload (schemaless encoding)
+
+        Args:
+            data: Confluent wire format bytes to deserialize.
+            ctx: Serialization context with topic and field metadata.
+
+        Returns:
+            A Python dict (or the result of from_dict if configured).
+
+        Raises:
+            DeserializationError: If the input is fewer than 5 bytes,
+                the magic byte is not 0x00, the Avro payload cannot be
+                decoded, or the from_dict callable raises an exception.
+            SchemaNotFoundError: If the schema identifier does not
+                correspond to any schema in the registry.
+            RegistryConnectionError: If the registry is unreachable
+                during schema resolution.
+        """
+        if len(data) < 5:
+            raise DeserializationError(
+                f"Input too short: expected at least 5 bytes, got {len(data)}"
+            )
+
+        if data[0] != 0x00:
+            raise DeserializationError(
+                f"Invalid magic byte: expected 0x00, got {data[0]:#04x}"
+            )
+
+        schema_id: int = struct.unpack(">I", data[1:5])[0]
+
+        if self.use_id == "globalId":
+            schema_dict = await self.registry_client.get_schema_by_global_id(schema_id)
+        else:
+            schema_dict = await self.registry_client.get_schema_by_content_id(schema_id)
+
+        if schema_id not in self._parsed_cache:
+            self._parsed_cache[schema_id] = fastavro.parse_schema(schema_dict)
+        parsed_schema = self._parsed_cache[schema_id]
+
+        try:
+            result: Any = fastavro.schemaless_reader(
+                io.BytesIO(data[5:]), parsed_schema, parsed_schema
+            )
+        except Exception as exc:
+            raise DeserializationError(
+                f"Avro decode failure: {exc}", cause=exc
+            ) from exc
+
+        if self.from_dict is not None:
+            try:
+                return self.from_dict(result, ctx)
+            except Exception as exc:
+                raise DeserializationError(
+                    f"from_dict conversion failed: {exc}", cause=exc
+                ) from exc
+
+        return result

--- a/tests/test_async_client.py
+++ b/tests/test_async_client.py
@@ -327,6 +327,204 @@ class TestClosedClientGuard:
             await client.get_schema("UserEvent")
 
 
+class TestTransportErrors:
+    """TD-001: TransportErrors beyond ConnectError raise RegistryConnectionError."""
+
+    async def test_get_schema_read_timeout_raises_registry_connection_error(
+        self, mock_registry: respx.MockRouter
+    ) -> None:
+        from apicurio_serdes._async_client import AsyncApicurioRegistryClient
+        from apicurio_serdes._errors import RegistryConnectionError
+
+        mock_registry.get(url__startswith=f"{REGISTRY_URL}/groups/").mock(
+            side_effect=httpx.ReadTimeout("timed out")
+        )
+        client = AsyncApicurioRegistryClient(url=REGISTRY_URL, group_id=GROUP_ID)
+        with pytest.raises(RegistryConnectionError):
+            await client.get_schema("Slow")
+
+
+class TestGetSchemaByGlobalId:
+    """Async get_schema_by_global_id mirrors sync interface."""
+
+    async def test_cache_miss_returns_schema(
+        self, mock_registry: respx.MockRouter
+    ) -> None:
+        from apicurio_serdes._async_client import AsyncApicurioRegistryClient
+
+        mock_registry.get(f"{REGISTRY_URL}/ids/globalIds/7").mock(
+            return_value=httpx.Response(200, content=json.dumps(USER_EVENT_SCHEMA_JSON))
+        )
+        client = AsyncApicurioRegistryClient(url=REGISTRY_URL, group_id=GROUP_ID)
+        result = await client.get_schema_by_global_id(7)
+        assert result == USER_EVENT_SCHEMA_JSON
+
+    async def test_cache_hit_no_second_request(
+        self, mock_registry: respx.MockRouter
+    ) -> None:
+        from apicurio_serdes._async_client import AsyncApicurioRegistryClient
+
+        route = mock_registry.get(f"{REGISTRY_URL}/ids/globalIds/7").mock(
+            return_value=httpx.Response(200, content=json.dumps(USER_EVENT_SCHEMA_JSON))
+        )
+        client = AsyncApicurioRegistryClient(url=REGISTRY_URL, group_id=GROUP_ID)
+        r1 = await client.get_schema_by_global_id(7)
+        r2 = await client.get_schema_by_global_id(7)
+        assert r1 == r2
+        assert route.call_count == 1
+
+    async def test_not_found_raises_schema_not_found_error(
+        self, mock_registry: respx.MockRouter
+    ) -> None:
+        from apicurio_serdes._async_client import AsyncApicurioRegistryClient
+        from apicurio_serdes._errors import SchemaNotFoundError
+
+        mock_registry.get(f"{REGISTRY_URL}/ids/globalIds/999").mock(
+            return_value=httpx.Response(404)
+        )
+        client = AsyncApicurioRegistryClient(url=REGISTRY_URL, group_id=GROUP_ID)
+        with pytest.raises(SchemaNotFoundError) as exc_info:
+            await client.get_schema_by_global_id(999)
+        assert exc_info.value.id_type == "globalId"
+        assert exc_info.value.id_value == 999
+
+    async def test_network_error_raises_registry_connection_error(
+        self, mock_registry: respx.MockRouter
+    ) -> None:
+        from apicurio_serdes._async_client import AsyncApicurioRegistryClient
+        from apicurio_serdes._errors import RegistryConnectionError
+
+        mock_registry.get(url__startswith=f"{REGISTRY_URL}/ids/globalIds/").mock(
+            side_effect=httpx.ConnectError("refused")
+        )
+        client = AsyncApicurioRegistryClient(url=REGISTRY_URL, group_id=GROUP_ID)
+        with pytest.raises(RegistryConnectionError):
+            await client.get_schema_by_global_id(7)
+
+    async def test_read_timeout_raises_registry_connection_error(
+        self, mock_registry: respx.MockRouter
+    ) -> None:
+        from apicurio_serdes._async_client import AsyncApicurioRegistryClient
+        from apicurio_serdes._errors import RegistryConnectionError
+
+        mock_registry.get(url__startswith=f"{REGISTRY_URL}/ids/globalIds/").mock(
+            side_effect=httpx.ReadTimeout("timed out")
+        )
+        client = AsyncApicurioRegistryClient(url=REGISTRY_URL, group_id=GROUP_ID)
+        with pytest.raises(RegistryConnectionError):
+            await client.get_schema_by_global_id(7)
+
+    async def test_unexpected_status_raises_registry_connection_error(
+        self, mock_registry: respx.MockRouter
+    ) -> None:
+        from apicurio_serdes._async_client import AsyncApicurioRegistryClient
+        from apicurio_serdes._errors import RegistryConnectionError
+
+        mock_registry.get(f"{REGISTRY_URL}/ids/globalIds/7").mock(
+            return_value=httpx.Response(500)
+        )
+        client = AsyncApicurioRegistryClient(url=REGISTRY_URL, group_id=GROUP_ID)
+        with pytest.raises(RegistryConnectionError):
+            await client.get_schema_by_global_id(7)
+
+
+class TestGetSchemaByContentId:
+    """Async get_schema_by_content_id mirrors sync interface."""
+
+    async def test_cache_miss_returns_schema(
+        self, mock_registry: respx.MockRouter
+    ) -> None:
+        from apicurio_serdes._async_client import AsyncApicurioRegistryClient
+
+        mock_registry.get(f"{REGISTRY_URL}/ids/contentIds/42").mock(
+            return_value=httpx.Response(200, content=json.dumps(USER_EVENT_SCHEMA_JSON))
+        )
+        client = AsyncApicurioRegistryClient(url=REGISTRY_URL, group_id=GROUP_ID)
+        result = await client.get_schema_by_content_id(42)
+        assert result == USER_EVENT_SCHEMA_JSON
+
+    async def test_cache_hit_no_second_request(
+        self, mock_registry: respx.MockRouter
+    ) -> None:
+        from apicurio_serdes._async_client import AsyncApicurioRegistryClient
+
+        route = mock_registry.get(f"{REGISTRY_URL}/ids/contentIds/42").mock(
+            return_value=httpx.Response(200, content=json.dumps(USER_EVENT_SCHEMA_JSON))
+        )
+        client = AsyncApicurioRegistryClient(url=REGISTRY_URL, group_id=GROUP_ID)
+        r1 = await client.get_schema_by_content_id(42)
+        r2 = await client.get_schema_by_content_id(42)
+        assert r1 == r2
+        assert route.call_count == 1
+
+    async def test_not_found_raises_schema_not_found_error(
+        self, mock_registry: respx.MockRouter
+    ) -> None:
+        from apicurio_serdes._async_client import AsyncApicurioRegistryClient
+        from apicurio_serdes._errors import SchemaNotFoundError
+
+        mock_registry.get(f"{REGISTRY_URL}/ids/contentIds/9999").mock(
+            return_value=httpx.Response(404)
+        )
+        client = AsyncApicurioRegistryClient(url=REGISTRY_URL, group_id=GROUP_ID)
+        with pytest.raises(SchemaNotFoundError) as exc_info:
+            await client.get_schema_by_content_id(9999)
+        assert exc_info.value.id_type == "contentId"
+        assert exc_info.value.id_value == 9999
+
+    async def test_network_error_raises_registry_connection_error(
+        self, mock_registry: respx.MockRouter
+    ) -> None:
+        from apicurio_serdes._async_client import AsyncApicurioRegistryClient
+        from apicurio_serdes._errors import RegistryConnectionError
+
+        mock_registry.get(url__startswith=f"{REGISTRY_URL}/ids/contentIds/").mock(
+            side_effect=httpx.ConnectError("refused")
+        )
+        client = AsyncApicurioRegistryClient(url=REGISTRY_URL, group_id=GROUP_ID)
+        with pytest.raises(RegistryConnectionError):
+            await client.get_schema_by_content_id(42)
+
+
+class TestClosedClientGuardIdMethods:
+    """get_schema_by_X on a closed client raises RuntimeError."""
+
+    async def test_get_schema_by_global_id_after_aclose_raises(self) -> None:
+        from apicurio_serdes._async_client import AsyncApicurioRegistryClient
+
+        client = AsyncApicurioRegistryClient(url=REGISTRY_URL, group_id=GROUP_ID)
+        await client.aclose()
+        with pytest.raises(RuntimeError):
+            await client.get_schema_by_global_id(7)
+
+
+class TestIdCacheDoubleCheckLocking:
+    """Coverage: inner cache-check return path for _id_cache."""
+
+    async def test_inner_id_cache_check_returns_cached_value(self) -> None:
+        from apicurio_serdes._async_client import AsyncApicurioRegistryClient
+
+        client = AsyncApicurioRegistryClient(url=REGISTRY_URL, group_id=GROUP_ID)
+
+        cached_schema: dict[str, Any] = {"type": "record", "name": "X", "fields": []}
+        cache_key = ("contentId", 42)
+        check_count: dict[str, int] = {"n": 0}
+
+        class _RaceDict(dict[tuple[str, int], Any]):
+            def __contains__(self, key: object) -> bool:
+                if key == cache_key:
+                    check_count["n"] += 1
+                    if check_count["n"] == 1:
+                        return False
+                    self[cache_key] = cached_schema  # type: ignore[index]
+                    return True
+                return super().__contains__(key)
+
+        client._id_cache = _RaceDict()  # type: ignore[assignment]
+        result = await client.get_schema_by_content_id(42)
+        assert result is cached_schema
+
+
 class TestDoubleCheckLocking:
     """Coverage: exercise the inner cache-check return path (line 70)."""
 

--- a/tests/test_async_deserializer.py
+++ b/tests/test_async_deserializer.py
@@ -1,0 +1,258 @@
+"""Tests for AsyncAvroDeserializer."""
+
+from __future__ import annotations
+
+import struct
+from typing import Any
+
+import pytest
+import respx
+
+from apicurio_serdes._async_client import AsyncApicurioRegistryClient
+from apicurio_serdes._errors import DeserializationError, RegistryConnectionError
+from apicurio_serdes.avro import AsyncAvroDeserializer
+from apicurio_serdes.serialization import MessageField, SerializationContext
+from tests.conftest import (
+    GROUP_ID,
+    REGISTRY_URL,
+    VALID_USER_EVENT,
+    make_confluent_bytes,
+)
+
+CONTENT_ID = 42
+
+
+def _make_async_client(mock_registry: respx.MockRouter) -> AsyncApicurioRegistryClient:
+    url = f"{REGISTRY_URL}/ids/contentIds/{CONTENT_ID}"
+    from tests.conftest import USER_EVENT_SCHEMA_JSON
+    import json
+    import httpx
+
+    mock_registry.get(url).mock(
+        return_value=httpx.Response(200, content=json.dumps(USER_EVENT_SCHEMA_JSON))
+    )
+    return AsyncApicurioRegistryClient(url=REGISTRY_URL, group_id=GROUP_ID)
+
+
+def _ctx() -> SerializationContext:
+    return SerializationContext(topic="test", field=MessageField.VALUE)
+
+
+# ── init ──
+
+
+async def test_init_stores_client(mock_registry: respx.MockRouter) -> None:
+    """AsyncAvroDeserializer stores registry_client."""
+    client = _make_async_client(mock_registry)
+    deser = AsyncAvroDeserializer(registry_client=client)
+    assert deser.registry_client is client
+
+
+async def test_init_default_use_id(mock_registry: respx.MockRouter) -> None:
+    """Default use_id is 'contentId'."""
+    client = _make_async_client(mock_registry)
+    deser = AsyncAvroDeserializer(registry_client=client)
+    assert deser.use_id == "contentId"
+
+
+async def test_init_explicit_use_id_global(mock_registry: respx.MockRouter) -> None:
+    """use_id can be set to 'globalId'."""
+    client = _make_async_client(mock_registry)
+    deser = AsyncAvroDeserializer(registry_client=client, use_id="globalId")
+    assert deser.use_id == "globalId"
+
+
+# ── successful decode ──
+
+
+async def test_call_valid_decode(mock_registry: respx.MockRouter) -> None:
+    """Valid Confluent-framed bytes decode to original dict."""
+    client = _make_async_client(mock_registry)
+    deser = AsyncAvroDeserializer(registry_client=client)
+    data = make_confluent_bytes(CONTENT_ID, VALID_USER_EVENT)
+    result = await deser(data, _ctx())
+    assert result == VALID_USER_EVENT
+
+
+# ── magic byte validation ──
+
+
+async def test_call_bad_magic_byte(mock_registry: respx.MockRouter) -> None:
+    """Non-0x00 magic byte raises DeserializationError immediately."""
+    client = _make_async_client(mock_registry)
+    deser = AsyncAvroDeserializer(registry_client=client)
+    bad_bytes = b"\x01" + struct.pack(">I", CONTENT_ID) + b"\x00\x00"
+    with pytest.raises(DeserializationError, match="magic"):
+        await deser(bad_bytes, _ctx())
+
+
+# ── length validation ──
+
+
+async def test_call_empty_input(mock_registry: respx.MockRouter) -> None:
+    """Empty input raises DeserializationError."""
+    client = _make_async_client(mock_registry)
+    deser = AsyncAvroDeserializer(registry_client=client)
+    with pytest.raises(DeserializationError):
+        await deser(b"", _ctx())
+
+
+async def test_call_input_too_short(mock_registry: respx.MockRouter) -> None:
+    """Input shorter than 5 bytes raises DeserializationError."""
+    client = _make_async_client(mock_registry)
+    deser = AsyncAvroDeserializer(registry_client=client)
+    with pytest.raises(DeserializationError):
+        await deser(b"\x00\x00\x00\x01", _ctx())
+
+
+# ── schema not found ──
+
+
+async def test_call_unknown_schema_id(mock_registry: respx.MockRouter) -> None:
+    """Unknown schema ID raises SchemaNotFoundError."""
+    import httpx
+
+    from apicurio_serdes._errors import SchemaNotFoundError
+
+    mock_registry.get(f"{REGISTRY_URL}/ids/contentIds/9999").mock(
+        return_value=httpx.Response(404)
+    )
+    client = AsyncApicurioRegistryClient(url=REGISTRY_URL, group_id=GROUP_ID)
+    deser = AsyncAvroDeserializer(registry_client=client)
+    bad_bytes = make_confluent_bytes(9999, VALID_USER_EVENT)
+    with pytest.raises(SchemaNotFoundError):
+        await deser(bad_bytes, _ctx())
+
+
+# ── corrupt payload ──
+
+
+async def test_call_corrupt_payload(mock_registry: respx.MockRouter) -> None:
+    """Corrupt Avro payload raises DeserializationError."""
+    client = _make_async_client(mock_registry)
+    deser = AsyncAvroDeserializer(registry_client=client)
+    corrupt = b"\x00" + struct.pack(">I", CONTENT_ID) + b"\xff\xff\xff"
+    with pytest.raises(DeserializationError, match="decode"):
+        await deser(corrupt, _ctx())
+
+
+# ── network error ──
+
+
+async def test_call_network_error(mock_registry: respx.MockRouter) -> None:
+    """Network failure during schema lookup raises RegistryConnectionError."""
+    import httpx
+
+    mock_registry.get(url__startswith=f"{REGISTRY_URL}/ids/").mock(
+        side_effect=httpx.ConnectError("refused")
+    )
+    client = AsyncApicurioRegistryClient(url=REGISTRY_URL, group_id=GROUP_ID)
+    deser = AsyncAvroDeserializer(registry_client=client)
+    data = make_confluent_bytes(CONTENT_ID, VALID_USER_EVENT)
+    with pytest.raises(RegistryConnectionError):
+        await deser(data, _ctx())
+
+
+# ── from_dict hook ──
+
+
+async def test_from_dict_applied(mock_registry: respx.MockRouter) -> None:
+    """from_dict callable is applied to decoded dict."""
+    from dataclasses import dataclass
+
+    @dataclass
+    class UserEvent:
+        userId: str
+        country: str
+
+    def from_dict(d: dict[str, Any], ctx: SerializationContext) -> UserEvent:
+        return UserEvent(**d)
+
+    client = _make_async_client(mock_registry)
+    deser = AsyncAvroDeserializer(registry_client=client, from_dict=from_dict)
+    data = make_confluent_bytes(CONTENT_ID, VALID_USER_EVENT)
+    result = await deser(data, _ctx())
+    assert isinstance(result, UserEvent)
+    assert result.userId == "abc-123"
+    assert result.country == "FR"
+
+
+async def test_from_dict_absent_returns_dict(mock_registry: respx.MockRouter) -> None:
+    """Absent from_dict returns plain dict."""
+    client = _make_async_client(mock_registry)
+    deser = AsyncAvroDeserializer(registry_client=client)
+    data = make_confluent_bytes(CONTENT_ID, VALID_USER_EVENT)
+    result = await deser(data, _ctx())
+    assert isinstance(result, dict)
+    assert result == VALID_USER_EVENT
+
+
+async def test_from_dict_error_wrapped(mock_registry: respx.MockRouter) -> None:
+    """from_dict exception wrapped as DeserializationError with cause."""
+
+    def bad_hook(d: dict[str, Any], ctx: SerializationContext) -> Any:
+        raise RuntimeError("hook failed")
+
+    client = _make_async_client(mock_registry)
+    deser = AsyncAvroDeserializer(registry_client=client, from_dict=bad_hook)
+    data = make_confluent_bytes(CONTENT_ID, VALID_USER_EVENT)
+    with pytest.raises(DeserializationError, match="from_dict") as exc_info:
+        await deser(data, _ctx())
+    assert isinstance(exc_info.value.__cause__, RuntimeError)
+
+
+# ── schema caching ──
+
+
+async def test_schema_cached_after_first_call(
+    mock_registry: respx.MockRouter,
+) -> None:
+    """Schema is fetched once and cached for subsequent calls."""
+    import httpx
+    import json
+
+    from tests.conftest import USER_EVENT_SCHEMA_JSON
+
+    url = f"{REGISTRY_URL}/ids/contentIds/{CONTENT_ID}"
+    route = mock_registry.get(url).mock(
+        return_value=httpx.Response(200, content=json.dumps(USER_EVENT_SCHEMA_JSON))
+    )
+    client = AsyncApicurioRegistryClient(url=REGISTRY_URL, group_id=GROUP_ID)
+    deser = AsyncAvroDeserializer(registry_client=client)
+    data = make_confluent_bytes(CONTENT_ID, VALID_USER_EVENT)
+
+    await deser(data, _ctx())
+    await deser(data, _ctx())
+
+    assert route.call_count == 1
+
+
+# ── globalId mode ──
+
+
+async def test_call_with_global_id_mode(mock_registry: respx.MockRouter) -> None:
+    """Deserializer with use_id='globalId' resolves via globalId endpoint."""
+    import httpx
+    import json
+
+    from tests.conftest import USER_EVENT_SCHEMA_JSON
+
+    global_id = 7
+    mock_registry.get(f"{REGISTRY_URL}/ids/globalIds/{global_id}").mock(
+        return_value=httpx.Response(200, content=json.dumps(USER_EVENT_SCHEMA_JSON))
+    )
+    client = AsyncApicurioRegistryClient(url=REGISTRY_URL, group_id=GROUP_ID)
+    deser = AsyncAvroDeserializer(registry_client=client, use_id="globalId")
+    data = make_confluent_bytes(global_id, VALID_USER_EVENT)
+    result = await deser(data, _ctx())
+    assert result == VALID_USER_EVENT
+
+
+# ── package export ──
+
+
+def test_async_avro_deserializer_importable_from_avro_package() -> None:
+    """AsyncAvroDeserializer is importable from apicurio_serdes.avro."""
+    from apicurio_serdes.avro import AsyncAvroDeserializer as Imported
+
+    assert Imported is AsyncAvroDeserializer

--- a/tests/test_async_deserializer.py
+++ b/tests/test_async_deserializer.py
@@ -24,9 +24,11 @@ CONTENT_ID = 42
 
 def _make_async_client(mock_registry: respx.MockRouter) -> AsyncApicurioRegistryClient:
     url = f"{REGISTRY_URL}/ids/contentIds/{CONTENT_ID}"
-    from tests.conftest import USER_EVENT_SCHEMA_JSON
     import json
+
     import httpx
+
+    from tests.conftest import USER_EVENT_SCHEMA_JSON
 
     mock_registry.get(url).mock(
         return_value=httpx.Response(200, content=json.dumps(USER_EVENT_SCHEMA_JSON))
@@ -208,8 +210,9 @@ async def test_schema_cached_after_first_call(
     mock_registry: respx.MockRouter,
 ) -> None:
     """Schema is fetched once and cached for subsequent calls."""
-    import httpx
     import json
+
+    import httpx
 
     from tests.conftest import USER_EVENT_SCHEMA_JSON
 
@@ -232,8 +235,9 @@ async def test_schema_cached_after_first_call(
 
 async def test_call_with_global_id_mode(mock_registry: respx.MockRouter) -> None:
     """Deserializer with use_id='globalId' resolves via globalId endpoint."""
-    import httpx
     import json
+
+    import httpx
 
     from tests.conftest import USER_EVENT_SCHEMA_JSON
 

--- a/tests/test_client.py
+++ b/tests/test_client.py
@@ -492,6 +492,34 @@ def test_content_id_outside_int64_raises_value_error(
         client.get_schema("OverflowTest2")
 
 
+def test_get_schema_read_timeout_raises_registry_connection_error(
+    mock_registry: respx.MockRouter,
+) -> None:
+    """httpx.ReadTimeout (not ConnectError) raises RegistryConnectionError [TD-001]."""
+    from apicurio_serdes._errors import RegistryConnectionError
+
+    mock_registry.get(
+        url__startswith=f"{REGISTRY_URL}/groups/{GROUP_ID}/artifacts/"
+    ).mock(side_effect=httpx.ReadTimeout("timed out"))
+    client = ApicurioRegistryClient(url=REGISTRY_URL, group_id=GROUP_ID)
+    with pytest.raises(RegistryConnectionError):
+        client.get_schema("Slow")
+
+
+def test_get_schema_by_global_id_read_timeout_raises_registry_connection_error(
+    mock_registry: respx.MockRouter,
+) -> None:
+    """httpx.ReadTimeout in _get_schema_by_id raises RegistryConnectionError [TD-001]."""
+    from apicurio_serdes._errors import RegistryConnectionError
+
+    mock_registry.get(url__startswith=f"{REGISTRY_URL}/ids/globalIds/").mock(
+        side_effect=httpx.ReadTimeout("timed out")
+    )
+    client = ApicurioRegistryClient(url=REGISTRY_URL, group_id=GROUP_ID)
+    with pytest.raises(RegistryConnectionError):
+        client.get_schema_by_global_id(7)
+
+
 def test_id_cache_double_check_locking(mock_registry: respx.MockRouter) -> None:
     """Exercise the double-checked locking return path for _id_cache (line 156).
 

--- a/tests/test_errors.py
+++ b/tests/test_errors.py
@@ -74,3 +74,38 @@ def test_schema_not_found_from_id_returns_correct_type() -> None:
     """from_id returns a SchemaNotFoundError instance."""
     err = SchemaNotFoundError.from_id("contentId", 9999)
     assert isinstance(err, SchemaNotFoundError)
+
+
+# ── TD-003: error classes exported from package root ──
+
+
+def test_schema_not_found_error_importable_from_package_root() -> None:
+    """SchemaNotFoundError is importable from apicurio_serdes [TD-003]."""
+    from apicurio_serdes import SchemaNotFoundError as Imported
+    from apicurio_serdes._errors import SchemaNotFoundError as Direct
+
+    assert Imported is Direct
+
+
+def test_deserialization_error_importable_from_package_root() -> None:
+    """DeserializationError is importable from apicurio_serdes [TD-003]."""
+    from apicurio_serdes import DeserializationError as Imported
+    from apicurio_serdes._errors import DeserializationError as Direct
+
+    assert Imported is Direct
+
+
+def test_serialization_error_importable_from_package_root() -> None:
+    """SerializationError is importable from apicurio_serdes [TD-003]."""
+    from apicurio_serdes import SerializationError as Imported
+    from apicurio_serdes._errors import SerializationError as Direct
+
+    assert Imported is Direct
+
+
+def test_registry_connection_error_importable_from_package_root() -> None:
+    """RegistryConnectionError is importable from apicurio_serdes [TD-003]."""
+    from apicurio_serdes import RegistryConnectionError as Imported
+    from apicurio_serdes._errors import RegistryConnectionError as Direct
+
+    assert Imported is Direct


### PR DESCRIPTION
## Summary

- **TD-001**: Widen transport error catch from `httpx.ConnectError` to `httpx.TransportError` in both sync and async clients — previously `ReadTimeout`, `WriteTimeout`, and other transport failures propagated as raw httpx exceptions instead of `RegistryConnectionError`
- **TD-003**: Re-export `SchemaNotFoundError`, `DeserializationError`, `SerializationError`, `RegistryConnectionError` from the package root — users no longer need to import from the private `_errors` module
- **Async interface parity**: Add `get_schema_by_global_id()`, `get_schema_by_content_id()`, and `_get_schema_by_id()` to `AsyncApicurioRegistryClient`, including `_id_cache` and closed-client guard
- **`AsyncAvroDeserializer`**: New class providing a fully non-blocking deserialization path using `AsyncApicurioRegistryClient`; exported from `apicurio_serdes.avro`

Note: TD-002 (sync client lifecycle management) was already resolved in `origin/main` before this branch was cut.

## Test plan

- [ ] 268 tests pass (up from 233), 100% line + branch coverage
- [ ] `mypy --strict` clean across all 9 source files
- [ ] `ruff check` and `ruff format --check` clean
- [ ] TD-001: `httpx.ReadTimeout` now raises `RegistryConnectionError` in both clients
- [ ] TD-003: all four error classes importable directly from `apicurio_serdes`
- [ ] Async ID methods: cache miss/hit, 404, network error, timeout, closed-client guard, double-check locking race covered
- [ ] `AsyncAvroDeserializer`: full scenario coverage (valid decode, bad magic, too short, unknown ID, corrupt payload, network error, from_dict hook, caching, globalId mode)

🤖 Generated with [Claude Code](https://claude.com/claude-code)