### PR TITLE
feat: client authentication — BearerAuth and KeycloakAuth (#38)

### DIFF
--- a/docs/plans/2026-03-13-auth-plan.md
+++ b/docs/plans/2026-03-13-auth-plan.md
@@ -1,0 +1,266 @@
+# Plan: Client Authentication — BearerAuth and KeycloakAuth (2026-03-13)
+
+## Summary
+
+Add authentication support to `ApicurioRegistryClient` and
+`AsyncApicurioRegistryClient` via a new `_auth.py` module. Two `httpx.Auth`
+subclasses are introduced: `BearerAuth` (static token or callable provider,
+covers GCP OIDC) and `KeycloakAuth` (client credentials flow with
+threshold-based auto-refresh). Both clients gain an `auth=` constructor kwarg.
+Both classes are exported from the top-level package. No new dependencies.
+
+## Stakes Classification
+
+**Level**: Medium
+
+**Rationale**: New module + changes to two existing clients + new public API
+surface. Well-contained (no architectural changes, no schema logic touched).
+Requires 100% coverage including async refresh paths.
+
+## Context
+
+**Research**: [docs/plans/2026-03-13-auth-research.md](2026-03-13-auth-research.md)
+
+**Worktree**: `.worktrees/feat-auth-38/`
+
+**Affected files**:
+
+- `src/apicurio_serdes/_auth.py` (new)
+- `src/apicurio_serdes/_client.py` (minor: `auth=` kwarg)
+- `src/apicurio_serdes/_async_client.py` (minor: `auth=` kwarg)
+- `src/apicurio_serdes/__init__.py` (add exports)
+- `tests/test_auth.py` (new)
+- `tests/test_client.py` (add constructor + header tests)
+- `tests/test_async_client.py` (add parity test)
+
+## Success Criteria
+
+- [ ] `BearerAuth(token="...")` injects `Authorization: Bearer <token>` header
+- [ ] `BearerAuth(token_provider=fn)` calls `fn()` on every request
+- [ ] `KeycloakAuth` fetches token via client credentials on first use
+- [ ] `KeycloakAuth` auto-refreshes when <20% TTL remains
+- [ ] `KeycloakAuth` works with both sync and async clients without blocking
+- [ ] `auth=None` (default) leaves existing behaviour unchanged
+- [ ] `BearerAuth` and `KeycloakAuth` exported from `apicurio_serdes`
+- [ ] 100% coverage on all new and modified code
+- [ ] mypy strict passes with no new errors
+
+## Implementation Steps
+
+### Phase 1: BearerAuth
+
+#### Step 1.1: Write BearerAuth tests (RED)
+
+- **Files**: `tests/test_auth.py` (new)
+- **Action**: Create test file with `TestBearerAuth` class. Use `respx` to
+  mock a registry endpoint and assert the `Authorization` header.
+- **Test cases**:
+  - Static token: `BearerAuth(token="tok")` — request carries
+    `Authorization: Bearer tok`
+  - Dynamic token: `BearerAuth(token_provider=lambda: "dyn")` — request carries
+    `Authorization: Bearer dyn`
+  - Provider called on each request: two requests → provider called twice
+    (assert call count)
+  - Missing both args: `BearerAuth()` → raises `ValueError`
+  - Both args provided: `BearerAuth(token="t", token_provider=fn)` → raises
+    `ValueError`
+  - Works via sync `httpx.Client` (direct httpx test, no registry)
+  - Works via async `httpx.AsyncClient` (direct httpx test, no registry)
+- **Verify**: Tests collected and all fail (no `_auth.py` yet)
+- **Complexity**: Small
+
+#### Step 1.2: Implement BearerAuth (GREEN)
+
+- **Files**: `src/apicurio_serdes/_auth.py` (new)
+- **Action**: Create module with `BearerAuth(httpx.Auth)`.
+  - `__init__`: validate exactly one of `token` or `token_provider` is given
+  - `_get_token() -> str`: returns `self._token` or calls `self._token_provider()`
+  - `auth_flow`: injects `Authorization: Bearer {self._get_token()}`, yields request
+  - Single `auth_flow` serves both sync and async (no I/O in the method)
+- **Verify**: All Step 1.1 tests pass; `uv run pytest tests/test_auth.py -x`
+- **Complexity**: Small
+
+### Phase 2: KeycloakAuth — sync path
+
+#### Step 2.1: Write KeycloakAuth sync tests (RED)
+
+- **Files**: `tests/test_auth.py`
+- **Action**: Add `TestKeycloakAuthSync` class. Mock the Keycloak token
+  endpoint with `respx` and a mock registry route.
+- **Test cases**:
+  - Happy path: first request triggers token POST; registry GET receives
+    `Authorization: Bearer <access_token>`
+  - Token reuse: two requests → token endpoint called only once
+  - Auto-refresh: manipulate `_expires_at` to be in the past; second request
+    triggers a second token POST
+  - Threshold refresh: set `_expires_at` to now + 0.1 × `_expires_in`
+    (within 20% window) → triggers refresh before the request
+  - Token endpoint returns 401 → raises `AuthenticationError`
+  - Token endpoint unreachable (transport error) → raises `AuthenticationError`
+  - `scope` param: `KeycloakAuth(..., scope="openid")` — POST body includes
+    `scope=openid`
+  - No `scope`: POST body omits `scope` field
+- **Verify**: Tests collected and all fail
+- **Complexity**: Small
+
+#### Step 2.2: Implement KeycloakAuth sync path (GREEN)
+
+- **Files**: `src/apicurio_serdes/_auth.py`, `src/apicurio_serdes/_errors.py`
+- **Action**:
+  - Add `AuthenticationError(Exception)` to `_errors.py`
+  - Add `KeycloakAuth(httpx.Auth)` to `_auth.py`:
+    - `__init__`: store `token_url`, `client_id`, `client_secret`, `scope`;
+      init `_token = ""`, `_expires_at = 0.0`, `_expires_in = 0.0`,
+      `_sync_lock = threading.Lock()`
+    - `_is_expired() -> bool`: `True` if no token or
+      `_expires_at < monotonic() + _expires_in * 0.2`
+    - `_sync_fetch_token()`: POST `token_url` with `httpx.Client()` (short-lived);
+      parse `access_token` + `expires_in`; update state;
+      raise `AuthenticationError` on non-200 or transport error
+    - `_sync_ensure_token()`: double-checked lock pattern calling
+      `_sync_fetch_token` if expired
+    - `sync_auth_flow`: call `_sync_ensure_token()`, inject header, yield request
+- **Verify**: All Step 2.1 tests pass; `uv run pytest tests/test_auth.py -x`
+- **Complexity**: Medium
+
+### Phase 3: KeycloakAuth — async path
+
+#### Step 3.1: Write KeycloakAuth async tests (RED)
+
+- **Files**: `tests/test_auth.py`
+- **Action**: Add `TestKeycloakAuthAsync` class. Mirror the sync test cases
+  using `pytest.mark.asyncio` and `respx` async context.
+- **Test cases** (async equivalents of Step 2.1):
+  - Happy path via `httpx.AsyncClient`
+  - Token reuse (single POST)
+  - Auto-refresh (manipulate `_expires_at`)
+  - Threshold refresh
+  - Token endpoint 401 → `AuthenticationError`
+  - Token endpoint unreachable → `AuthenticationError`
+  - Lazy lock: `KeycloakAuth` created outside event loop → still works when
+    used inside `async with`
+- **Verify**: Tests collected and all fail
+- **Complexity**: Small
+
+#### Step 3.2: Implement KeycloakAuth async path (GREEN)
+
+- **Files**: `src/apicurio_serdes/_auth.py`
+- **Action**: Extend `KeycloakAuth`:
+  - Add `_async_lock: asyncio.Lock | None = None` (init as `None`)
+  - `_get_async_lock()`: creates lock lazily on first call
+  - `_async_fetch_token()`: `async with httpx.AsyncClient() as c: await c.post(...)`;
+    same parse + error handling as sync
+  - `_async_ensure_token()`: async double-checked lock using `_get_async_lock()`
+  - `async_auth_flow`: `await _async_ensure_token()`, inject header, yield request
+- **Verify**: All Step 3.1 tests pass; full `uv run pytest tests/test_auth.py`
+- **Complexity**: Medium
+
+### Phase 4: Wire auth into registry clients
+
+#### Step 4.1: Write client auth wiring tests (RED)
+
+- **Files**: `tests/test_client.py`, `tests/test_async_client.py`
+- **Action**: Add auth-related tests to existing test classes.
+- **Test cases for `test_client.py`**:
+  - Constructor accepts `auth=None` (default, existing tests still pass)
+  - Constructor accepts `auth=BearerAuth(token="tok")`
+  - Registry request carries `Authorization: Bearer tok` header (via respx
+    `route.calls[0].request.headers`)
+- **Test cases for `test_async_client.py`**:
+  - Same three cases, async variants
+  - `TestInterfaceParity`: assert `AsyncApicurioRegistryClient.__init__` has
+    `auth` parameter matching sync client signature
+- **Verify**: New tests collected and fail; existing tests still pass
+- **Complexity**: Small
+
+#### Step 4.2: Update `_client.py` and `_async_client.py` (GREEN)
+
+- **Files**: `src/apicurio_serdes/_client.py:44-46`,
+  `src/apicurio_serdes/_async_client.py:31-34`
+- **Action**:
+  - `_client.py`: add `auth: httpx.Auth | None = None` to `__init__` signature;
+    pass `auth=auth` to `httpx.Client(base_url=url, auth=auth)`
+  - `_async_client.py`: same change for `httpx.AsyncClient`
+  - Update docstrings for both to document the `auth` parameter
+- **Verify**: All Step 4.1 tests pass; `uv run pytest -x`
+- **Complexity**: Small
+
+### Phase 5: Public API and coverage gate
+
+#### Step 5.1: Export BearerAuth and KeycloakAuth
+
+- **Files**: `src/apicurio_serdes/__init__.py:17-26`
+- **Action**: Import `BearerAuth`, `KeycloakAuth` from `._auth`; add both to
+  `__all__`; import `AuthenticationError` from `._errors` and add to `__all__`
+- **Verify**: `python -c "from apicurio_serdes import BearerAuth, KeycloakAuth,
+  AuthenticationError"` succeeds
+- **Complexity**: Small
+
+#### Step 5.2: Full test suite and coverage gate
+
+- **Files**: all test files
+- **Action**: Run full suite with coverage
+- **Verify**:
+  - `uv run pytest --tb=short` — 0 failures
+  - Coverage report shows 100% on `_auth.py`, `_errors.py`, `_client.py`,
+    `_async_client.py`, `__init__.py`
+  - `uv run mypy src/` — 0 errors
+- **Complexity**: Small
+
+## Test Strategy
+
+### Automated Tests
+
+| Test case | Type | Input | Expected output |
+| --------- | ---- | ----- | --------------- |
+| Static Bearer injects header | Unit | `BearerAuth(token="tok")` | `Authorization: Bearer tok` |
+| Dynamic Bearer calls provider | Unit | `BearerAuth(token_provider=fn)` | fn called; header set |
+| Provider called per request | Unit | Two requests | fn called twice |
+| BearerAuth no args | Unit | `BearerAuth()` | `ValueError` |
+| BearerAuth both args | Unit | `BearerAuth(token=..., token_provider=...)` | `ValueError` |
+| BearerAuth sync client | Integration | `httpx.Client(auth=BearerAuth(...))` | header on request |
+| BearerAuth async client | Integration | `httpx.AsyncClient(auth=BearerAuth(...))` | header on request |
+| Keycloak happy path (sync) | Integration | First request | token POST made; header set |
+| Keycloak token reuse (sync) | Integration | Two requests | one POST only |
+| Keycloak auto-refresh (sync) | Integration | Expired `_expires_at` | second POST made |
+| Keycloak threshold (sync) | Integration | Near-expiry `_expires_at` | refresh before request |
+| Keycloak 401 token endpoint (sync) | Integration | Mock 401 on token URL | `AuthenticationError` |
+| Keycloak transport error (sync) | Integration | Mock connection refused | `AuthenticationError` |
+| Keycloak scope param (sync) | Unit | `scope="openid"` | body includes `scope=openid` |
+| Keycloak no scope (sync) | Unit | no scope | body omits `scope` |
+| Keycloak happy path (async) | Integration | First async request | token POST made; header set |
+| Keycloak token reuse (async) | Integration | Two async requests | one POST only |
+| Keycloak auto-refresh (async) | Integration | Expired `_expires_at` | second POST made |
+| Keycloak lazy lock | Unit | Created outside loop | no error on first async use |
+| Client auth=None default | Unit | `ApicurioRegistryClient(url, group_id)` | no auth header |
+| Client auth kwarg (sync) | Integration | `auth=BearerAuth(token="t")` | header on registry call |
+| Client auth kwarg (async) | Integration | `auth=BearerAuth(token="t")` | header on registry call |
+| Interface parity | Unit | Inspect signatures | sync and async match |
+
+### Manual Verification
+
+- [ ] `python -c "from apicurio_serdes import BearerAuth, KeycloakAuth,
+  AuthenticationError; print('OK')"` — all three importable
+- [ ] `uv run mypy src/` — zero errors after implementation
+
+## Risks and Mitigations
+
+| Risk | Impact | Mitigation |
+| ---- | ------ | ---------- |
+| Lazy `asyncio.Lock` race on first async call | Two concurrent calls both fetch tokens | Lock creation is idempotent; worst case is two fetches on first use, then one lock in use — acceptable |
+| Short-lived `httpx.Client` in `_sync_fetch_token` adds overhead | Minor latency on refresh | Only on token refresh (rare); acceptable trade-off for simplicity |
+| `_expires_at` clock drift | Premature refresh | Using `time.monotonic()` (not wall clock); 20% threshold provides margin |
+| mypy strict rejects `Callable[[], str]` annotation | Build failure | Type imported from `collections.abc`; tested locally before PR |
+| Test isolation: `_expires_at` mutation bleeds across tests | Flaky tests | Each test instantiates a fresh `KeycloakAuth`; no shared state |
+
+## Rollback Strategy
+
+All changes are additive — no existing signatures are broken (new `auth=None`
+default is backwards-compatible). Rollback is `git revert` of the feature
+branch. No database migrations. No config changes in production.
+
+## Status
+
+- [x] Plan approved
+- [x] Implementation started
+- [x] Implementation complete

--- a/docs/plans/2026-03-13-auth-research.md
+++ b/docs/plans/2026-03-13-auth-research.md
@@ -1,0 +1,265 @@
+# Research: Client Authentication (2026-03-13)
+
+## Problem Statement
+
+The registry clients (`ApicurioRegistryClient` and `AsyncApicurioRegistryClient`)
+make unauthenticated HTTP calls. The first production deployment requires writing
+to a Kafka topic on a GCP staging cluster from Airflow DAGs. The Apicurio registry
+may be secured behind Keycloak OIDC. Two auth patterns are needed:
+
+- **Bearer token** — static string or dynamic callable (GCP OIDC identity token)
+- **Keycloak OAuth2** — client credentials flow with automatic token refresh
+
+## Requirements
+
+| ID   | Requirement |
+|------|-------------|
+| R-1  | `auth=` kwarg on both `ApicurioRegistryClient` and `AsyncApicurioRegistryClient` |
+| R-2  | `BearerAuth(token="...")` for static tokens |
+| R-3  | `BearerAuth(token_provider=callable)` for dynamic tokens (e.g., GCP OIDC) |
+| R-4  | `KeycloakAuth(token_url, client_id, client_secret)` for client credentials flow |
+| R-5  | `KeycloakAuth` auto-refreshes when token nears expiry (threshold-based) |
+| R-6  | Both auth classes work with sync and async clients |
+| R-7  | No new runtime dependencies |
+| R-8  | 100% test coverage maintained |
+| R-9  | Exported from top-level `apicurio_serdes` package |
+
+## Findings
+
+### Relevant Files
+
+| File | Purpose | Key Lines |
+|------|---------|-----------|
+| `src/apicurio_serdes/_base.py` | Base class: `url`, `group_id`, caches, response parsing | 40–49 |
+| `src/apicurio_serdes/_client.py` | Sync client; constructs `httpx.Client(base_url=url)` | 44–46 |
+| `src/apicurio_serdes/_async_client.py` | Async client; constructs `httpx.AsyncClient(base_url=url)` | 31–34 |
+| `src/apicurio_serdes/__init__.py` | Public exports — needs `BearerAuth`, `KeycloakAuth` added | 17–26 |
+| `tests/conftest.py` | `mock_registry` fixture via `respx`; route helpers | 135–139 |
+| `tests/test_client.py` | Sync client tests; constructor validation pattern | 264+ |
+| `tests/test_async_client.py` | Async client tests; `TestInterfaceParity` at line 196 | 196+ |
+
+### Client Construction Extension Points
+
+Both clients are minimal wrappers: `__init__` calls `super().__init__(url, group_id)`
+then constructs the httpx client. Auth needs to be threaded through here:
+
+```python
+# _client.py — current
+self._http_client = httpx.Client(base_url=url)
+
+# _client.py — after change
+self._http_client = httpx.Client(base_url=url, auth=auth)
+```
+
+The base class (`_RegistryClientBase`) does **not** need to change. It holds no
+HTTP client; auth is purely a transport-layer concern of the subclasses.
+
+### httpx Auth Protocol
+
+httpx provides a generator-based `httpx.Auth` protocol with three methods:
+
+```python
+class httpx.Auth:
+    def auth_flow(self, request) -> Generator[Request, Response, None]: ...
+    def sync_auth_flow(self, request) -> Generator[Request, Response, None]: ...
+    async def async_auth_flow(self, request) -> AsyncGenerator[Request, Response]: ...
+```
+
+- `sync_auth_flow` is called by `httpx.Client`
+- `async_auth_flow` is called by `httpx.AsyncClient`
+- By default, both delegate to `auth_flow` if only `auth_flow` is overridden
+- **Key**: when `auth_flow` does no I/O (just injects a header), one class serves both clients
+
+**Simple Bearer injection (no I/O, single class works for sync + async):**
+
+```python
+class BearerAuth(httpx.Auth):
+    def auth_flow(self, request):
+        request.headers["Authorization"] = f"Bearer {self._get_token()}"
+        yield request
+```
+
+### Keycloak Token Flow
+
+Endpoint: `POST {token_url}` where `token_url` is the full URL, e.g.
+`https://keycloak.example.com/realms/myrealm/protocol/openid-connect/token`.
+
+Request body (`application/x-www-form-urlencoded`):
+
+```text
+grant_type=client_credentials&client_id=<id>&client_secret=<secret>
+```
+
+Response JSON:
+
+```json
+{
+  "access_token": "eyJhbGci...",
+  "expires_in": 300,
+  "token_type": "Bearer"
+}
+```
+
+No refresh token is issued for client credentials grants — a new token must be
+fetched on expiry.
+
+### Token Refresh Pattern
+
+Confluent's production implementation uses a **threshold-based expiry window**:
+refresh when less than 20% of the TTL remains (`expires_at - now < 0.2 * expires_in`).
+This avoids clock-skew races where a token expires mid-request.
+
+Pattern with double-checked locking:
+
+```python
+def _is_expired(self) -> bool:
+    if not self._token:
+        return True
+    return self._expires_at < time.monotonic() + (self._expires_in * 0.2)
+
+def _ensure_token(self) -> None:
+    if self._is_expired():
+        with self._lock:
+            if self._is_expired():   # second check inside lock
+                self._fetch_token()
+```
+
+### Sync vs Async Duality for KeycloakAuth
+
+`BearerAuth` has no I/O in `auth_flow` → single class with `auth_flow` works.
+
+`KeycloakAuth` must perform an HTTP POST to fetch a token. This creates a duality:
+
+- **Sync client path**: `sync_auth_flow` must use `threading.Lock` and `httpx.Client`
+- **Async client path**: `async_auth_flow` must use `asyncio.Lock` and avoid blocking
+
+**Recommended approach — separate `sync_auth_flow` and `async_auth_flow`**:
+
+```python
+class KeycloakAuth(httpx.Auth):
+    def __init__(self, token_url, client_id, client_secret, scope=None):
+        ...
+        self._sync_lock = threading.Lock()
+        self._async_lock: asyncio.Lock | None = None  # lazily created
+
+    def sync_auth_flow(self, request):
+        self._sync_ensure_token()
+        request.headers["Authorization"] = f"Bearer {self._token}"
+        yield request
+
+    async def async_auth_flow(self, request):
+        await self._async_ensure_token()
+        request.headers["Authorization"] = f"Bearer {self._token}"
+        yield request
+```
+
+`_sync_ensure_token` uses `threading.Lock` + opens a short-lived `httpx.Client`
+for the token POST.
+
+`_async_ensure_token` uses `asyncio.Lock` (created lazily on first call to stay
+event-loop-safe) + opens a short-lived `httpx.AsyncClient` for the token POST.
+
+**Why lazy async lock?** Although Python ≥ 3.10 allows creating `asyncio.Lock()`
+without a running loop, creating it lazily inside `_async_ensure_token` is
+the safest pattern and avoids any edge cases when the object is used across
+different event loops in tests.
+
+**Alternative — `asyncio.to_thread`**: Run `_sync_fetch_token` in a thread pool
+from `_async_ensure_token`. Simpler, but introduces thread-pool overhead on every
+token refresh and still requires careful lock handling.
+
+### Test Patterns
+
+The project uses `respx` for HTTP mocking. Auth tests need to:
+
+1. Verify `Authorization: Bearer` header is sent on registry requests
+2. For `KeycloakAuth`: mock the token endpoint POST + the registry GET
+3. Verify auto-refresh: set `expires_at` in the past, confirm a new token fetch
+
+`respx` can assert on request headers:
+
+```python
+route = router.get(url).mock(...)
+assert route.calls[0].request.headers["authorization"] == "Bearer test-token"
+```
+
+For `KeycloakAuth`, mock the token endpoint separately:
+
+```python
+router.post("https://keycloak/token").mock(
+    return_value=Response(200, json={"access_token": "tok", "expires_in": 300})
+)
+```
+
+### External Research Summary
+
+| Topic | Finding | Source |
+|-------|---------|--------|
+| httpx `auth_flow` | Generator protocol; `sync_auth_flow`/`async_auth_flow` wrap it | httpx docs + source |
+| Single class for sync+async | Works when `auth_flow` has no I/O | httpx source `_auth.py` |
+| Keycloak endpoint | `POST /realms/{realm}/protocol/openid-connect/token` | Keycloak official docs |
+| Token response | `access_token` + `expires_in` (no refresh token) | RFC 6749 §4.4 |
+| Threshold refresh | 20% TTL remaining; double-checked lock | Confluent source |
+| CUSTOM bearer source | User-supplied callable; Confluent `_CustomOAuthClient` | Confluent source |
+
+### Technical Constraints
+
+- **No new dependencies** — httpx is already a dependency; token fetch uses httpx directly
+- **Python ≥ 3.10** — `asyncio.Lock()` safe without running loop; `asyncio.to_thread` available
+- **100% coverage** — every branch in both `sync_auth_flow` and `async_auth_flow` must be tested,
+  including the token-expired refresh path
+- **mypy strict** — `httpx.Auth` subclasses must be properly typed; `token_provider` typed as
+  `Callable[[], str]`; async lock typed as `asyncio.Lock | None`
+- **Thread-safe sync, coroutine-safe async** — double-checked locking pattern required
+
+## Open Questions
+
+1. Does the staging Apicurio registry actually require auth, or only Kafka does?
+   (If registry is open, Bearer/Keycloak support is still correct to ship but not blocking.)
+2. What realm name does the backend team use in Keycloak? (Needed for `token_url` in docs/examples.)
+3. Should `KeycloakAuth` accept an optional `scope` parameter? (Default: no scope sent.)
+4. Should auth errors (e.g., 401 from token endpoint) raise a new `AuthenticationError`,
+   or wrap into `RegistryConnectionError`?
+
+## Recommendations
+
+### New module: `src/apicurio_serdes/_auth.py`
+
+```python
+class BearerAuth(httpx.Auth):
+    def __init__(
+        self,
+        token: str | None = None,
+        token_provider: Callable[[], str] | None = None,
+    ) -> None: ...
+
+    def auth_flow(self, request: httpx.Request) -> Generator[...]: ...
+
+
+class KeycloakAuth(httpx.Auth):
+    def __init__(
+        self,
+        token_url: str,
+        client_id: str,
+        client_secret: str,
+        scope: str | None = None,
+    ) -> None: ...
+
+    def sync_auth_flow(self, request: httpx.Request) -> Generator[...]: ...
+    async def async_auth_flow(self, request: httpx.Request) -> AsyncGenerator[...]: ...
+```
+
+### Changes to `_client.py` and `_async_client.py`
+
+Add `auth: httpx.Auth | None = None` parameter; pass to `httpx.Client`/`httpx.AsyncClient`.
+
+### Changes to `__init__.py`
+
+Export `BearerAuth` and `KeycloakAuth` from top-level package.
+
+### Test files
+
+- `tests/test_auth.py` — unit tests for `BearerAuth` and `KeycloakAuth` in isolation
+  (no real HTTP, mock token endpoint with respx)
+- `tests/test_client.py` — add constructor test for `auth=BearerAuth(...)` passed through
+- `tests/test_async_client.py` — same parity test

--- a/src/apicurio_serdes/__init__.py
+++ b/src/apicurio_serdes/__init__.py
@@ -3,8 +3,10 @@
 from importlib.metadata import version
 
 from apicurio_serdes._async_client import AsyncApicurioRegistryClient
+from apicurio_serdes._auth import BearerAuth, KeycloakAuth
 from apicurio_serdes._client import ApicurioRegistryClient
 from apicurio_serdes._errors import (
+    AuthenticationError,
     DeserializationError,
     RegistryConnectionError,
     ResolverError,
@@ -19,7 +21,10 @@ __version__ = version("apicurio-serdes")
 __all__ = [
     "ApicurioRegistryClient",
     "AsyncApicurioRegistryClient",
+    "AuthenticationError",
+    "BearerAuth",
     "DeserializationError",
+    "KeycloakAuth",
     "RegistryConnectionError",
     "ResolverError",
     "SchemaNotFoundError",

--- a/src/apicurio_serdes/_async_client.py
+++ b/src/apicurio_serdes/_async_client.py
@@ -26,14 +26,20 @@ class AsyncApicurioRegistryClient(_RegistryClientBase):
              Example: "http://registry:8080/apis/registry/v3"
         group_id: Schema group identifier. Applied to every
                   schema lookup made by this client instance.
+        auth: Optional httpx authentication handler. Pass a
+              :class:`~apicurio_serdes.BearerAuth` or
+              :class:`~apicurio_serdes.KeycloakAuth` instance for
+              authenticated registries. Defaults to ``None`` (no auth).
 
     Raises:
         ValueError: If url or group_id is empty.
     """
 
-    def __init__(self, url: str, group_id: str) -> None:
+    def __init__(
+        self, url: str, group_id: str, auth: httpx.Auth | None = None
+    ) -> None:
         super().__init__(url, group_id)
-        self._http_client = httpx.AsyncClient(base_url=url)
+        self._http_client = httpx.AsyncClient(base_url=url, auth=auth)
         self._lock = asyncio.Lock()
 
     async def get_schema(self, artifact_id: str) -> CachedSchema:

--- a/src/apicurio_serdes/_async_client.py
+++ b/src/apicurio_serdes/_async_client.py
@@ -35,9 +35,7 @@ class AsyncApicurioRegistryClient(_RegistryClientBase):
         ValueError: If url or group_id is empty.
     """
 
-    def __init__(
-        self, url: str, group_id: str, auth: httpx.Auth | None = None
-    ) -> None:
+    def __init__(self, url: str, group_id: str, auth: httpx.Auth | None = None) -> None:
         super().__init__(url, group_id)
         self._http_client = httpx.AsyncClient(base_url=url, auth=auth)
         self._lock = asyncio.Lock()

--- a/src/apicurio_serdes/_auth.py
+++ b/src/apicurio_serdes/_auth.py
@@ -5,8 +5,7 @@ from __future__ import annotations
 import asyncio
 import threading
 import time
-from collections.abc import Callable, Generator
-from typing import AsyncGenerator
+from collections.abc import AsyncGenerator, Callable, Generator
 from urllib.parse import urlparse, urlunparse
 
 import httpx
@@ -130,7 +129,9 @@ class KeycloakAuth(httpx.Auth):
     def _is_expired(self) -> bool:
         if not self._token:
             return True
-        return self._expires_at < time.monotonic() + self._expires_in * _REFRESH_THRESHOLD
+        return (
+            self._expires_at < time.monotonic() + self._expires_in * _REFRESH_THRESHOLD
+        )
 
     def _build_token_data(self) -> dict[str, str]:
         data: dict[str, str] = {
@@ -175,9 +176,7 @@ class KeycloakAuth(httpx.Auth):
     def _sync_fetch_token(self) -> None:
         try:
             with httpx.Client() as client:
-                response = client.post(
-                    self._token_url, data=self._build_token_data()
-                )
+                response = client.post(self._token_url, data=self._build_token_data())
         except httpx.TransportError as exc:
             raise AuthenticationError(
                 f"Could not reach token endpoint {self._safe_url(self._token_url)}: {exc}"

--- a/src/apicurio_serdes/_auth.py
+++ b/src/apicurio_serdes/_auth.py
@@ -5,12 +5,15 @@ from __future__ import annotations
 import asyncio
 import threading
 import time
-from collections.abc import AsyncGenerator, Callable, Generator
+from typing import TYPE_CHECKING
 from urllib.parse import urlparse, urlunparse
 
 import httpx
 
 from apicurio_serdes._errors import AuthenticationError
+
+if TYPE_CHECKING:
+    from collections.abc import AsyncGenerator, Callable, Generator
 
 __all__ = ["BearerAuth", "KeycloakAuth"]
 
@@ -172,15 +175,18 @@ class KeycloakAuth(httpx.Auth):
             expires_in = float(payload["expires_in"])
         except (KeyError, TypeError, ValueError) as exc:
             raise AuthenticationError(
-                f"Unexpected token endpoint response (missing access_token or expires_in): {exc}"
+                "Unexpected token endpoint response"
+                f" (missing access_token or expires_in): {exc}"
             ) from exc
         if not isinstance(token, str) or not token:
             raise AuthenticationError(
-                f"Unexpected token endpoint response (access_token is empty or not a string): {token!r}"
+                "Unexpected token endpoint response"
+                f" (access_token is empty or not a string): {token!r}"
             )
         if expires_in <= 0:
             raise AuthenticationError(
-                f"Unexpected token endpoint response (expires_in must be positive): {expires_in}"
+                "Unexpected token endpoint response"
+                f" (expires_in must be positive): {expires_in}"
             )
         self._token = token
         self._expires_in = expires_in
@@ -194,7 +200,8 @@ class KeycloakAuth(httpx.Auth):
                 response = client.post(self._token_url, data=self._build_token_data())
         except httpx.TransportError as exc:
             raise AuthenticationError(
-                f"Could not reach token endpoint {self._safe_url(self._token_url)}: {exc}"
+                f"Could not reach token endpoint"
+                f" {self._safe_url(self._token_url)}: {exc}"
             ) from exc
         self._parse_token_response(response)
 
@@ -227,7 +234,8 @@ class KeycloakAuth(httpx.Auth):
                 )
         except httpx.TransportError as exc:
             raise AuthenticationError(
-                f"Could not reach token endpoint {self._safe_url(self._token_url)}: {exc}"
+                f"Could not reach token endpoint"
+                f" {self._safe_url(self._token_url)}: {exc}"
             ) from exc
         self._parse_token_response(response)
 

--- a/src/apicurio_serdes/_auth.py
+++ b/src/apicurio_serdes/_auth.py
@@ -147,7 +147,10 @@ class KeycloakAuth(httpx.Auth):
     def _safe_url(url: str) -> str:
         """Strip userinfo from a URL to avoid leaking embedded credentials."""
         parsed = urlparse(url)
-        return urlunparse(parsed._replace(netloc=parsed.hostname or ""))
+        netloc = parsed.hostname or ""
+        if parsed.port:
+            netloc = f"{netloc}:{parsed.port}"
+        return urlunparse(parsed._replace(netloc=netloc))
 
     def _parse_token_response(self, response: httpx.Response) -> None:
         try:

--- a/src/apicurio_serdes/_auth.py
+++ b/src/apicurio_serdes/_auth.py
@@ -85,8 +85,10 @@ class KeycloakAuth(httpx.Auth):
         scope: Optional OAuth2 scope string (e.g. ``"openid"``).
 
     Raises:
-        AuthenticationError: If the token endpoint is unreachable or returns
-            a non-200 response.
+        AuthenticationError: If the token endpoint is unreachable, returns a
+            non-200 response, or returns a 200 response with a malformed body
+            (missing or empty ``access_token``, missing ``expires_in``, or
+            non-JSON).
 
     Example:
         ```python
@@ -172,6 +174,10 @@ class KeycloakAuth(httpx.Auth):
             raise AuthenticationError(
                 f"Unexpected token endpoint response (missing access_token or expires_in): {exc}"
             ) from exc
+        if not isinstance(token, str) or not token:
+            raise AuthenticationError(
+                f"Unexpected token endpoint response (access_token is empty or not a string): {token!r}"
+            )
         self._token = token
         self._expires_in = expires_in
         self._expires_at = time.monotonic() + expires_in

--- a/src/apicurio_serdes/_auth.py
+++ b/src/apicurio_serdes/_auth.py
@@ -166,13 +166,15 @@ class KeycloakAuth(httpx.Auth):
             ) from exc
         try:
             payload = response.json()
-            self._token = payload["access_token"]
-            self._expires_in = float(payload["expires_in"])
+            token = payload["access_token"]
+            expires_in = float(payload["expires_in"])
         except (KeyError, TypeError, ValueError) as exc:
             raise AuthenticationError(
                 f"Unexpected token endpoint response (missing access_token or expires_in): {exc}"
             ) from exc
-        self._expires_at = time.monotonic() + self._expires_in
+        self._token = token
+        self._expires_in = expires_in
+        self._expires_at = time.monotonic() + expires_in
 
     # ── Sync path ──
 

--- a/src/apicurio_serdes/_auth.py
+++ b/src/apicurio_serdes/_auth.py
@@ -87,8 +87,8 @@ class KeycloakAuth(httpx.Auth):
     Raises:
         AuthenticationError: If the token endpoint is unreachable, returns a
             non-200 response, or returns a 200 response with a malformed body
-            (missing or empty ``access_token``, missing ``expires_in``, or
-            non-JSON).
+            (missing or empty ``access_token``, missing or non-positive
+            ``expires_in``, or non-JSON).
 
     Example:
         ```python
@@ -177,6 +177,10 @@ class KeycloakAuth(httpx.Auth):
         if not isinstance(token, str) or not token:
             raise AuthenticationError(
                 f"Unexpected token endpoint response (access_token is empty or not a string): {token!r}"
+            )
+        if expires_in <= 0:
+            raise AuthenticationError(
+                f"Unexpected token endpoint response (expires_in must be positive): {expires_in}"
             )
         self._token = token
         self._expires_in = expires_in

--- a/src/apicurio_serdes/_auth.py
+++ b/src/apicurio_serdes/_auth.py
@@ -1,0 +1,232 @@
+"""Authentication classes for Apicurio registry clients."""
+
+from __future__ import annotations
+
+import asyncio
+import threading
+import time
+from collections.abc import Callable, Generator
+from typing import AsyncGenerator
+from urllib.parse import urlparse, urlunparse
+
+import httpx
+
+from apicurio_serdes._errors import AuthenticationError
+
+__all__ = ["BearerAuth", "KeycloakAuth"]
+
+_REFRESH_THRESHOLD = 0.2  # refresh when < 20% of TTL remains
+
+
+class BearerAuth(httpx.Auth):
+    """Bearer token authentication for Apicurio registry clients.
+
+    Exactly one of *token* or *token_provider* must be supplied.
+
+    Args:
+        token: Static Bearer token string.
+        token_provider: Zero-argument callable that returns a token string.
+            Called on every request, so it can return fresh tokens (e.g.
+            GCP OIDC identity tokens retrieved via ``google-auth``).
+
+    Raises:
+        ValueError: If neither or both of *token* and *token_provider* are given.
+
+    Example:
+        ```python
+        # Static token
+        auth = BearerAuth(token="my-static-token")
+
+        # Dynamic token (GCP OIDC)
+        auth = BearerAuth(token_provider=lambda: get_google_id_token())
+
+        client = ApicurioRegistryClient(url="...", group_id="...", auth=auth)
+        ```
+    """
+
+    def __init__(
+        self,
+        token: str | None = None,
+        token_provider: Callable[[], str] | None = None,
+    ) -> None:
+        if (token is None) == (token_provider is None):
+            raise ValueError(
+                "BearerAuth requires exactly one of 'token' or 'token_provider'."
+            )
+        self._token = token
+        self._token_provider = token_provider
+
+    def _get_token(self) -> str:
+        if self._token_provider is not None:
+            return self._token_provider()
+        return self._token  # type: ignore[return-value]
+
+    def auth_flow(
+        self, request: httpx.Request
+    ) -> Generator[httpx.Request, httpx.Response, None]:
+        """Inject Authorization header; works for both sync and async clients."""
+        request.headers["Authorization"] = f"Bearer {self._get_token()}"
+        yield request
+
+
+class KeycloakAuth(httpx.Auth):
+    """OAuth2 client credentials auth against a Keycloak token endpoint.
+
+    Fetches a token on first use and automatically refreshes it when
+    less than 20% of its TTL remains (threshold-based refresh).
+
+    Implements separate ``sync_auth_flow`` / ``async_auth_flow`` so that
+    async callers never block the event loop.
+
+    Args:
+        token_url: Full URL of the Keycloak token endpoint, e.g.
+            ``"https://keycloak.example.com/realms/myrealm/protocol/openid-connect/token"``.
+        client_id: OAuth2 client ID.
+        client_secret: OAuth2 client secret.
+        scope: Optional OAuth2 scope string (e.g. ``"openid"``).
+
+    Raises:
+        AuthenticationError: If the token endpoint is unreachable or returns
+            a non-200 response.
+
+    Example:
+        ```python
+        auth = KeycloakAuth(
+            token_url="https://keycloak.example.com/realms/myrealm/protocol/openid-connect/token",
+            client_id="my-client",
+            client_secret="secret",
+        )
+        client = ApicurioRegistryClient(url="...", group_id="...", auth=auth)
+        ```
+    """
+
+    def __init__(
+        self,
+        token_url: str,
+        client_id: str,
+        client_secret: str,
+        scope: str | None = None,
+    ) -> None:
+        self._token_url = token_url
+        self._client_id = client_id
+        self._client_secret = client_secret
+        self._scope = scope
+
+        self._token: str = ""
+        self._expires_at: float = 0.0
+        self._expires_in: float = 0.0
+
+        self._sync_lock = threading.Lock()
+        self._async_lock: asyncio.Lock | None = None
+
+    def __repr__(self) -> str:
+        return (
+            f"KeycloakAuth(token_url={self._token_url!r}, "
+            f"client_id={self._client_id!r}, client_secret=***)"
+        )
+
+    # ── Shared helpers ──
+
+    def _is_expired(self) -> bool:
+        if not self._token:
+            return True
+        return self._expires_at < time.monotonic() + self._expires_in * _REFRESH_THRESHOLD
+
+    def _build_token_data(self) -> dict[str, str]:
+        data: dict[str, str] = {
+            "grant_type": "client_credentials",
+            "client_id": self._client_id,
+            "client_secret": self._client_secret,
+        }
+        if self._scope is not None:
+            data["scope"] = self._scope
+        return data
+
+    @staticmethod
+    def _safe_url(url: str) -> str:
+        """Strip userinfo from a URL to avoid leaking embedded credentials."""
+        parsed = urlparse(url)
+        return urlunparse(parsed._replace(netloc=parsed.hostname or ""))
+
+    def _parse_token_response(self, response: httpx.Response) -> None:
+        try:
+            response.raise_for_status()
+        except httpx.HTTPStatusError as exc:
+            # Limit error text to avoid leaking secrets from non-standard IdP responses
+            try:
+                error_detail = response.json().get("error", response.status_code)
+            except Exception:
+                error_detail = response.status_code
+            raise AuthenticationError(
+                f"Token endpoint returned {response.status_code}: {error_detail}"
+            ) from exc
+        try:
+            payload = response.json()
+            self._token = payload["access_token"]
+            self._expires_in = float(payload["expires_in"])
+        except (KeyError, TypeError, ValueError) as exc:
+            raise AuthenticationError(
+                f"Unexpected token endpoint response (missing access_token or expires_in): {exc}"
+            ) from exc
+        self._expires_at = time.monotonic() + self._expires_in
+
+    # ── Sync path ──
+
+    def _sync_fetch_token(self) -> None:
+        try:
+            with httpx.Client() as client:
+                response = client.post(
+                    self._token_url, data=self._build_token_data()
+                )
+        except httpx.TransportError as exc:
+            raise AuthenticationError(
+                f"Could not reach token endpoint {self._safe_url(self._token_url)}: {exc}"
+            ) from exc
+        self._parse_token_response(response)
+
+    def _sync_ensure_token(self) -> None:
+        if self._is_expired():
+            with self._sync_lock:
+                if self._is_expired():
+                    self._sync_fetch_token()
+
+    def sync_auth_flow(
+        self, request: httpx.Request
+    ) -> Generator[httpx.Request, httpx.Response, None]:
+        """Sync auth flow: ensure token, inject header."""
+        self._sync_ensure_token()
+        request.headers["Authorization"] = f"Bearer {self._token}"
+        yield request
+
+    # ── Async path ──
+
+    def _get_async_lock(self) -> asyncio.Lock:
+        if self._async_lock is None:
+            self._async_lock = asyncio.Lock()
+        return self._async_lock
+
+    async def _async_fetch_token(self) -> None:
+        try:
+            async with httpx.AsyncClient() as client:
+                response = await client.post(
+                    self._token_url, data=self._build_token_data()
+                )
+        except httpx.TransportError as exc:
+            raise AuthenticationError(
+                f"Could not reach token endpoint {self._safe_url(self._token_url)}: {exc}"
+            ) from exc
+        self._parse_token_response(response)
+
+    async def _async_ensure_token(self) -> None:
+        if self._is_expired():
+            async with self._get_async_lock():
+                if self._is_expired():
+                    await self._async_fetch_token()
+
+    async def async_auth_flow(
+        self, request: httpx.Request
+    ) -> AsyncGenerator[httpx.Request, httpx.Response]:
+        """Async auth flow: ensure token without blocking, inject header."""
+        await self._async_ensure_token()
+        request.headers["Authorization"] = f"Bearer {self._token}"
+        yield request

--- a/src/apicurio_serdes/_client.py
+++ b/src/apicurio_serdes/_client.py
@@ -28,6 +28,10 @@ class ApicurioRegistryClient(_RegistryClientBase):
              Example: ``"http://registry:8080/apis/registry/v3"``.
         group_id: Schema group identifier. Applied to every
                   schema lookup made by this client instance.
+        auth: Optional httpx authentication handler. Pass a
+              :class:`~apicurio_serdes.BearerAuth` or
+              :class:`~apicurio_serdes.KeycloakAuth` instance for
+              authenticated registries. Defaults to ``None`` (no auth).
 
     Raises:
         ValueError: If *url* or *group_id* is empty.
@@ -44,9 +48,11 @@ class ApicurioRegistryClient(_RegistryClientBase):
         ```
     """
 
-    def __init__(self, url: str, group_id: str) -> None:
+    def __init__(
+        self, url: str, group_id: str, auth: httpx.Auth | None = None
+    ) -> None:
         super().__init__(url, group_id)
-        self._http_client = httpx.Client(base_url=url)
+        self._http_client = httpx.Client(base_url=url, auth=auth)
         self._lock = threading.RLock()
 
     def get_schema(self, artifact_id: str) -> CachedSchema:

--- a/src/apicurio_serdes/_client.py
+++ b/src/apicurio_serdes/_client.py
@@ -48,9 +48,7 @@ class ApicurioRegistryClient(_RegistryClientBase):
         ```
     """
 
-    def __init__(
-        self, url: str, group_id: str, auth: httpx.Auth | None = None
-    ) -> None:
+    def __init__(self, url: str, group_id: str, auth: httpx.Auth | None = None) -> None:
         super().__init__(url, group_id)
         self._http_client = httpx.Client(base_url=url, auth=auth)
         self._lock = threading.RLock()

--- a/src/apicurio_serdes/_errors.py
+++ b/src/apicurio_serdes/_errors.py
@@ -138,7 +138,9 @@ class SchemaRegistrationError(Exception):
 class AuthenticationError(Exception):
     """Raised when authentication with the token endpoint fails.
 
-    Covers: token endpoint unreachable, non-200 response from token endpoint.
+    Covers: token endpoint unreachable, non-200 response, or a 200 response
+    with a malformed body (missing or empty ``access_token``, missing
+    ``expires_in``, or non-JSON).
 
     Args:
         message: Description of the authentication failure.

--- a/src/apicurio_serdes/_errors.py
+++ b/src/apicurio_serdes/_errors.py
@@ -135,6 +135,19 @@ class SchemaRegistrationError(Exception):
         self.__cause__ = cause
 
 
+class AuthenticationError(Exception):
+    """Raised when authentication with the token endpoint fails.
+
+    Covers: token endpoint unreachable, non-200 response from token endpoint.
+
+    Args:
+        message: Description of the authentication failure.
+    """
+
+    def __init__(self, message: str) -> None:
+        super().__init__(message)
+
+
 class RegistryConnectionError(Exception):
     """Raised when the Apicurio Registry is unreachable.
 

--- a/src/apicurio_serdes/_errors.py
+++ b/src/apicurio_serdes/_errors.py
@@ -139,8 +139,8 @@ class AuthenticationError(Exception):
     """Raised when authentication with the token endpoint fails.
 
     Covers: token endpoint unreachable, non-200 response, or a 200 response
-    with a malformed body (missing or empty ``access_token``, missing
-    ``expires_in``, or non-JSON).
+    with a malformed body (missing or empty ``access_token``, missing or
+    non-positive ``expires_in``, or non-JSON).
 
     Args:
         message: Description of the authentication failure.

--- a/tests/test_async_client.py
+++ b/tests/test_async_client.py
@@ -754,3 +754,41 @@ class TestRegisterSchemaAsync:
             assert (
                 sync_sig.parameters[name].default == async_sig.parameters[name].default
             ), f"Default mismatch for param '{name}'"
+
+
+# ── Auth wiring tests ──
+
+
+def test_async_client_auth_defaults_to_none() -> None:
+    """auth parameter defaults to None; existing tests unaffected."""
+    import inspect
+
+    params = inspect.signature(AsyncApicurioRegistryClient.__init__).parameters
+    assert "auth" in params
+    assert params["auth"].default is None
+
+
+@pytest.mark.asyncio
+async def test_async_client_accepts_bearer_auth(
+    mock_registry: respx.MockRouter,
+) -> None:
+    """AsyncApicurioRegistryClient accepts auth=BearerAuth and passes it to httpx."""
+    from httpx import Response
+
+    from apicurio_serdes._auth import BearerAuth
+
+    url = (
+        f"{REGISTRY_URL}/groups/{GROUP_ID}/artifacts/Auth/versions/latest/content"
+    )
+    route = mock_registry.get(url).mock(
+        return_value=Response(
+            200,
+            content=b'{"type":"record","name":"X","fields":[]}',
+            headers={"X-Registry-GlobalId": "1", "X-Registry-ContentId": "2"},
+        )
+    )
+    client = AsyncApicurioRegistryClient(
+        url=REGISTRY_URL, group_id=GROUP_ID, auth=BearerAuth(token="async-wire")
+    )
+    await client.get_schema("Auth")
+    assert route.calls[0].request.headers["authorization"] == "Bearer async-wire"

--- a/tests/test_async_client.py
+++ b/tests/test_async_client.py
@@ -777,9 +777,7 @@ async def test_async_client_accepts_bearer_auth(
 
     from apicurio_serdes._auth import BearerAuth
 
-    url = (
-        f"{REGISTRY_URL}/groups/{GROUP_ID}/artifacts/Auth/versions/latest/content"
-    )
+    url = f"{REGISTRY_URL}/groups/{GROUP_ID}/artifacts/Auth/versions/latest/content"
     route = mock_registry.get(url).mock(
         return_value=Response(
             200,

--- a/tests/test_auth.py
+++ b/tests/test_auth.py
@@ -169,25 +169,24 @@ class TestKeycloakAuthSync:
         with respx.mock() as router:
             router.post(TOKEN_URL).mock(return_value=Response(401, text="Unauthorized"))
             auth = self._auth()
-            with httpx.Client(auth=auth) as client:
-                with pytest.raises(AuthenticationError, match="401"):
-                    client.get(ARTIFACT_URL)
+            with httpx.Client(auth=auth) as client, pytest.raises(
+                AuthenticationError, match="401"
+            ):
+                client.get(ARTIFACT_URL)
 
     def test_token_endpoint_unreachable_raises_authentication_error(self) -> None:
         with respx.mock() as router:
             router.post(TOKEN_URL).mock(side_effect=httpx.ConnectError("refused"))
             auth = self._auth()
-            with httpx.Client(auth=auth) as client:
-                with pytest.raises(AuthenticationError):
-                    client.get(ARTIFACT_URL)
+            with httpx.Client(auth=auth) as client, pytest.raises(AuthenticationError):
+                client.get(ARTIFACT_URL)
 
     def test_token_endpoint_read_timeout_raises_authentication_error(self) -> None:
         with respx.mock() as router:
             router.post(TOKEN_URL).mock(side_effect=httpx.ReadTimeout("timed out"))
             auth = self._auth()
-            with httpx.Client(auth=auth) as client:
-                with pytest.raises(AuthenticationError):
-                    client.get(ARTIFACT_URL)
+            with httpx.Client(auth=auth) as client, pytest.raises(AuthenticationError):
+                client.get(ARTIFACT_URL)
 
     def test_scope_included_in_token_request(self) -> None:
         with respx.mock() as router:
@@ -338,7 +337,6 @@ class TestDoubleCheckedLocking:
         """Second _is_expired() inside the lock returns False → _sync_fetch_token skipped."""
         auth = self._auth()
         call_count = [0]
-        original = auth._is_expired
 
         def once_then_false() -> bool:
             call_count[0] += 1
@@ -386,9 +384,10 @@ class TestKeycloakAuthSecurity:
                 return_value=Response(200, json={"expires_in": 300})
             )
             auth = self._auth()
-            with httpx.Client(auth=auth) as client:
-                with pytest.raises(AuthenticationError, match="access_token"):
-                    client.get(ARTIFACT_URL)
+            with httpx.Client(auth=auth) as client, pytest.raises(
+                AuthenticationError, match="access_token"
+            ):
+                client.get(ARTIFACT_URL)
 
     def test_200_with_empty_access_token_raises_authentication_error(self) -> None:
         with respx.mock() as router:
@@ -396,9 +395,10 @@ class TestKeycloakAuthSecurity:
                 return_value=Response(200, json={"access_token": "", "expires_in": 300})
             )
             auth = self._auth()
-            with httpx.Client(auth=auth) as client:
-                with pytest.raises(AuthenticationError, match="access_token"):
-                    client.get(ARTIFACT_URL)
+            with httpx.Client(auth=auth) as client, pytest.raises(
+                AuthenticationError, match="access_token"
+            ):
+                client.get(ARTIFACT_URL)
         assert auth._token == ""
 
     def test_200_with_null_access_token_raises_authentication_error(self) -> None:
@@ -409,9 +409,10 @@ class TestKeycloakAuthSecurity:
                 )
             )
             auth = self._auth()
-            with httpx.Client(auth=auth) as client:
-                with pytest.raises(AuthenticationError, match="access_token"):
-                    client.get(ARTIFACT_URL)
+            with httpx.Client(auth=auth) as client, pytest.raises(
+                AuthenticationError, match="access_token"
+            ):
+                client.get(ARTIFACT_URL)
         assert auth._token == ""
 
     def test_200_with_missing_expires_in_raises_authentication_error(self) -> None:
@@ -420,9 +421,10 @@ class TestKeycloakAuthSecurity:
                 return_value=Response(200, json={"access_token": "tok"})
             )
             auth = self._auth()
-            with httpx.Client(auth=auth) as client:
-                with pytest.raises(AuthenticationError, match="expires_in"):
-                    client.get(ARTIFACT_URL)
+            with httpx.Client(auth=auth) as client, pytest.raises(
+                AuthenticationError, match="expires_in"
+            ):
+                client.get(ARTIFACT_URL)
         # Token state must not be partially mutated on failure
         assert auth._token == ""
         assert auth._expires_at == 0.0
@@ -438,9 +440,10 @@ class TestKeycloakAuthSecurity:
                 )
             )
             auth = self._auth()
-            with httpx.Client(auth=auth) as client:
-                with pytest.raises(AuthenticationError, match="expires_in"):
-                    client.get(ARTIFACT_URL)
+            with httpx.Client(auth=auth) as client, pytest.raises(
+                AuthenticationError, match="expires_in"
+            ):
+                client.get(ARTIFACT_URL)
         # Token state must not be mutated on failure
         assert auth._token == ""
         assert auth._expires_at == 0.0
@@ -449,18 +452,18 @@ class TestKeycloakAuthSecurity:
         with respx.mock() as router:
             router.post(TOKEN_URL).mock(return_value=Response(200, text="not json"))
             auth = self._auth()
-            with httpx.Client(auth=auth) as client:
-                with pytest.raises(AuthenticationError):
-                    client.get(ARTIFACT_URL)
+            with httpx.Client(auth=auth) as client, pytest.raises(AuthenticationError):
+                client.get(ARTIFACT_URL)
 
     def test_401_error_message_does_not_include_full_response_body(self) -> None:
         sensitive_body = '{"error":"invalid_client","secret_echo":"super-secret"}'
         with respx.mock() as router:
             router.post(TOKEN_URL).mock(return_value=Response(401, text=sensitive_body))
             auth = self._auth()
-            with httpx.Client(auth=auth) as client:
-                with pytest.raises(AuthenticationError) as exc_info:
-                    client.get(ARTIFACT_URL)
+            with httpx.Client(auth=auth) as client, pytest.raises(
+                AuthenticationError
+            ) as exc_info:
+                client.get(ARTIFACT_URL)
             # Full body must not appear in the error message
             assert sensitive_body not in str(exc_info.value)
 
@@ -480,9 +483,10 @@ class TestKeycloakAuthSecurity:
         )
         with respx.mock() as router:
             router.post(url_with_creds).mock(side_effect=httpx.ConnectError("refused"))
-            with httpx.Client(auth=auth) as client:
-                with pytest.raises(AuthenticationError) as exc_info:
-                    client.get(ARTIFACT_URL)
+            with httpx.Client(auth=auth) as client, pytest.raises(
+                AuthenticationError
+            ) as exc_info:
+                client.get(ARTIFACT_URL)
         assert "pass" not in str(exc_info.value)
         assert "user" not in str(exc_info.value)
 
@@ -495,8 +499,9 @@ class TestKeycloakAuthSecurity:
         )
         with respx.mock() as router:
             router.post(url_with_creds).mock(side_effect=httpx.ConnectError("refused"))
-            with httpx.Client(auth=auth) as client:
-                with pytest.raises(AuthenticationError) as exc_info:
-                    client.get(ARTIFACT_URL)
+            with httpx.Client(auth=auth) as client, pytest.raises(
+                AuthenticationError
+            ) as exc_info:
+                client.get(ARTIFACT_URL)
         assert "pass" not in str(exc_info.value)
         assert ":8443" in str(exc_info.value)

--- a/tests/test_auth.py
+++ b/tests/test_auth.py
@@ -411,3 +411,18 @@ class TestKeycloakAuthSecurity:
                     client.get(ARTIFACT_URL)
         assert "pass" not in str(exc_info.value)
         assert "user" not in str(exc_info.value)
+
+    def test_transport_error_message_preserves_port(self) -> None:
+        url_with_creds = "https://user:pass@keycloak.example.com:8443/realms/r/protocol/openid-connect/token"
+        auth = KeycloakAuth(
+            token_url=url_with_creds,
+            client_id="client",
+            client_secret="secret",
+        )
+        with respx.mock() as router:
+            router.post(url_with_creds).mock(side_effect=httpx.ConnectError("refused"))
+            with httpx.Client(auth=auth) as client:
+                with pytest.raises(AuthenticationError) as exc_info:
+                    client.get(ARTIFACT_URL)
+        assert "pass" not in str(exc_info.value)
+        assert ":8443" in str(exc_info.value)

--- a/tests/test_auth.py
+++ b/tests/test_auth.py
@@ -46,9 +46,7 @@ class TestBearerAuth:
             route = _mock_registry(router)
             with httpx.Client(auth=BearerAuth(token="my-token")) as client:
                 client.get(ARTIFACT_URL)
-            assert (
-                route.calls[0].request.headers["authorization"] == "Bearer my-token"
-            )
+            assert route.calls[0].request.headers["authorization"] == "Bearer my-token"
 
     def test_dynamic_token_calls_provider(self) -> None:
         provider = MagicMock(return_value="dyn-token")
@@ -56,9 +54,7 @@ class TestBearerAuth:
             route = _mock_registry(router)
             with httpx.Client(auth=BearerAuth(token_provider=provider)) as client:
                 client.get(ARTIFACT_URL)
-            assert (
-                route.calls[0].request.headers["authorization"] == "Bearer dyn-token"
-            )
+            assert route.calls[0].request.headers["authorization"] == "Bearer dyn-token"
 
     def test_provider_called_on_each_request(self) -> None:
         call_count = 0
@@ -94,13 +90,9 @@ class TestBearerAuth:
     async def test_works_with_async_httpx_client(self) -> None:
         with respx.mock() as router:
             route = _mock_registry(router)
-            async with httpx.AsyncClient(
-                auth=BearerAuth(token="async-tok")
-            ) as client:
+            async with httpx.AsyncClient(auth=BearerAuth(token="async-tok")) as client:
                 await client.get(ARTIFACT_URL)
-            assert (
-                route.calls[0].request.headers["authorization"] == "Bearer async-tok"
-            )
+            assert route.calls[0].request.headers["authorization"] == "Bearer async-tok"
 
 
 # ── KeycloakAuth sync ──
@@ -191,9 +183,7 @@ class TestKeycloakAuthSync:
 
     def test_scope_included_in_token_request(self) -> None:
         with respx.mock() as router:
-            token_route = router.post(TOKEN_URL).mock(
-                return_value=_token_response()
-            )
+            token_route = router.post(TOKEN_URL).mock(return_value=_token_response())
             _mock_registry(router)
             auth = self._auth(scope="openid")
             with httpx.Client(auth=auth) as client:
@@ -203,9 +193,7 @@ class TestKeycloakAuthSync:
 
     def test_no_scope_omits_scope_from_request(self) -> None:
         with respx.mock() as router:
-            token_route = router.post(TOKEN_URL).mock(
-                return_value=_token_response()
-            )
+            token_route = router.post(TOKEN_URL).mock(return_value=_token_response())
             _mock_registry(router)
             auth = self._auth()
             with httpx.Client(auth=auth) as client:
@@ -385,9 +373,7 @@ class TestKeycloakAuthSecurity:
 
     def test_200_with_non_json_body_raises_authentication_error(self) -> None:
         with respx.mock() as router:
-            router.post(TOKEN_URL).mock(
-                return_value=Response(200, text="not json")
-            )
+            router.post(TOKEN_URL).mock(return_value=Response(200, text="not json"))
             auth = self._auth()
             with httpx.Client(auth=auth) as client:
                 with pytest.raises(AuthenticationError):
@@ -396,9 +382,7 @@ class TestKeycloakAuthSecurity:
     def test_401_error_message_does_not_include_full_response_body(self) -> None:
         sensitive_body = '{"error":"invalid_client","secret_echo":"super-secret"}'
         with respx.mock() as router:
-            router.post(TOKEN_URL).mock(
-                return_value=Response(401, text=sensitive_body)
-            )
+            router.post(TOKEN_URL).mock(return_value=Response(401, text=sensitive_body))
             auth = self._auth()
             with httpx.Client(auth=auth) as client:
                 with pytest.raises(AuthenticationError) as exc_info:
@@ -421,9 +405,7 @@ class TestKeycloakAuthSecurity:
             client_secret="secret",
         )
         with respx.mock() as router:
-            router.post(url_with_creds).mock(
-                side_effect=httpx.ConnectError("refused")
-            )
+            router.post(url_with_creds).mock(side_effect=httpx.ConnectError("refused"))
             with httpx.Client(auth=auth) as client:
                 with pytest.raises(AuthenticationError) as exc_info:
                     client.get(ARTIFACT_URL)

--- a/tests/test_auth.py
+++ b/tests/test_auth.py
@@ -169,8 +169,9 @@ class TestKeycloakAuthSync:
         with respx.mock() as router:
             router.post(TOKEN_URL).mock(return_value=Response(401, text="Unauthorized"))
             auth = self._auth()
-            with httpx.Client(auth=auth) as client, pytest.raises(
-                AuthenticationError, match="401"
+            with (
+                httpx.Client(auth=auth) as client,
+                pytest.raises(AuthenticationError, match="401"),
             ):
                 client.get(ARTIFACT_URL)
 
@@ -384,8 +385,9 @@ class TestKeycloakAuthSecurity:
                 return_value=Response(200, json={"expires_in": 300})
             )
             auth = self._auth()
-            with httpx.Client(auth=auth) as client, pytest.raises(
-                AuthenticationError, match="access_token"
+            with (
+                httpx.Client(auth=auth) as client,
+                pytest.raises(AuthenticationError, match="access_token"),
             ):
                 client.get(ARTIFACT_URL)
 
@@ -395,8 +397,9 @@ class TestKeycloakAuthSecurity:
                 return_value=Response(200, json={"access_token": "", "expires_in": 300})
             )
             auth = self._auth()
-            with httpx.Client(auth=auth) as client, pytest.raises(
-                AuthenticationError, match="access_token"
+            with (
+                httpx.Client(auth=auth) as client,
+                pytest.raises(AuthenticationError, match="access_token"),
             ):
                 client.get(ARTIFACT_URL)
         assert auth._token == ""
@@ -409,8 +412,9 @@ class TestKeycloakAuthSecurity:
                 )
             )
             auth = self._auth()
-            with httpx.Client(auth=auth) as client, pytest.raises(
-                AuthenticationError, match="access_token"
+            with (
+                httpx.Client(auth=auth) as client,
+                pytest.raises(AuthenticationError, match="access_token"),
             ):
                 client.get(ARTIFACT_URL)
         assert auth._token == ""
@@ -421,8 +425,9 @@ class TestKeycloakAuthSecurity:
                 return_value=Response(200, json={"access_token": "tok"})
             )
             auth = self._auth()
-            with httpx.Client(auth=auth) as client, pytest.raises(
-                AuthenticationError, match="expires_in"
+            with (
+                httpx.Client(auth=auth) as client,
+                pytest.raises(AuthenticationError, match="expires_in"),
             ):
                 client.get(ARTIFACT_URL)
         # Token state must not be partially mutated on failure
@@ -440,8 +445,9 @@ class TestKeycloakAuthSecurity:
                 )
             )
             auth = self._auth()
-            with httpx.Client(auth=auth) as client, pytest.raises(
-                AuthenticationError, match="expires_in"
+            with (
+                httpx.Client(auth=auth) as client,
+                pytest.raises(AuthenticationError, match="expires_in"),
             ):
                 client.get(ARTIFACT_URL)
         # Token state must not be mutated on failure
@@ -460,9 +466,10 @@ class TestKeycloakAuthSecurity:
         with respx.mock() as router:
             router.post(TOKEN_URL).mock(return_value=Response(401, text=sensitive_body))
             auth = self._auth()
-            with httpx.Client(auth=auth) as client, pytest.raises(
-                AuthenticationError
-            ) as exc_info:
+            with (
+                httpx.Client(auth=auth) as client,
+                pytest.raises(AuthenticationError) as exc_info,
+            ):
                 client.get(ARTIFACT_URL)
             # Full body must not appear in the error message
             assert sensitive_body not in str(exc_info.value)
@@ -483,9 +490,10 @@ class TestKeycloakAuthSecurity:
         )
         with respx.mock() as router:
             router.post(url_with_creds).mock(side_effect=httpx.ConnectError("refused"))
-            with httpx.Client(auth=auth) as client, pytest.raises(
-                AuthenticationError
-            ) as exc_info:
+            with (
+                httpx.Client(auth=auth) as client,
+                pytest.raises(AuthenticationError) as exc_info,
+            ):
                 client.get(ARTIFACT_URL)
         assert "pass" not in str(exc_info.value)
         assert "user" not in str(exc_info.value)
@@ -499,9 +507,10 @@ class TestKeycloakAuthSecurity:
         )
         with respx.mock() as router:
             router.post(url_with_creds).mock(side_effect=httpx.ConnectError("refused"))
-            with httpx.Client(auth=auth) as client, pytest.raises(
-                AuthenticationError
-            ) as exc_info:
+            with (
+                httpx.Client(auth=auth) as client,
+                pytest.raises(AuthenticationError) as exc_info,
+            ):
                 client.get(ARTIFACT_URL)
         assert "pass" not in str(exc_info.value)
         assert ":8443" in str(exc_info.value)

--- a/tests/test_auth.py
+++ b/tests/test_auth.py
@@ -1,0 +1,431 @@
+"""Tests for authentication classes: BearerAuth and KeycloakAuth."""
+
+from __future__ import annotations
+
+import time
+from unittest.mock import MagicMock
+
+import httpx
+import pytest
+import respx
+from httpx import Response
+
+from apicurio_serdes._auth import BearerAuth, KeycloakAuth
+from apicurio_serdes._errors import AuthenticationError
+
+TOKEN_URL = "https://keycloak.example.com/realms/myrealm/protocol/openid-connect/token"
+REGISTRY_URL = "http://registry:8080/apis/registry/v3"
+ARTIFACT_URL = f"{REGISTRY_URL}/groups/g/artifacts/a/versions/latest/content"
+
+
+# ── Helpers ──
+
+
+def _mock_registry(router: respx.MockRouter) -> respx.Route:
+    return router.get(ARTIFACT_URL).mock(
+        return_value=Response(
+            200,
+            content=b'{"type":"record","name":"X","fields":[]}',
+            headers={"X-Registry-GlobalId": "1", "X-Registry-ContentId": "2"},
+        )
+    )
+
+
+def _token_response(token: str = "tok", expires_in: int = 300) -> Response:
+    return Response(200, json={"access_token": token, "expires_in": expires_in})
+
+
+# ── BearerAuth ──
+
+
+class TestBearerAuth:
+    """BearerAuth injects a static or dynamic Bearer token."""
+
+    def test_static_token_injects_header(self) -> None:
+        with respx.mock() as router:
+            route = _mock_registry(router)
+            with httpx.Client(auth=BearerAuth(token="my-token")) as client:
+                client.get(ARTIFACT_URL)
+            assert (
+                route.calls[0].request.headers["authorization"] == "Bearer my-token"
+            )
+
+    def test_dynamic_token_calls_provider(self) -> None:
+        provider = MagicMock(return_value="dyn-token")
+        with respx.mock() as router:
+            route = _mock_registry(router)
+            with httpx.Client(auth=BearerAuth(token_provider=provider)) as client:
+                client.get(ARTIFACT_URL)
+            assert (
+                route.calls[0].request.headers["authorization"] == "Bearer dyn-token"
+            )
+
+    def test_provider_called_on_each_request(self) -> None:
+        call_count = 0
+
+        def provider() -> str:
+            nonlocal call_count
+            call_count += 1
+            return f"token-{call_count}"
+
+        with respx.mock() as router:
+            _mock_registry(router)
+            with httpx.Client(auth=BearerAuth(token_provider=provider)) as client:
+                client.get(ARTIFACT_URL)
+                client.get(ARTIFACT_URL)
+        assert call_count == 2
+
+    def test_no_args_raises_value_error(self) -> None:
+        with pytest.raises(ValueError, match="exactly one"):
+            BearerAuth()
+
+    def test_both_args_raises_value_error(self) -> None:
+        with pytest.raises(ValueError, match="exactly one"):
+            BearerAuth(token="t", token_provider=lambda: "t")
+
+    def test_works_with_sync_httpx_client(self) -> None:
+        with respx.mock() as router:
+            route = _mock_registry(router)
+            with httpx.Client(auth=BearerAuth(token="sync-tok")) as client:
+                client.get(ARTIFACT_URL)
+            assert "Bearer sync-tok" in route.calls[0].request.headers["authorization"]
+
+    @pytest.mark.asyncio
+    async def test_works_with_async_httpx_client(self) -> None:
+        with respx.mock() as router:
+            route = _mock_registry(router)
+            async with httpx.AsyncClient(
+                auth=BearerAuth(token="async-tok")
+            ) as client:
+                await client.get(ARTIFACT_URL)
+            assert (
+                route.calls[0].request.headers["authorization"] == "Bearer async-tok"
+            )
+
+
+# ── KeycloakAuth sync ──
+
+
+class TestKeycloakAuthSync:
+    """KeycloakAuth fetches and auto-refreshes tokens via client credentials (sync)."""
+
+    def _auth(self, scope: str | None = None) -> KeycloakAuth:
+        return KeycloakAuth(
+            token_url=TOKEN_URL,
+            client_id="client",
+            client_secret="secret",
+            scope=scope,
+        )
+
+    def test_happy_path_injects_token(self) -> None:
+        with respx.mock() as router:
+            router.post(TOKEN_URL).mock(return_value=_token_response("tok1"))
+            route = _mock_registry(router)
+            auth = self._auth()
+            with httpx.Client(auth=auth) as client:
+                client.get(ARTIFACT_URL)
+            assert route.calls[0].request.headers["authorization"] == "Bearer tok1"
+
+    def test_token_reused_on_second_request(self) -> None:
+        with respx.mock() as router:
+            token_route = router.post(TOKEN_URL).mock(
+                return_value=_token_response("tok1")
+            )
+            _mock_registry(router)
+            auth = self._auth()
+            with httpx.Client(auth=auth) as client:
+                client.get(ARTIFACT_URL)
+                client.get(ARTIFACT_URL)
+            assert token_route.call_count == 1
+
+    def test_auto_refresh_when_expired(self) -> None:
+        with respx.mock() as router:
+            token_route = router.post(TOKEN_URL).mock(
+                side_effect=[
+                    _token_response("tok1"),
+                    _token_response("tok2"),
+                ]
+            )
+            _mock_registry(router)
+            auth = self._auth()
+            with httpx.Client(auth=auth) as client:
+                client.get(ARTIFACT_URL)
+                # Force expiry
+                auth._expires_at = time.monotonic() - 1
+                client.get(ARTIFACT_URL)
+            assert token_route.call_count == 2
+
+    def test_threshold_refresh_before_expiry(self) -> None:
+        with respx.mock() as router:
+            token_route = router.post(TOKEN_URL).mock(
+                side_effect=[
+                    _token_response("tok1", expires_in=100),
+                    _token_response("tok2", expires_in=100),
+                ]
+            )
+            _mock_registry(router)
+            auth = self._auth()
+            with httpx.Client(auth=auth) as client:
+                client.get(ARTIFACT_URL)
+                # Within 20% threshold (< 20s remaining of 100s)
+                auth._expires_at = time.monotonic() + 10
+                auth._expires_in = 100
+                client.get(ARTIFACT_URL)
+            assert token_route.call_count == 2
+
+    def test_token_endpoint_401_raises_authentication_error(self) -> None:
+        with respx.mock() as router:
+            router.post(TOKEN_URL).mock(return_value=Response(401, text="Unauthorized"))
+            auth = self._auth()
+            with httpx.Client(auth=auth) as client:
+                with pytest.raises(AuthenticationError, match="401"):
+                    client.get(ARTIFACT_URL)
+
+    def test_token_endpoint_unreachable_raises_authentication_error(self) -> None:
+        with respx.mock() as router:
+            router.post(TOKEN_URL).mock(side_effect=httpx.ConnectError("refused"))
+            auth = self._auth()
+            with httpx.Client(auth=auth) as client:
+                with pytest.raises(AuthenticationError):
+                    client.get(ARTIFACT_URL)
+
+    def test_scope_included_in_token_request(self) -> None:
+        with respx.mock() as router:
+            token_route = router.post(TOKEN_URL).mock(
+                return_value=_token_response()
+            )
+            _mock_registry(router)
+            auth = self._auth(scope="openid")
+            with httpx.Client(auth=auth) as client:
+                client.get(ARTIFACT_URL)
+            body = token_route.calls[0].request.content.decode()
+            assert "scope=openid" in body
+
+    def test_no_scope_omits_scope_from_request(self) -> None:
+        with respx.mock() as router:
+            token_route = router.post(TOKEN_URL).mock(
+                return_value=_token_response()
+            )
+            _mock_registry(router)
+            auth = self._auth()
+            with httpx.Client(auth=auth) as client:
+                client.get(ARTIFACT_URL)
+            body = token_route.calls[0].request.content.decode()
+            assert "scope" not in body
+
+
+# ── KeycloakAuth async ──
+
+
+class TestKeycloakAuthAsync:
+    """KeycloakAuth fetches and auto-refreshes tokens via client credentials (async)."""
+
+    def _auth(self, scope: str | None = None) -> KeycloakAuth:
+        return KeycloakAuth(
+            token_url=TOKEN_URL,
+            client_id="client",
+            client_secret="secret",
+            scope=scope,
+        )
+
+    @pytest.mark.asyncio
+    async def test_happy_path_injects_token(self) -> None:
+        with respx.mock() as router:
+            router.post(TOKEN_URL).mock(return_value=_token_response("atok1"))
+            route = _mock_registry(router)
+            auth = self._auth()
+            async with httpx.AsyncClient(auth=auth) as client:
+                await client.get(ARTIFACT_URL)
+            assert route.calls[0].request.headers["authorization"] == "Bearer atok1"
+
+    @pytest.mark.asyncio
+    async def test_token_reused_on_second_request(self) -> None:
+        with respx.mock() as router:
+            token_route = router.post(TOKEN_URL).mock(
+                return_value=_token_response("atok1")
+            )
+            _mock_registry(router)
+            auth = self._auth()
+            async with httpx.AsyncClient(auth=auth) as client:
+                await client.get(ARTIFACT_URL)
+                await client.get(ARTIFACT_URL)
+            assert token_route.call_count == 1
+
+    @pytest.mark.asyncio
+    async def test_auto_refresh_when_expired(self) -> None:
+        with respx.mock() as router:
+            token_route = router.post(TOKEN_URL).mock(
+                side_effect=[
+                    _token_response("atok1"),
+                    _token_response("atok2"),
+                ]
+            )
+            _mock_registry(router)
+            auth = self._auth()
+            async with httpx.AsyncClient(auth=auth) as client:
+                await client.get(ARTIFACT_URL)
+                auth._expires_at = time.monotonic() - 1
+                await client.get(ARTIFACT_URL)
+            assert token_route.call_count == 2
+
+    @pytest.mark.asyncio
+    async def test_threshold_refresh_before_expiry(self) -> None:
+        with respx.mock() as router:
+            token_route = router.post(TOKEN_URL).mock(
+                side_effect=[
+                    _token_response("atok1", expires_in=100),
+                    _token_response("atok2", expires_in=100),
+                ]
+            )
+            _mock_registry(router)
+            auth = self._auth()
+            async with httpx.AsyncClient(auth=auth) as client:
+                await client.get(ARTIFACT_URL)
+                auth._expires_at = time.monotonic() + 10
+                auth._expires_in = 100
+                await client.get(ARTIFACT_URL)
+            assert token_route.call_count == 2
+
+    @pytest.mark.asyncio
+    async def test_token_endpoint_401_raises_authentication_error(self) -> None:
+        with respx.mock() as router:
+            router.post(TOKEN_URL).mock(return_value=Response(401, text="Unauthorized"))
+            auth = self._auth()
+            async with httpx.AsyncClient(auth=auth) as client:
+                with pytest.raises(AuthenticationError, match="401"):
+                    await client.get(ARTIFACT_URL)
+
+    @pytest.mark.asyncio
+    async def test_token_endpoint_unreachable_raises_authentication_error(
+        self,
+    ) -> None:
+        with respx.mock() as router:
+            router.post(TOKEN_URL).mock(side_effect=httpx.ConnectError("refused"))
+            auth = self._auth()
+            async with httpx.AsyncClient(auth=auth) as client:
+                with pytest.raises(AuthenticationError):
+                    await client.get(ARTIFACT_URL)
+
+    def test_lazy_lock_usable_from_inside_event_loop(self) -> None:
+        """KeycloakAuth created outside event loop works fine when used async."""
+        # Object is created here (outside any event loop)
+        auth = self._auth()
+        # Lock should be None until first async use
+        assert auth._async_lock is None
+
+
+# ── Double-checked locking coverage ──
+
+
+class TestDoubleCheckedLocking:
+    """Cover the second-check-is-False branch in sync and async ensure_token."""
+
+    def _auth(self) -> KeycloakAuth:
+        return KeycloakAuth(
+            token_url=TOKEN_URL,
+            client_id="client",
+            client_secret="secret",
+        )
+
+    def test_sync_second_check_skips_fetch_when_token_refreshed(self) -> None:
+        """Second _is_expired() inside the lock returns False → _sync_fetch_token skipped."""
+        auth = self._auth()
+        call_count = [0]
+        original = auth._is_expired
+
+        def once_then_false() -> bool:
+            call_count[0] += 1
+            # First call (outer): expired; second call (inner lock): already refreshed
+            return call_count[0] == 1
+
+        auth._is_expired = once_then_false  # type: ignore[method-assign]
+        # No HTTP mock needed — fetch should NOT be called
+        auth._sync_ensure_token()
+        assert call_count[0] == 2
+
+    @pytest.mark.asyncio
+    async def test_async_second_check_skips_fetch_when_token_refreshed(
+        self,
+    ) -> None:
+        """Second _is_expired() inside async lock returns False → _async_fetch_token skipped."""
+        auth = self._auth()
+        call_count = [0]
+
+        def once_then_false() -> bool:
+            call_count[0] += 1
+            return call_count[0] == 1
+
+        auth._is_expired = once_then_false  # type: ignore[method-assign]
+        await auth._async_ensure_token()
+        assert call_count[0] == 2
+
+
+# ── Security hardening tests ──
+
+
+class TestKeycloakAuthSecurity:
+    """Cover security hardening: malformed responses, repr masking, URL sanitisation."""
+
+    def _auth(self) -> KeycloakAuth:
+        return KeycloakAuth(
+            token_url=TOKEN_URL,
+            client_id="client",
+            client_secret="super-secret",
+        )
+
+    def test_200_with_missing_access_token_raises_authentication_error(self) -> None:
+        with respx.mock() as router:
+            router.post(TOKEN_URL).mock(
+                return_value=Response(200, json={"expires_in": 300})
+            )
+            auth = self._auth()
+            with httpx.Client(auth=auth) as client:
+                with pytest.raises(AuthenticationError, match="access_token"):
+                    client.get(ARTIFACT_URL)
+
+    def test_200_with_non_json_body_raises_authentication_error(self) -> None:
+        with respx.mock() as router:
+            router.post(TOKEN_URL).mock(
+                return_value=Response(200, text="not json")
+            )
+            auth = self._auth()
+            with httpx.Client(auth=auth) as client:
+                with pytest.raises(AuthenticationError):
+                    client.get(ARTIFACT_URL)
+
+    def test_401_error_message_does_not_include_full_response_body(self) -> None:
+        sensitive_body = '{"error":"invalid_client","secret_echo":"super-secret"}'
+        with respx.mock() as router:
+            router.post(TOKEN_URL).mock(
+                return_value=Response(401, text=sensitive_body)
+            )
+            auth = self._auth()
+            with httpx.Client(auth=auth) as client:
+                with pytest.raises(AuthenticationError) as exc_info:
+                    client.get(ARTIFACT_URL)
+            # Full body must not appear in the error message
+            assert sensitive_body not in str(exc_info.value)
+
+    def test_repr_masks_client_secret(self) -> None:
+        auth = self._auth()
+        r = repr(auth)
+        assert "super-secret" not in r
+        assert "***" in r
+        assert "client_id='client'" in r
+
+    def test_transport_error_message_strips_embedded_credentials(self) -> None:
+        url_with_creds = "https://user:pass@keycloak.example.com/realms/r/protocol/openid-connect/token"
+        auth = KeycloakAuth(
+            token_url=url_with_creds,
+            client_id="client",
+            client_secret="secret",
+        )
+        with respx.mock() as router:
+            router.post(url_with_creds).mock(
+                side_effect=httpx.ConnectError("refused")
+            )
+            with httpx.Client(auth=auth) as client:
+                with pytest.raises(AuthenticationError) as exc_info:
+                    client.get(ARTIFACT_URL)
+        assert "pass" not in str(exc_info.value)
+        assert "user" not in str(exc_info.value)

--- a/tests/test_auth.py
+++ b/tests/test_auth.py
@@ -427,6 +427,24 @@ class TestKeycloakAuthSecurity:
         assert auth._token == ""
         assert auth._expires_at == 0.0
 
+    @pytest.mark.parametrize("expires_in", [0, -1, -300])
+    def test_200_with_non_positive_expires_in_raises_authentication_error(
+        self, expires_in: int
+    ) -> None:
+        with respx.mock() as router:
+            router.post(TOKEN_URL).mock(
+                return_value=Response(
+                    200, json={"access_token": "tok", "expires_in": expires_in}
+                )
+            )
+            auth = self._auth()
+            with httpx.Client(auth=auth) as client:
+                with pytest.raises(AuthenticationError, match="expires_in"):
+                    client.get(ARTIFACT_URL)
+        # Token state must not be mutated on failure
+        assert auth._token == ""
+        assert auth._expires_at == 0.0
+
     def test_200_with_non_json_body_raises_authentication_error(self) -> None:
         with respx.mock() as router:
             router.post(TOKEN_URL).mock(return_value=Response(200, text="not json"))

--- a/tests/test_auth.py
+++ b/tests/test_auth.py
@@ -404,7 +404,9 @@ class TestKeycloakAuthSecurity:
     def test_200_with_null_access_token_raises_authentication_error(self) -> None:
         with respx.mock() as router:
             router.post(TOKEN_URL).mock(
-                return_value=Response(200, json={"access_token": None, "expires_in": 300})
+                return_value=Response(
+                    200, json={"access_token": None, "expires_in": 300}
+                )
             )
             auth = self._auth()
             with httpx.Client(auth=auth) as client:

--- a/tests/test_auth.py
+++ b/tests/test_auth.py
@@ -181,6 +181,14 @@ class TestKeycloakAuthSync:
                 with pytest.raises(AuthenticationError):
                     client.get(ARTIFACT_URL)
 
+    def test_token_endpoint_read_timeout_raises_authentication_error(self) -> None:
+        with respx.mock() as router:
+            router.post(TOKEN_URL).mock(side_effect=httpx.ReadTimeout("timed out"))
+            auth = self._auth()
+            with httpx.Client(auth=auth) as client:
+                with pytest.raises(AuthenticationError):
+                    client.get(ARTIFACT_URL)
+
     def test_scope_included_in_token_request(self) -> None:
         with respx.mock() as router:
             token_route = router.post(TOKEN_URL).mock(return_value=_token_response())
@@ -294,6 +302,17 @@ class TestKeycloakAuthAsync:
                 with pytest.raises(AuthenticationError):
                     await client.get(ARTIFACT_URL)
 
+    @pytest.mark.asyncio
+    async def test_token_endpoint_read_timeout_raises_authentication_error(
+        self,
+    ) -> None:
+        with respx.mock() as router:
+            router.post(TOKEN_URL).mock(side_effect=httpx.ReadTimeout("timed out"))
+            auth = self._auth()
+            async with httpx.AsyncClient(auth=auth) as client:
+                with pytest.raises(AuthenticationError):
+                    await client.get(ARTIFACT_URL)
+
     def test_lazy_lock_usable_from_inside_event_loop(self) -> None:
         """KeycloakAuth created outside event loop works fine when used async."""
         # Object is created here (outside any event loop)
@@ -370,6 +389,28 @@ class TestKeycloakAuthSecurity:
             with httpx.Client(auth=auth) as client:
                 with pytest.raises(AuthenticationError, match="access_token"):
                     client.get(ARTIFACT_URL)
+
+    def test_200_with_empty_access_token_raises_authentication_error(self) -> None:
+        with respx.mock() as router:
+            router.post(TOKEN_URL).mock(
+                return_value=Response(200, json={"access_token": "", "expires_in": 300})
+            )
+            auth = self._auth()
+            with httpx.Client(auth=auth) as client:
+                with pytest.raises(AuthenticationError, match="access_token"):
+                    client.get(ARTIFACT_URL)
+        assert auth._token == ""
+
+    def test_200_with_null_access_token_raises_authentication_error(self) -> None:
+        with respx.mock() as router:
+            router.post(TOKEN_URL).mock(
+                return_value=Response(200, json={"access_token": None, "expires_in": 300})
+            )
+            auth = self._auth()
+            with httpx.Client(auth=auth) as client:
+                with pytest.raises(AuthenticationError, match="access_token"):
+                    client.get(ARTIFACT_URL)
+        assert auth._token == ""
 
     def test_200_with_missing_expires_in_raises_authentication_error(self) -> None:
         with respx.mock() as router:

--- a/tests/test_auth.py
+++ b/tests/test_auth.py
@@ -371,6 +371,19 @@ class TestKeycloakAuthSecurity:
                 with pytest.raises(AuthenticationError, match="access_token"):
                     client.get(ARTIFACT_URL)
 
+    def test_200_with_missing_expires_in_raises_authentication_error(self) -> None:
+        with respx.mock() as router:
+            router.post(TOKEN_URL).mock(
+                return_value=Response(200, json={"access_token": "tok"})
+            )
+            auth = self._auth()
+            with httpx.Client(auth=auth) as client:
+                with pytest.raises(AuthenticationError, match="expires_in"):
+                    client.get(ARTIFACT_URL)
+        # Token state must not be partially mutated on failure
+        assert auth._token == ""
+        assert auth._expires_at == 0.0
+
     def test_200_with_non_json_body_raises_authentication_error(self) -> None:
         with respx.mock() as router:
             router.post(TOKEN_URL).mock(return_value=Response(200, text="not json"))

--- a/tests/test_client.py
+++ b/tests/test_client.py
@@ -793,3 +793,36 @@ def test_id_cache_double_check_locking(mock_registry: respx.MockRouter) -> None:
     client._id_cache = _RaceDict()  # type: ignore[assignment]
     result = client.get_schema_by_content_id(42)
     assert result is cached_schema
+
+
+# ── Auth wiring tests ──
+
+
+def test_client_auth_defaults_to_none() -> None:
+    """auth parameter defaults to None; existing tests unaffected."""
+    import inspect
+
+    params = inspect.signature(ApicurioRegistryClient.__init__).parameters
+    assert "auth" in params
+    assert params["auth"].default is None
+
+
+def test_client_accepts_bearer_auth(mock_registry: respx.MockRouter) -> None:
+    """ApicurioRegistryClient accepts auth=BearerAuth and passes it to httpx."""
+    from httpx import Response
+
+    from apicurio_serdes._auth import BearerAuth
+
+    url = f"{REGISTRY_URL}/groups/{GROUP_ID}/artifacts/Auth/versions/latest/content"
+    route = mock_registry.get(url).mock(
+        return_value=Response(
+            200,
+            content=b'{"type":"record","name":"X","fields":[]}',
+            headers={"X-Registry-GlobalId": "1", "X-Registry-ContentId": "2"},
+        )
+    )
+    client = ApicurioRegistryClient(
+        url=REGISTRY_URL, group_id=GROUP_ID, auth=BearerAuth(token="wire-tok")
+    )
+    client.get_schema("Auth")
+    assert route.calls[0].request.headers["authorization"] == "Bearer wire-tok"


### PR DESCRIPTION
## Summary

Closes #38. Adds authentication support to `ApicurioRegistryClient` and `AsyncApicurioRegistryClient` via an optional `auth=` constructor kwarg. Two `httpx.Auth` subclasses are provided:

- **`BearerAuth(token="...")`** — static Bearer token
- **`BearerAuth(token_provider=callable)`** — dynamic token (GCP OIDC, any callable)
- **`KeycloakAuth(token_url, client_id, client_secret)`** — OAuth2 client credentials flow with threshold-based auto-refresh (<20% TTL triggers refresh). Separate `sync_auth_flow` / `async_auth_flow` avoid blocking the event loop.
- **`AuthenticationError`** — raised when the token endpoint is unreachable or returns a non-200 response.

All three classes are exported from the top-level `apicurio_serdes` package. No new runtime dependencies.

## Security hardening

- Malformed 200 responses (missing `access_token`/`expires_in`) raise `AuthenticationError` instead of leaking `KeyError`/`TypeError`
- Error messages show the parsed `error` field only, not the full response body
- `token_url` userinfo stripped before appearing in error messages
- `KeycloakAuth.__repr__` masks `client_secret` as `***`

## Test plan

- [x] `uv run pytest` — 310 passed, 0 failures
- [x] 100% branch coverage on all new and modified files
- [x] `uv run mypy src/` — 0 errors (strict mode)
- [ ] Manual: `python -c "from apicurio_serdes import BearerAuth, KeycloakAuth, AuthenticationError; print('OK')"`

## Usage

```python
from apicurio_serdes import ApicurioRegistryClient, BearerAuth, KeycloakAuth

# Static token (e.g. GCP OIDC identity token)
client = ApicurioRegistryClient(
    url="http://registry:8080/apis/registry/v3",
    group_id="my-group",
    auth=BearerAuth(token_provider=lambda: get_google_id_token()),
)

# Keycloak client credentials
client = ApicurioRegistryClient(
    url="http://registry:8080/apis/registry/v3",
    group_id="my-group",
    auth=KeycloakAuth(
        token_url="https://keycloak.example.com/realms/myrealm/protocol/openid-connect/token",
        client_id="my-client",
        client_secret="secret",
    ),
)
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)