### PR TITLE
test: drop private-attribute assertion in resolver construction test

### DIFF
--- a/tests/test_serializer.py
+++ b/tests/test_serializer.py
@@ -664,8 +664,7 @@ def test_artifact_resolver_only_constructs_successfully() -> None:
     """artifact_resolver only constructs without error (new behaviour)."""
     client = ApicurioRegistryClient(url=REGISTRY_URL, group_id=GROUP_ID)
     resolver = lambda ctx: "UserEvent"  # noqa: E731
-    ser = AvroSerializer(registry_client=client, artifact_resolver=resolver)
-    assert ser._artifact_resolver is resolver
+    AvroSerializer(registry_client=client, artifact_resolver=resolver)
 
 
 # ── artifact_resolver serialize path integration tests ──


### PR DESCRIPTION
## Summary

- Removes the `assert ser._artifact_resolver is resolver` line from `test_artifact_resolver_only_constructs_successfully` in `tests/test_serializer.py`.
- Construction success is already implicit — if `AvroSerializer(...)` raises, the test fails. No behavior assertion is needed here; the existing integration tests already cover the resolver call path.
- Brings the test in line with the symmetric `test_artifact_id_only_constructs_successfully`, which only asserts on the public `artifact_id` attribute.

Closes #50

## Test plan

- [x] `uv run pytest tests/test_serializer.py -x -q` — 31 passed
- [x] `uv run pytest --tb=short -q` — 293 passed, 100% coverage

🤖 Generated with [Claude Code](https://claude.com/claude-code)