### PR TITLE
feat: add QualifiedRecordIdStrategy and TopicRecordIdStrategy (#34)

### DIFF
--- a/docs/changelog.en.md
+++ b/docs/changelog.en.md
@@ -20,6 +20,17 @@ All user-visible changes are documented here.
   fields in the response body). Exported from the package root.
 - `if_exists` values follow the Apicurio Registry v3 API: `"FAIL"`,
   `"FIND_OR_CREATE_VERSION"` (default), `"CREATE_VERSION"`.
+- `QualifiedRecordIdStrategy` — new artifact resolver strategy. Derives the
+  artifact ID from the Avro schema's record name and namespace:
+  `"{namespace}.{name}"` when namespace is present, `"{name}"` otherwise.
+  Matches the Confluent `RecordNameStrategy`. Raises `ValueError` at
+  construction if the schema has no `"name"` field.
+- `TopicRecordIdStrategy` — new artifact resolver strategy. Derives the
+  artifact ID from the topic and the Avro schema's record name:
+  `"{topic}-{namespace}.{name}"` when namespace is present,
+  `"{topic}-{name}"` otherwise. Matches the Confluent
+  `TopicRecordNameStrategy`. Raises `ValueError` at construction if the
+  schema has no `"name"` field.
 
 ## 0.2.0 (2026-03-11)
 

--- a/docs/plans/2026-03-16-subject-strategies-plan.md
+++ b/docs/plans/2026-03-16-subject-strategies-plan.md
@@ -1,0 +1,259 @@
+# Plan: Subject / Artifact Name Strategies (2026-03-16)
+
+## Summary
+
+Add two new artifact resolver strategy classes — `QualifiedRecordIdStrategy`
+and `TopicRecordIdStrategy` — to `apicurio-serdes`. Both derive the artifact
+ID from the Avro schema's record name and namespace, injected at construction
+time. They complement the existing `TopicIdStrategy` and
+`SimpleTopicIdStrategy` and cover the record-name–based naming conventions
+used by both Apicurio (Java) and Confluent Schema Registry. Update exports,
+tests, user-guide documentation, and the changelog.
+
+## Stakes Classification
+
+**Level**: Low
+
+**Rationale**: Self-contained addition to a single module
+(`_strategies.py`). No changes to existing classes, no changes to
+`SerializationContext`, `ArtifactResolver`, or `AvroSerializer`. Easy to
+roll back by reverting the new file additions.
+
+## Context
+
+**Research**: [2026-03-16-subject-strategies-research.md](2026-03-16-subject-strategies-research.md)
+
+**Web research**: Confluent Python uses call-time injection
+(`strategy(ctx, record_name)`); our constructor-injection approach is
+justified by the `ArtifactResolver = Callable[[SerializationContext], str]`
+type alias contract. Java `RecordIdStrategy` (groupId=namespace routing) is
+intentionally omitted.
+
+**Affected Areas**:
+
+- `src/apicurio_serdes/avro/_strategies.py` — new classes
+- `src/apicurio_serdes/avro/__init__.py` — new exports
+- `tests/test_strategies.py` — new test cases
+- `docs/user-guide/avro-serializer.en.md` — document new strategies
+- `docs/changelog.en.md` — record new public API
+
+## Success Criteria
+
+- [ ] `QualifiedRecordIdStrategy` and `TopicRecordIdStrategy` are importable
+  from `apicurio_serdes.avro`
+- [ ] Both strategies satisfy the `ArtifactResolver` protocol
+- [ ] `QualifiedRecordIdStrategy` returns `"{namespace}.{name}"` when namespace
+  is present, `"{name}"` when absent
+- [ ] `TopicRecordIdStrategy` returns `"{topic}-{namespace}.{name}"` when
+  namespace is present, `"{topic}-{name}"` when absent
+- [ ] Both strategies raise `ValueError` at construction when schema has no
+  `"name"` field
+- [ ] All tests pass with 100% branch coverage
+- [ ] User-guide documents new strategies with usage examples
+- [ ] Changelog records new public API
+
+## Implementation Steps
+
+### Phase 1: Tests (RED)
+
+#### Step 1.1: Write failing tests for `QualifiedRecordIdStrategy`
+
+- **Files**: `tests/test_strategies.py`
+- **Action**: Add `TestQualifiedRecordIdStrategy` class with failing tests
+- **Test cases**:
+  - `schema={"name": "Order", "namespace": "com.example"}` →
+    `"com.example.Order"` (field irrelevant — same result for KEY and VALUE)
+  - `schema={"name": "Order"}` (no namespace) → `"Order"`
+  - `schema={}` (no name) → raises `ValueError` at construction
+  - `schema={"name": ""}` (empty name) → raises `ValueError` at construction
+- **Verify**: Tests exist and fail (`ImportError` or `AttributeError`)
+- **Complexity**: Small
+
+#### Step 1.2: Write failing tests for `TopicRecordIdStrategy`
+
+- **Files**: `tests/test_strategies.py`
+- **Action**: Add `TestTopicRecordIdStrategy` class with failing tests
+- **Test cases**:
+  - `schema={"name": "Order", "namespace": "com.example"}`,
+    topic=`"orders"`, field=VALUE → `"orders-com.example.Order"`
+  - `schema={"name": "Order", "namespace": "com.example"}`,
+    topic=`"orders"`, field=KEY → `"orders-com.example.Order"`
+  - `schema={"name": "Order"}` (no namespace), topic=`"orders"` →
+    `"orders-Order"`
+  - `schema={}` (no name) → raises `ValueError` at construction
+  - `schema={"name": ""}` (empty name) → raises `ValueError` at
+    construction
+- **Verify**: Tests exist and fail
+- **Complexity**: Small
+
+#### Step 1.3: Write lambda/callable test for new strategies
+
+- **Files**: `tests/test_strategies.py`
+- **Action**: Assert that instances of both new classes satisfy
+  `ArtifactResolver` at runtime (type check via `callable()`)
+- **Test cases**:
+  - `isinstance(QualifiedRecordIdStrategy(schema), ArtifactResolver)` is not
+    checkable (it's a type alias), but `callable(strategy)` → `True`
+  - Call the instance: `strategy(ctx)` returns a `str`
+- **Verify**: Tests exist and fail
+- **Complexity**: Small
+
+### Phase 2: Implementation (GREEN)
+
+#### Step 2.1: Implement `QualifiedRecordIdStrategy`
+
+- **Files**: `src/apicurio_serdes/avro/_strategies.py`
+- **Action**: Add `QualifiedRecordIdStrategy` class after
+  `SimpleTopicIdStrategy`. Constructor extracts `name` and `namespace` from
+  the schema dict, raises `ValueError` if `name` is missing or empty.
+  `__call__` returns `"{namespace}.{name}"` or `"{name}"`.
+
+  ```python
+  class QualifiedRecordIdStrategy:
+      def __init__(self, schema: dict[str, Any]) -> None:
+          name = schema.get("name")
+          if not name:
+              raise ValueError(
+                  "schema must have a non-empty 'name' field"
+              )
+          namespace = schema.get("namespace")
+          self._artifact_id = (
+              f"{namespace}.{name}" if namespace else name
+          )
+
+      def __call__(self, ctx: SerializationContext) -> str:
+          return self._artifact_id
+  ```
+
+- **Verify**: Tests from Step 1.1 pass; `uv run pytest tests/test_strategies.py`
+- **Complexity**: Small
+
+#### Step 2.2: Implement `TopicRecordIdStrategy`
+
+- **Files**: `src/apicurio_serdes/avro/_strategies.py`
+- **Action**: Add `TopicRecordIdStrategy` class after
+  `QualifiedRecordIdStrategy`. Constructor extracts `name` and `namespace`,
+  raises `ValueError` if name missing or empty. `__call__` returns
+  `"{topic}-{namespace}.{name}"` or `"{topic}-{name}"`.
+
+  ```python
+  class TopicRecordIdStrategy:
+      def __init__(self, schema: dict[str, Any]) -> None:
+          name = schema.get("name")
+          if not name:
+              raise ValueError(
+                  "schema must have a non-empty 'name' field"
+              )
+          namespace = schema.get("namespace")
+          self._record_part = (
+              f"{namespace}.{name}" if namespace else name
+          )
+
+      def __call__(self, ctx: SerializationContext) -> str:
+          return f"{ctx.topic}-{self._record_part}"
+  ```
+
+- **Verify**: Tests from Steps 1.2 and 1.3 pass;
+  `uv run pytest tests/test_strategies.py`
+- **Complexity**: Small
+
+#### Step 2.3: Add type annotation import
+
+- **Files**: `src/apicurio_serdes/avro/_strategies.py`
+- **Action**: Add `Any` to the `TYPE_CHECKING` or top-level imports so the
+  `dict[str, Any]` annotation resolves correctly
+- **Verify**: `uv run pytest tests/test_strategies.py` passes with no import
+  errors; `uv run mypy src/` (if applicable) passes
+- **Complexity**: Small
+
+#### Step 2.4: Export new strategies from `avro/__init__.py`
+
+- **Files**: `src/apicurio_serdes/avro/__init__.py`
+- **Action**: Add `QualifiedRecordIdStrategy` and `TopicRecordIdStrategy` to
+  the `from apicurio_serdes.avro._strategies import (...)` block and to
+  `__all__`
+- **Verify**: `from apicurio_serdes.avro import QualifiedRecordIdStrategy,
+  TopicRecordIdStrategy` works in a Python REPL;
+  `uv run pytest tests/test_strategies.py`
+- **Complexity**: Small
+
+### Phase 3: Full Verification
+
+#### Step 3.1: Run full test suite with coverage
+
+- **Files**: N/A (verification only)
+- **Action**: `uv run pytest --cov=apicurio_serdes --cov-fail-under=100`
+- **Verify**: All tests pass; coverage stays at 100%; no regressions
+- **Complexity**: Small
+
+### Phase 4: Documentation
+
+#### Step 4.1: Update user-guide
+
+- **Files**: `docs/user-guide/avro-serializer.en.md`
+- **Action**: Add a section documenting `QualifiedRecordIdStrategy` and
+  `TopicRecordIdStrategy` alongside the existing strategy descriptions.
+  Include:
+  - Brief description of each strategy
+  - Constructor argument (`schema: dict`)
+  - Output formula (with and without namespace)
+  - Note that the Java `RecordIdStrategy` (groupId=namespace routing) is not
+    implemented; use `group_id` on the client instead
+  - Note that each instance is schema-specific (constructor-injection
+    trade-off)
+  - Code example for `QualifiedRecordIdStrategy` with `auto_register=True`
+- **Verify**: Markdown lints clean; content is accurate
+- **Complexity**: Small
+
+#### Step 4.2: Update changelog
+
+- **Files**: `docs/changelog.en.md`
+- **Action**: Add `QualifiedRecordIdStrategy` and `TopicRecordIdStrategy` to
+  the `## Unreleased` section under "Added"
+- **Verify**: Markdown lints clean
+- **Complexity**: Small
+
+## Test Strategy
+
+### Automated Tests
+
+| Test Case | Type | Input | Expected Output |
+| --- | --- | --- | --- |
+| Qualified with namespace | Unit | `{"name":"Order","namespace":"com.example"}` | `"com.example.Order"` |
+| Qualified without namespace | Unit | `{"name":"Order"}` | `"Order"` |
+| Qualified no name → ValueError | Unit | `{}` | `ValueError` at construction |
+| Qualified empty name → ValueError | Unit | `{"name":""}` | `ValueError` at construction |
+| TopicRecord with namespace, VALUE | Unit | schema + topic=`"orders"`, VALUE | `"orders-com.example.Order"` |
+| TopicRecord with namespace, KEY | Unit | schema + topic=`"orders"`, KEY | `"orders-com.example.Order"` |
+| TopicRecord without namespace | Unit | `{"name":"Order"}` + topic=`"orders"` | `"orders-Order"` |
+| TopicRecord no name → ValueError | Unit | `{}` | `ValueError` at construction |
+| TopicRecord empty name → ValueError | Unit | `{"name":""}` | `ValueError` at construction |
+| callable() returns True | Unit | any valid strategy instance | `True` |
+| strategy(ctx) returns str | Unit | any valid strategy instance + ctx | `str` |
+
+### Manual Verification
+
+- [ ] `from apicurio_serdes.avro import QualifiedRecordIdStrategy,
+  TopicRecordIdStrategy` works in a fresh Python session
+- [ ] Both strategies can be passed as `artifact_resolver` to `AvroSerializer`
+  without errors (smoke test)
+
+## Risks and Mitigations
+
+| Risk | Impact | Mitigation |
+| --- | --- | --- |
+| `Any` import missing in `_strategies.py` | `NameError` at runtime | Add to imports in Step 2.3 |
+| Namespace-only or name-only schemas (rare Avro edge cases) | Wrong artifact ID | Validate at construction; document behavior |
+| Java `RecordIdStrategy` confusion | Users expect groupId routing | Clear docstring note in both classes |
+
+## Rollback Strategy
+
+All changes are additive — no existing classes or interfaces are modified.
+Rollback is a single `git revert` of the new commits, with no downstream
+impact on existing serializers or resolvers.
+
+## Status
+
+- [x] Plan approved
+- [x] Implementation started
+- [x] Implementation complete

--- a/docs/plans/2026-03-16-subject-strategies-research.md
+++ b/docs/plans/2026-03-16-subject-strategies-research.md
@@ -1,0 +1,201 @@
+# Research: Subject / Artifact Name Strategies (2026-03-16)
+
+## Problem Statement
+
+Expand the existing artifact name strategy system so users can auto-derive
+artifact IDs from Kafka topic names and/or Avro schema record names, covering
+the full set of strategies offered by the Apicurio Java reference implementation
+and Confluent Schema Registry. Both `AvroSerializer` and `AvroDeserializer` are
+in scope.
+
+## Requirements
+
+- Add record-name–based strategies: `RecordIdStrategy` and `TopicRecordIdStrategy`
+- Strategies must satisfy the existing `ArtifactResolver` protocol
+  (`Callable[[SerializationContext], str]`) to remain backward-compatible
+- Deserializer support: since the schema ID is embedded in the wire format, the
+  deserializer does not need strategies for schema lookup — no changes required
+- Do not change the `SerializationContext` dataclass or `ArtifactResolver`
+  type alias
+
+## Findings
+
+### Relevant Files
+
+| File | Purpose | Key Lines |
+| --- | --- | --- |
+| `src/apicurio_serdes/avro/_strategies.py` | `ArtifactResolver` type alias + strategies | 1–73 |
+| `src/apicurio_serdes/serialization.py` | `SerializationContext(topic, field)` | 1–46 |
+| `src/apicurio_serdes/avro/_serializer.py` | Consumes resolver; lazy caching | 101–216 |
+| `src/apicurio_serdes/avro/_deserializer.py` | Wire-format schema lookup; no strategy | — |
+| `src/apicurio_serdes/avro/__init__.py` | Public re-exports for `avro` sub-package | 1–19 |
+| `tests/test_strategies.py` | Strategy unit tests; TDD anchor | 1–45 |
+
+### Existing Patterns
+
+**`ArtifactResolver` type alias**
+
+```python
+ArtifactResolver = Callable[["SerializationContext"], str]
+```
+
+Any callable `(ctx: SerializationContext) -> str` satisfies the protocol. Both
+built-in strategies are callable classes that implement `__call__`.
+
+**`SerializationContext` shape**
+
+```python
+@dataclass(frozen=True)
+class SerializationContext:
+    topic: str
+    field: MessageField   # MessageField.KEY or MessageField.VALUE
+```
+
+The context carries **no schema information**. Topic-based strategies are
+trivial; record-name–based strategies must receive the schema via another
+mechanism (see Recommendations).
+
+**`TopicIdStrategy`** — `"{topic}-{field}"` (e.g. `"orders-value"`)
+
+**`SimpleTopicIdStrategy`** — `"{topic}"` (e.g. `"orders"`)
+
+**`AvroSerializer` lazy resolution** (`_serializer.py` lines 180–216):
+The resolver is called exactly once on the first `serialize()` call and the
+result is cached in `_resolved_artifact_id`. The strategy is called with the
+live `SerializationContext` from that first call.
+
+**Auto-registration pattern**: `AvroSerializer` already accepts `schema=` at
+construction time for `auto_register=True`. This constructor injection pattern
+is the right model for schema-aware strategies.
+
+**Mutual exclusivity**: `artifact_id` and `artifact_resolver` are mutually
+exclusive — exactly one must be provided.
+
+### Dependencies
+
+- No new external libraries needed
+- `fastavro.parse_schema` is already available for schema introspection if needed
+- Strategies must remain pure callables — no registry access, no I/O
+
+### External Research
+
+**Confluent naming conventions** (from Confluent Schema Registry documentation):
+
+| Strategy | Formula | Key/value suffix? |
+| --- | --- | --- |
+| `TopicNameStrategy` | `{topic}-{key\|value}` | Yes |
+| `RecordNameStrategy` | `{namespace}.{RecordName}` | No |
+| `TopicRecordNameStrategy` | `{topic}-{namespace}.{RecordName}` | No |
+
+Critical: the `-key`/`-value` suffix is **exclusive to `TopicNameStrategy`**.
+`RecordNameStrategy` and `TopicRecordNameStrategy` use the fully-qualified record
+name without any suffix.
+
+**Apicurio Java strategies** (from Apicurio Registry Java SDK):
+
+| Strategy | Artifact ID | GroupId |
+| --- | --- | --- |
+| `TopicIdStrategy` | `{topic}-{key\|value}` | configured |
+| `SimpleTopicIdStrategy` | `{topic}` | configured |
+| `RecordIdStrategy` | `{RecordName}` | `{namespace}` |
+| `TopicRecordIdStrategy` | `{topic}-{namespace}.{RecordName}` | configured |
+| `QualifiedRecordIdStrategy` | `{namespace}.{RecordName}` | configured |
+
+Notes:
+
+- `RecordIdStrategy` routes to a **different groupId** (namespace) — incompatible
+  with the current single-group-per-client design
+- `QualifiedRecordIdStrategy` is the most practical record-name strategy when
+  keeping a single configured groupId
+- `TopicRecordIdStrategy` prefixes the topic, same logic as Confluent's
+  `TopicRecordNameStrategy`
+- Apicurio's official Python client has no built-in serde strategies; strategies
+  exist only in the Java SDK
+
+### Technical Constraints
+
+1. **Schema not in `SerializationContext`**: Record-name strategies need the Avro
+   schema's `name` and optional `namespace`. Since the context carries no schema,
+   the schema must be injected at strategy **construction time** — the same pattern
+   already used by `AvroSerializer(schema=...)`.
+
+2. **`ArtifactResolver` protocol must not change**: Changing the signature would
+   break any user lambda or callable that satisfies the current protocol. Constructor
+   injection is strictly backward-compatible.
+
+3. **`RecordIdStrategy` groupId routing**: The Java `RecordIdStrategy` uses the
+   schema's namespace as the groupId, requiring the client to target multiple groups.
+   This conflicts with `ApicurioRegistryClient`'s single `group_id`. **Skip** this
+   variant; implement `QualifiedRecordIdStrategy` (`{namespace}.{RecordName}`)
+   against the configured group instead.
+
+4. **Missing namespace handling**: Avro schemas at the root level may omit
+   `namespace`. Strategies should handle this gracefully: if `namespace` is absent,
+   fall back to `name` only (or raise `ValueError` at construction time with a clear
+   message — prefer raising to failing silently at call time).
+
+5. **100% branch coverage gate**: Every new branch must be covered by a test.
+
+## Open Questions
+
+- Should `RecordIdStrategy` be skipped entirely (since it requires multi-group
+  routing) or included with a note that users must configure `group_id=namespace`
+  manually? Recommendation: skip it; add a note in the docstring of
+  `QualifiedRecordIdStrategy`.
+- Should strategies validate the schema at construction time (fail fast) or
+  lazily at first call? Recommendation: validate at construction time.
+
+## Recommendations
+
+Add two new strategy classes to `src/apicurio_serdes/avro/_strategies.py`:
+
+### `QualifiedRecordIdStrategy`
+
+Mirrors Confluent's `RecordNameStrategy` and Apicurio's
+`QualifiedRecordIdStrategy`. Returns `"{namespace}.{RecordName}"` if the schema
+has a namespace, or `"{RecordName}"` if not. Schema injected at construction.
+
+```python
+class QualifiedRecordIdStrategy:
+    def __init__(self, schema: dict[str, Any]) -> None:
+        name = schema.get("name")
+        if not name:
+            raise ValueError("schema must have a 'name' field")
+        namespace = schema.get("namespace")
+        self._artifact_id = f"{namespace}.{name}" if namespace else name
+
+    def __call__(self, ctx: SerializationContext) -> str:
+        return self._artifact_id
+```
+
+### `TopicRecordIdStrategy`
+
+Mirrors Confluent's `TopicRecordNameStrategy` and Apicurio's
+`TopicRecordIdStrategy`. Returns `"{topic}-{namespace}.{RecordName}"`. Schema
+injected at construction; topic from context at call time.
+
+```python
+class TopicRecordIdStrategy:
+    def __init__(self, schema: dict[str, Any]) -> None:
+        name = schema.get("name")
+        if not name:
+            raise ValueError("schema must have a 'name' field")
+        namespace = schema.get("namespace")
+        self._record_part = f"{namespace}.{name}" if namespace else name
+
+    def __call__(self, ctx: SerializationContext) -> str:
+        return f"{ctx.topic}-{self._record_part}"
+```
+
+Both classes must be exported from `src/apicurio_serdes/avro/__init__.py` and
+added to `__all__`.
+
+Test coverage required for:
+
+- Happy path (with namespace)
+- No-namespace fallback
+- `ValueError` at construction when `name` is missing
+- `TopicRecordIdStrategy` with both KEY and VALUE fields
+
+No changes needed to `AvroDeserializer`, `AsyncAvroDeserializer`,
+`SerializationContext`, or `ArtifactResolver`.

--- a/docs/user-guide/avro-serializer.en.md
+++ b/docs/user-guide/avro-serializer.en.md
@@ -33,6 +33,97 @@ payload = serializer({"userId": "abc-123", "country": "FR"}, ctx)
 | `use_id` | `"globalId"` or `"contentId"` | `"globalId"` | Which schema identifier to embed in the wire format header. See [Choosing Between globalId and contentId](../how-to/identifier-selection.md). |
 | `strict` | `bool` | `False` | Reject input fields not present in the schema with `ValueError`. |
 
+## Artifact resolver strategies
+
+Instead of a static `artifact_id`, you can pass `artifact_resolver` — a
+callable `(SerializationContext) -> str` that derives the artifact ID at
+serialization time. Four built-in strategies are provided.
+
+### `TopicIdStrategy`
+
+Returns `"{topic}-{field}"` (e.g. `"orders-value"`, `"orders-key"`).
+Matches the Apicurio Java `TopicIdStrategy`.
+
+```python
+from apicurio_serdes.avro import TopicIdStrategy
+
+serializer = AvroSerializer(registry_client=client, artifact_resolver=TopicIdStrategy())
+```
+
+### `SimpleTopicIdStrategy`
+
+Returns `"{topic}"` (e.g. `"orders"`), ignoring the message field.
+Matches the Apicurio Java `SimpleTopicIdStrategy`.
+
+```python
+from apicurio_serdes.avro import SimpleTopicIdStrategy
+
+serializer = AvroSerializer(registry_client=client, artifact_resolver=SimpleTopicIdStrategy())
+```
+
+### `QualifiedRecordIdStrategy`
+
+Returns `"{namespace}.{name}"` when the schema has a namespace (e.g.
+`"com.example.Order"`), or `"{name}"` otherwise (e.g. `"Order"`). The topic
+and message field are ignored — the artifact ID is fixed at construction time
+from the schema. Matches the Confluent `RecordNameStrategy`.
+
+Each instance is schema-specific: pass the Avro schema dict at construction.
+
+```python
+from apicurio_serdes.avro import QualifiedRecordIdStrategy
+
+schema = {
+    "type": "record",
+    "name": "Order",
+    "namespace": "com.example",
+    "fields": [{"name": "orderId", "type": "string"}],
+}
+serializer = AvroSerializer(
+    registry_client=client,
+    artifact_resolver=QualifiedRecordIdStrategy(schema),
+    schema=schema,
+    auto_register=True,
+)
+```
+
+Raises `ValueError` at construction if the schema has no `"name"` key or
+the name is empty.
+
+> **Note**: The Java `RecordIdStrategy` (groupId = namespace routing) is
+> **not** implemented. Use the `group_id` parameter on
+> `ApicurioRegistryClient` for that routing behaviour.
+
+### `TopicRecordIdStrategy`
+
+Returns `"{topic}-{namespace}.{name}"` when the schema has a namespace (e.g.
+`"orders-com.example.Order"`), or `"{topic}-{name}"` otherwise (e.g.
+`"orders-Order"`). Matches the Confluent `TopicRecordNameStrategy`.
+
+Each instance is schema-specific: pass the Avro schema dict at construction.
+
+```python
+from apicurio_serdes.avro import TopicRecordIdStrategy
+from apicurio_serdes.serialization import MessageField, SerializationContext
+
+schema = {
+    "type": "record",
+    "name": "Order",
+    "namespace": "com.example",
+    "fields": [{"name": "orderId", "type": "string"}],
+}
+strategy = TopicRecordIdStrategy(schema)
+ctx = SerializationContext(topic="orders", field=MessageField.VALUE)
+# strategy(ctx) == "orders-com.example.Order"
+```
+
+Raises `ValueError` at construction if the schema has no `"name"` key or
+the name is empty.
+
+> **Note**: The Java `RecordIdStrategy` (groupId = namespace routing) is
+> **not** implemented. Use the `group_id` parameter on
+> `ApicurioRegistryClient` for that routing behaviour.
+
 ## Auto-registration
 
 When `auto_register=True` and the artifact is not found in the registry (HTTP

--- a/src/apicurio_serdes/avro/__init__.py
+++ b/src/apicurio_serdes/avro/__init__.py
@@ -5,8 +5,10 @@ from apicurio_serdes.avro._deserializer import AvroDeserializer
 from apicurio_serdes.avro._serializer import AvroSerializer
 from apicurio_serdes.avro._strategies import (
     ArtifactResolver,
+    QualifiedRecordIdStrategy,
     SimpleTopicIdStrategy,
     TopicIdStrategy,
+    TopicRecordIdStrategy,
 )
 
 __all__ = [
@@ -14,6 +16,8 @@ __all__ = [
     "AsyncAvroDeserializer",
     "AvroDeserializer",
     "AvroSerializer",
+    "QualifiedRecordIdStrategy",
     "SimpleTopicIdStrategy",
     "TopicIdStrategy",
+    "TopicRecordIdStrategy",
 ]

--- a/src/apicurio_serdes/avro/_strategies.py
+++ b/src/apicurio_serdes/avro/_strategies.py
@@ -3,7 +3,7 @@
 from __future__ import annotations
 
 from collections.abc import Callable
-from typing import TYPE_CHECKING
+from typing import TYPE_CHECKING, Any
 
 if TYPE_CHECKING:
     from apicurio_serdes.serialization import SerializationContext
@@ -71,3 +71,107 @@ class SimpleTopicIdStrategy:
             The topic name as the artifact ID.
         """
         return ctx.topic
+
+
+class QualifiedRecordIdStrategy:
+    """Derives the artifact ID from the Avro schema's record name and namespace.
+
+    Returns ``"{namespace}.{name}"`` when namespace is present, ``"{name}"``
+    otherwise. Matches the Confluent ``RecordNameStrategy`` and Apicurio's
+    qualified-record convention.
+
+    The topic and message field are ignored — the artifact ID is fixed at
+    construction time from the schema.
+
+    Note:
+        The Java ``RecordIdStrategy`` (groupId=namespace routing) is **not**
+        implemented. Use the ``group_id`` parameter on the Apicurio client for
+        that routing behaviour.
+
+    Args:
+        schema: Avro schema dict. Must contain a non-empty ``"name"`` key.
+
+    Raises:
+        ValueError: If ``schema`` has no ``"name"`` key or the name is empty.
+
+    Example:
+        ```python
+        from apicurio_serdes.avro import QualifiedRecordIdStrategy
+
+        schema = {"type": "record", "name": "Order", "namespace": "com.example", "fields": []}
+        strategy = QualifiedRecordIdStrategy(schema)
+        # strategy(ctx) == "com.example.Order"
+        ```
+    """
+
+    def __init__(self, schema: dict[str, Any]) -> None:
+        name = schema.get("name")
+        if not name:
+            raise ValueError("schema must have a non-empty 'name' field")
+        namespace = schema.get("namespace")
+        self._artifact_id = f"{namespace}.{name}" if namespace else name
+
+    def __call__(self, ctx: SerializationContext) -> str:
+        """Return the qualified record name, ignoring context.
+
+        Args:
+            ctx: The serialization context (unused).
+
+        Returns:
+            Artifact ID string in the form ``"{namespace}.{name}"`` or
+            ``"{name}"``.
+        """
+        return self._artifact_id
+
+
+class TopicRecordIdStrategy:
+    """Derives the artifact ID from the topic and Avro schema's record name.
+
+    Returns ``"{topic}-{namespace}.{name}"`` when namespace is present,
+    ``"{topic}-{name}"`` otherwise. Matches the Confluent
+    ``TopicRecordNameStrategy``.
+
+    The artifact ID is partially fixed at construction time (record part) and
+    partially resolved at call time (topic).
+
+    Note:
+        The Java ``RecordIdStrategy`` (groupId=namespace routing) is **not**
+        implemented. Use the ``group_id`` parameter on the Apicurio client for
+        that routing behaviour.
+
+    Args:
+        schema: Avro schema dict. Must contain a non-empty ``"name"`` key.
+
+    Raises:
+        ValueError: If ``schema`` has no ``"name"`` key or the name is empty.
+
+    Example:
+        ```python
+        from apicurio_serdes.avro import TopicRecordIdStrategy
+        from apicurio_serdes.serialization import MessageField, SerializationContext
+
+        schema = {"type": "record", "name": "Order", "namespace": "com.example", "fields": []}
+        strategy = TopicRecordIdStrategy(schema)
+        ctx = SerializationContext(topic="orders", field=MessageField.VALUE)
+        # strategy(ctx) == "orders-com.example.Order"
+        ```
+    """
+
+    def __init__(self, schema: dict[str, Any]) -> None:
+        name = schema.get("name")
+        if not name:
+            raise ValueError("schema must have a non-empty 'name' field")
+        namespace = schema.get("namespace")
+        self._record_part = f"{namespace}.{name}" if namespace else name
+
+    def __call__(self, ctx: SerializationContext) -> str:
+        """Return ``"{topic}-{record}"`` for the given context.
+
+        Args:
+            ctx: The serialization context containing the topic.
+
+        Returns:
+            Artifact ID string in the form ``"{topic}-{namespace}.{name}"``
+            or ``"{topic}-{name}"``.
+        """
+        return f"{ctx.topic}-{self._record_part}"

--- a/src/apicurio_serdes/avro/_strategies.py
+++ b/src/apicurio_serdes/avro/_strategies.py
@@ -98,7 +98,10 @@ class QualifiedRecordIdStrategy:
         ```python
         from apicurio_serdes.avro import QualifiedRecordIdStrategy
 
-        schema = {"type": "record", "name": "Order", "namespace": "com.example", "fields": []}
+        schema = {
+            "type": "record", "name": "Order",
+            "namespace": "com.example", "fields": [],
+        }
         strategy = QualifiedRecordIdStrategy(schema)
         # strategy(ctx) == "com.example.Order"
         ```
@@ -150,7 +153,10 @@ class TopicRecordIdStrategy:
         from apicurio_serdes.avro import TopicRecordIdStrategy
         from apicurio_serdes.serialization import MessageField, SerializationContext
 
-        schema = {"type": "record", "name": "Order", "namespace": "com.example", "fields": []}
+        schema = {
+            "type": "record", "name": "Order",
+            "namespace": "com.example", "fields": [],
+        }
         strategy = TopicRecordIdStrategy(schema)
         ctx = SerializationContext(topic="orders", field=MessageField.VALUE)
         # strategy(ctx) == "orders-com.example.Order"

--- a/tests/test_strategies.py
+++ b/tests/test_strategies.py
@@ -2,10 +2,14 @@
 
 from __future__ import annotations
 
+import pytest
+
 from apicurio_serdes.avro import (
     ArtifactResolver,
+    QualifiedRecordIdStrategy,
     SimpleTopicIdStrategy,
     TopicIdStrategy,
+    TopicRecordIdStrategy,
 )
 from apicurio_serdes.serialization import MessageField, SerializationContext
 
@@ -36,6 +40,68 @@ class TestSimpleTopicIdStrategy:
     def test_key_field(self) -> None:
         strategy = SimpleTopicIdStrategy()
         assert strategy(_ctx("orders", MessageField.KEY)) == "orders"
+
+
+class TestQualifiedRecordIdStrategy:
+    def test_with_namespace(self) -> None:
+        strategy = QualifiedRecordIdStrategy({"name": "Order", "namespace": "com.example"})
+        assert strategy(_ctx("orders", MessageField.VALUE)) == "com.example.Order"
+
+    def test_without_namespace(self) -> None:
+        strategy = QualifiedRecordIdStrategy({"name": "Order"})
+        assert strategy(_ctx("orders", MessageField.VALUE)) == "Order"
+
+    def test_field_ignored(self) -> None:
+        strategy = QualifiedRecordIdStrategy({"name": "Order", "namespace": "com.example"})
+        assert strategy(_ctx("orders", MessageField.KEY)) == "com.example.Order"
+
+    def test_no_name_raises(self) -> None:
+        with pytest.raises(ValueError):
+            QualifiedRecordIdStrategy({})
+
+    def test_empty_name_raises(self) -> None:
+        with pytest.raises(ValueError):
+            QualifiedRecordIdStrategy({"name": ""})
+
+    def test_callable(self) -> None:
+        strategy = QualifiedRecordIdStrategy({"name": "Order"})
+        assert callable(strategy)
+
+    def test_returns_str(self) -> None:
+        strategy = QualifiedRecordIdStrategy({"name": "Order"})
+        result = strategy(_ctx("orders", MessageField.VALUE))
+        assert isinstance(result, str)
+
+
+class TestTopicRecordIdStrategy:
+    def test_with_namespace_value(self) -> None:
+        strategy = TopicRecordIdStrategy({"name": "Order", "namespace": "com.example"})
+        assert strategy(_ctx("orders", MessageField.VALUE)) == "orders-com.example.Order"
+
+    def test_with_namespace_key(self) -> None:
+        strategy = TopicRecordIdStrategy({"name": "Order", "namespace": "com.example"})
+        assert strategy(_ctx("orders", MessageField.KEY)) == "orders-com.example.Order"
+
+    def test_without_namespace(self) -> None:
+        strategy = TopicRecordIdStrategy({"name": "Order"})
+        assert strategy(_ctx("orders", MessageField.VALUE)) == "orders-Order"
+
+    def test_no_name_raises(self) -> None:
+        with pytest.raises(ValueError):
+            TopicRecordIdStrategy({})
+
+    def test_empty_name_raises(self) -> None:
+        with pytest.raises(ValueError):
+            TopicRecordIdStrategy({"name": ""})
+
+    def test_callable(self) -> None:
+        strategy = TopicRecordIdStrategy({"name": "Order"})
+        assert callable(strategy)
+
+    def test_returns_str(self) -> None:
+        strategy = TopicRecordIdStrategy({"name": "Order"})
+        result = strategy(_ctx("orders", MessageField.VALUE))
+        assert isinstance(result, str)
 
 
 def test_lambda_satisfies_artifact_resolver_protocol() -> None:

--- a/tests/test_strategies.py
+++ b/tests/test_strategies.py
@@ -44,7 +44,9 @@ class TestSimpleTopicIdStrategy:
 
 class TestQualifiedRecordIdStrategy:
     def test_with_namespace(self) -> None:
-        strategy = QualifiedRecordIdStrategy({"name": "Order", "namespace": "com.example"})
+        strategy = QualifiedRecordIdStrategy(
+            {"name": "Order", "namespace": "com.example"}
+        )
         assert strategy(_ctx("orders", MessageField.VALUE)) == "com.example.Order"
 
     def test_without_namespace(self) -> None:
@@ -52,7 +54,9 @@ class TestQualifiedRecordIdStrategy:
         assert strategy(_ctx("orders", MessageField.VALUE)) == "Order"
 
     def test_field_ignored(self) -> None:
-        strategy = QualifiedRecordIdStrategy({"name": "Order", "namespace": "com.example"})
+        strategy = QualifiedRecordIdStrategy(
+            {"name": "Order", "namespace": "com.example"}
+        )
         assert strategy(_ctx("orders", MessageField.KEY)) == "com.example.Order"
 
     def test_no_name_raises(self) -> None:
@@ -76,7 +80,9 @@ class TestQualifiedRecordIdStrategy:
 class TestTopicRecordIdStrategy:
     def test_with_namespace_value(self) -> None:
         strategy = TopicRecordIdStrategy({"name": "Order", "namespace": "com.example"})
-        assert strategy(_ctx("orders", MessageField.VALUE)) == "orders-com.example.Order"
+        assert (
+            strategy(_ctx("orders", MessageField.VALUE)) == "orders-com.example.Order"
+        )
 
     def test_with_namespace_key(self) -> None:
         strategy = TopicRecordIdStrategy({"name": "Order", "namespace": "com.example"})


### PR DESCRIPTION
## Summary

- Adds `QualifiedRecordIdStrategy`: derives artifact ID as `"{namespace}.{name}"` (or `"{name}"` when namespace absent), matching the Confluent `RecordNameStrategy`
- Adds `TopicRecordIdStrategy`: derives artifact ID as `"{topic}-{namespace}.{name}"` (or `"{topic}-{name}"`), matching the Confluent `TopicRecordNameStrategy`
- Both strategies validate the schema at construction and raise `ValueError` if `"name"` is missing or empty
- Exports both classes from `apicurio_serdes.avro`
- Documents all four built-in strategies in the user guide with usage examples
- Records new public API in the changelog

## Test plan

- [ ] All 353 tests pass with 100% branch coverage (`uv run pytest --cov=apicurio_serdes --cov-fail-under=100`)
- [ ] `QualifiedRecordIdStrategy` and `TopicRecordIdStrategy` importable from `apicurio_serdes.avro`
- [ ] Both strategies satisfy `ArtifactResolver` protocol (callable, return `str`)
- [ ] `ValueError` raised at construction for missing or empty `"name"` field
- [ ] Namespace-present and namespace-absent branches tested for both strategies

🤖 Generated with [Claude Code](https://claude.com/claude-code)