### PR TITLE
fix: skip publish-testpypi and sonarcloud for dependabot PRs

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -91,6 +91,7 @@ jobs:
     if: >-
       github.event_name == 'pull_request'
       && github.event.pull_request.draft == false
+      && github.actor != 'dependabot[bot]'
     runs-on: ubuntu-latest
     timeout-minutes: 10
     steps:

--- a/.github/workflows/sonarcloud.yml
+++ b/.github/workflows/sonarcloud.yml
@@ -11,7 +11,7 @@ permissions:
 
 jobs:
   sonarcloud:
-    if: github.event.pull_request.draft == false || github.event_name == 'push'
+    if: (github.event.pull_request.draft == false || github.event_name == 'push') && github.actor != 'dependabot[bot]'
     runs-on: ubuntu-latest
     timeout-minutes: 10
     steps:


### PR DESCRIPTION
## Summary

- `publish-testpypi` and `sonarcloud` both fail on all dependabot PRs because Dependabot runs under a restricted token that cannot access repository secrets (`TESTPYPI_API_TOKEN`, `SONAR_TOKEN`)
- Fix: add `&& github.actor != 'dependabot[bot]'` to the `if:` condition on both jobs so they are skipped (not failed) for dependency update PRs

## Test plan

- [ ] Dependabot PRs no longer show failed `publish-testpypi` / `sonarcloud` checks
- [ ] Both jobs still run normally on non-dependabot PRs and `main` pushes

🤖 Generated with [Claude Code](https://claude.ai/code)