### PR TITLE
fix: add pre-push stage to ruff hooks and document hook install (#56)

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -4,4 +4,6 @@ repos:
     hooks:
       - id: ruff
         args: [--fix]
+        stages: [pre-commit, pre-push]
       - id: ruff-format
+        stages: [pre-commit, pre-push]

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -29,6 +29,9 @@ curl -LsSf https://astral.sh/uv/install.sh | sh
 git clone https://github.com/jcbianic/apicurio-serdes.git
 cd apicurio-serdes
 uv sync --group dev
+
+# Install git hooks (runs ruff on commit and on push)
+uv run pre-commit install --hook-type pre-commit --hook-type pre-push
 ```
 
 ## Running checks locally


### PR DESCRIPTION
Closes #56

## Summary

- `.pre-commit-config.yaml`: adds `stages: [pre-commit, pre-push]` to both `ruff` and `ruff-format` hooks so lint violations are caught locally on `git push`, not just on `git commit`
- `CONTRIBUTING.md`: adds `pre-commit install --hook-type pre-commit --hook-type pre-push` to the dev setup steps so new contributors get both hooks from the start

## Why

Ruff E501 violations in docstrings slipped past the commit-time hook and were only caught by CI after a push (see #56). Gating on push closes that gap while keeping the commit-time fix-and-reformat behaviour.

## Test plan

- [ ] `git push` with a ruff violation is blocked locally
- [ ] `git push` with clean code proceeds normally
- [ ] CI lint job continues to pass as backstop

🤖 Generated with [Claude Code](https://claude.ai/code)