### PR TITLE
fix(ci): add --clobber to retroactive sign workflow upload

### DIFF
--- a/.github/workflows/sign-release-retroactive.yml
+++ b/.github/workflows/sign-release-retroactive.yml
@@ -42,4 +42,4 @@ jobs:
       - name: Upload signatures to GitHub release
         env:
           GH_TOKEN: ${{ github.token }}
-        run: gh release upload "${{ github.event.inputs.tag }}" dist/*.sigstore.json --repo "${{ github.repository }}"
+        run: gh release upload "${{ github.event.inputs.tag }}" dist/*.sigstore.json --repo "${{ github.repository }}" --clobber


### PR DESCRIPTION
Overwrites any pre-existing `.sigstore.json` assets on the release so the workflow can be re-run without manual asset deletion.

🤖 Generated with [Claude Code](https://claude.ai/code)