### PR TITLE
feat: add retry with exponential backoff and httpx escape hatch (#37)

### DIFF
--- a/.markdownlint.json
+++ b/.markdownlint.json
@@ -1,5 +1,6 @@
 {
   "default": true,
   "MD013": { "line_length": 120, "tables": false, "code_blocks": false },
+  "MD024": { "siblings_only": true },
   "MD060": false
 }

--- a/docs/changelog.en.md
+++ b/docs/changelog.en.md
@@ -6,6 +6,15 @@ All user-visible changes are documented here.
 
 ### Added
 
+- `ApicurioRegistryClient` and `AsyncApicurioRegistryClient` now retry automatically
+  on transient failures. Retries on `httpx.TransportError` and HTTP 429/502/503/504
+  with exponential backoff and full jitter. Three new constructor parameters control
+  the behaviour: `max_retries` (default 3), `retry_backoff_ms` (default 1 000 ms),
+  `retry_max_backoff_ms` (default 20 000 ms). Set `max_retries=0` to disable.
+- Both clients accept an optional `http_client` escape hatch (`httpx.Client` /
+  `httpx.AsyncClient`). When provided the supplied client is used as-is and is
+  **not** closed by `close()` / `aclose()`. An `auth` parameter is also available
+  for httpx-compatible authentication handlers when not using the escape hatch.
 - `AvroDeserializer` and `AsyncAvroDeserializer` accept an optional
   `reader_schema` parameter (Avro schema dict, default `None`). When provided,
   fastavro performs Avro schema resolution between the writer schema (embedded
@@ -42,18 +51,23 @@ All user-visible changes are documented here.
 
 ### Client Hardening & Deduplication
 
-This release focuses on improving robustness and maintainability through comprehensive client hardening and code deduplication.
+This release focuses on improving robustness and maintainability through comprehensive
+client hardening and code deduplication.
 
 ### Added
 
-- `ApicurioRegistryClient` — HTTP client for the Apicurio Registry v3 native API with schema caching and thread-safe access.
+- `ApicurioRegistryClient` — HTTP client for the Apicurio Registry v3 native API
+  with schema caching and thread-safe access.
 - `AsyncApicurioRegistryClient` — async counterpart using `httpx.AsyncClient`, safe for concurrent coroutine use.
-- `AvroSerializer` — serializes Python data to Confluent-framed Avro bytes. Supports custom `to_dict` hooks, `globalId`/`contentId` wire format selection, strict mode, and `KAFKA_HEADERS` wire format.
+- `AvroSerializer` — serializes Python data to Confluent-framed Avro bytes. Supports
+  custom `to_dict` hooks, `globalId`/`contentId` wire format selection, strict mode,
+  and `KAFKA_HEADERS` wire format.
 - `AvroDeserializer` — deserializes Confluent-framed Avro bytes back to Python dicts with optional `from_dict` hook.
 - `AsyncAvroDeserializer` — async counterpart to `AvroDeserializer`.
 - `SerializationContext` and `MessageField` — thin context objects compatible with confluent-kafka's interface.
 - `WireFormat` enum — `CONFLUENT_PAYLOAD` and `KAFKA_HEADERS` framing modes.
-- `SchemaNotFoundError`, `RegistryConnectionError`, `SerializationError`, `DeserializationError` — typed exception hierarchy for predictable error handling.
+- `SchemaNotFoundError`, `RegistryConnectionError`, `SerializationError`,
+  `DeserializationError` — typed exception hierarchy for predictable error handling.
 - `CachedSchema` — frozen (immutable) dataclass holding resolved schema data and registry metadata.
 - Closed-client guard (`RuntimeError`) on both sync and async clients to prevent use-after-close.
 - 32-bit schema ID validation for `CONFLUENT_PAYLOAD` wire format with actionable error message suggesting `KAFKA_HEADERS`.
@@ -62,7 +76,8 @@ This release focuses on improving robustness and maintainability through compreh
 
 ### Changed
 
-- **Breaking**: `AvroDeserializer` and `AsyncAvroDeserializer` `use_id` default changed from `"contentId"` to `"globalId"` to match `AvroSerializer` default (see ADR-006).
+- **Breaking**: `AvroDeserializer` and `AsyncAvroDeserializer` `use_id` default changed
+  from `"contentId"` to `"globalId"` to match `AvroSerializer` default (see ADR-006).
 
 ### Internal
 

--- a/docs/changelog.fr.md
+++ b/docs/changelog.fr.md
@@ -6,6 +6,18 @@ Toutes les modifications visibles par les utilisateurs sont documentées ici.
 
 ### Ajouts
 
+- `ApicurioRegistryClient` et `AsyncApicurioRegistryClient` effectuent désormais
+  automatiquement des nouvelles tentatives sur les défaillances transitoires. Les
+  nouvelles tentatives couvrent les `httpx.TransportError` et les codes HTTP
+  429/502/503/504, avec un délai exponentiel et full jitter. Trois nouveaux paramètres
+  de constructeur contrôlent ce comportement : `max_retries` (défaut 3),
+  `retry_backoff_ms` (défaut 1 000 ms), `retry_max_backoff_ms` (défaut 20 000 ms).
+  Définir `max_retries=0` pour désactiver.
+- Les deux clients acceptent un paramètre de fuite optionnel `http_client`
+  (`httpx.Client` / `httpx.AsyncClient`). Quand il est fourni, le client fourni est
+  utilisé tel quel et **n'est pas** fermé par `close()` / `aclose()`. Un paramètre
+  `auth` est également disponible pour les gestionnaires d'authentification
+  compatibles httpx quand le paramètre `http_client` n'est pas utilisé.
 - `AvroDeserializer` et `AsyncAvroDeserializer` acceptent un paramètre optionnel
   `reader_schema` (dict de schema Avro, défaut `None`). Quand il est fourni,
   fastavro effectue une résolution de schema Avro entre le schema d'écriture
@@ -42,27 +54,37 @@ Toutes les modifications visibles par les utilisateurs sont documentées ici.
 
 ### Durcissement des clients et déduplication
 
-Cette version se concentre sur l'amélioration de la robustesse et de la maintenabilité par le durcissement complet des clients et la déduplication du code.
+Cette version se concentre sur l'amélioration de la robustesse et de la maintenabilité
+par le durcissement complet des clients et la déduplication du code.
 
 ### Ajouts
 
-- `ApicurioRegistryClient` — client HTTP pour l'API native v3 d'Apicurio Registry avec mise en cache des schemas et accès thread-safe.
-- `AsyncApicurioRegistryClient` — équivalent asynchrone utilisant `httpx.AsyncClient`, adapté à l'utilisation concurrente de coroutines.
-- `AvroSerializer` — sérialise les données Python en octets Avro au cadrage Confluent. Prend en charge les hooks `to_dict` personnalisés, la sélection du wire format `globalId`/`contentId`, le mode strict, et le wire format `KAFKA_HEADERS`.
+- `ApicurioRegistryClient` — client HTTP pour l'API native v3 d'Apicurio Registry avec
+  mise en cache des schemas et accès thread-safe.
+- `AsyncApicurioRegistryClient` — équivalent asynchrone utilisant `httpx.AsyncClient`,
+  adapté à l'utilisation concurrente de coroutines.
+- `AvroSerializer` — sérialise les données Python en octets Avro au cadrage Confluent.
+  Prend en charge les hooks `to_dict` personnalisés, la sélection du wire format
+  `globalId`/`contentId`, le mode strict, et le wire format `KAFKA_HEADERS`.
 - `AvroDeserializer` — désérialise les octets Avro au cadrage Confluent en dicts Python avec hook `from_dict` optionnel.
 - `AsyncAvroDeserializer` — équivalent asynchrone d'`AvroDeserializer`.
 - `SerializationContext` et `MessageField` — objets de contexte légers compatibles avec l'interface de confluent-kafka.
 - Enum `WireFormat` — modes de cadrage `CONFLUENT_PAYLOAD` et `KAFKA_HEADERS`.
-- `SchemaNotFoundError`, `RegistryConnectionError`, `SerializationError`, `DeserializationError` — hiérarchie d'exceptions typées pour une gestion d'erreurs prévisible.
+- `SchemaNotFoundError`, `RegistryConnectionError`, `SerializationError`,
+  `DeserializationError` — hiérarchie d'exceptions typées pour une gestion
+  d'erreurs prévisible.
 - `CachedSchema` — dataclass gelée (immutable) contenant les données de schema résolues et les métadonnées du registry.
 - Protection contre l'utilisation d'un client fermé (`RuntimeError`) sur les clients sync et async.
-- Validation de l'identifiant de schema 32 bits pour le wire format `CONFLUENT_PAYLOAD` avec message d'erreur suggérant `KAFKA_HEADERS`.
+- Validation de l'identifiant de schema 32 bits pour le wire format `CONFLUENT_PAYLOAD`
+  avec message d'erreur suggérant `KAFKA_HEADERS`.
 - Validation de la plage int64 signé sur les `globalId`/`contentId` des en-têtes de réponse du registry.
 - 19 Architecture Decision Records dans `docs/decisions/`.
 
 ### Modifié
 
-- **Rupture** : le défaut de `use_id` d'`AvroDeserializer` et `AsyncAvroDeserializer` est passé de `"contentId"` à `"globalId"` pour correspondre au défaut d'`AvroSerializer` (voir ADR-006).
+- **Rupture** : le défaut de `use_id` d'`AvroDeserializer` et `AsyncAvroDeserializer`
+  est passé de `"contentId"` à `"globalId"` pour correspondre au défaut
+  d'`AvroSerializer` (voir ADR-006).
 
 ### Interne
 

--- a/docs/decisions/014-no-timeout-retry-configuration.md
+++ b/docs/decisions/014-no-timeout-retry-configuration.md
@@ -1,6 +1,6 @@
 # ADR-014: No timeout or retry configuration on HTTP clients
 
-**Status:** Accepted
+**Status:** Superseded by ADR-020
 **Date:** 2026-03-11
 **Context:** PR #32 review item 15 — "No timeout/retry configuration on HTTP clients"
 

--- a/docs/decisions/020-retry-with-exponential-backoff.md
+++ b/docs/decisions/020-retry-with-exponential-backoff.md
@@ -1,0 +1,67 @@
+# ADR-020: Retry with Exponential Backoff and httpx Escape Hatch
+
+**Status:** Accepted
+**Date:** 2026-03-18
+**Supersedes:** ADR-014 (No timeout or retry configuration on HTTP clients)
+
+## Context
+
+ADR-014 rejected built-in retry logic on the grounds that retry policy is
+application-specific and baking it in forces opinions on callers. However, both
+reference implementations disagree:
+
+- **Confluent Python** (`SchemaRegistryClient`): built-in retry with
+  `max.retries=3`, `retries.wait.ms=1000`, `retries.max.wait.ms=20000`,
+  exponential backoff with full jitter, retrying on 408/429/5xx.
+- **Apicurio Java** (`SchemaResolverConfig`): built-in retry with
+  `apicurio.registry.retry-count=3`, `apicurio.registry.retry-backoff-ms=300`.
+
+Additionally, the "delegate to the user" escape hatch proposed in ADR-014
+(pass a pre-configured `httpx.Client`) does not actually cover the transient
+HTTP status code case: `httpx.HTTPTransport(retries=N)` only retries on
+connection errors, not on 429/5xx responses. Users who need full retry
+coverage would have to implement the retry loop themselves — a significant
+burden for a trivially common operational concern.
+
+The set of retryable events (transport errors, 429, 502, 503, 504) is
+uncontroversial, well-established, and safe regardless of caller SLA. A user
+who wants no retries can set `max_retries=0`.
+
+## Decision
+
+1. Add `max_retries`, `retry_backoff_ms`, and `retry_max_backoff_ms`
+   keyword-only parameters to both `ApicurioRegistryClient` and
+   `AsyncApicurioRegistryClient`, with defaults matching Confluent Python
+   (`max_retries=3`, `retry_backoff_ms=1000`, `retry_max_backoff_ms=20000`).
+
+2. Implement exponential backoff with full jitter:
+   `delay = random.uniform(0, min(retry_backoff_ms * 2^attempt, retry_max_backoff_ms)) / 1000`.
+
+3. Retry on: `httpx.TransportError` (any), HTTP 429, 502, 503, 504.
+   Do **not** retry on: 4xx other than 429, 500 (ambiguous for mutations).
+
+4. Also accept an `http_client` keyword-only parameter (`httpx.Client` for
+   sync, `httpx.AsyncClient` for async) as a power-user escape hatch for
+   custom transports, connection pools, auth, and mTLS. When a user-provided
+   client is given, the library does not close it on `close()` / `aclose()`.
+
+## Rationale
+
+- Aligns with both reference implementations.
+- Retryable events are infrastructure noise, not business logic — the
+  right policy is uncontroversial for this class of errors.
+- `httpx.HTTPTransport(retries=N)` is insufficient for production use
+  (covers only connection errors, not 5xx/429).
+- `max_retries=0` fully disables retry for callers who prefer to manage
+  it themselves.
+- The `http_client` escape hatch preserves the power-user path from ADR-014's
+  revisit trigger.
+
+## Consequences
+
+- Existing clients get 3 retries by default where they previously had none.
+  On persistent registry outages, failure takes up to ~3× longer to surface.
+  This is acceptable and matches the behaviour users expect from the reference
+  implementations.
+- The `http_client` parameter enables advanced scenarios (mTLS, custom proxies,
+  service-mesh-aware auth) without the library needing to expose every knob.

--- a/docs/how-to/error-handling.en.md
+++ b/docs/how-to/error-handling.en.md
@@ -1,6 +1,7 @@
 # Error Handling
 
-`apicurio-serdes` raises specific exception types for each failure mode, plus standard Python exceptions for validation errors.
+`apicurio-serdes` raises specific exception types for each failure mode, plus standard
+Python exceptions for validation errors.
 
 ## Exception Overview
 
@@ -60,24 +61,31 @@ except RegistryConnectionError as e:
 - The URL is wrong (missing `/apis/registry/v3` path)
 - A firewall or network issue is blocking the connection
 
-**Recovery pattern — retry with backoff:**
+**Built-in retry:** Both clients retry automatically on transient failures — no
+manual retry loop is needed. Configure the retry behaviour at construction time:
 
 ```python
-import time
-from apicurio_serdes._errors import RegistryConnectionError
+from apicurio_serdes import ApicurioRegistryClient
 
-max_retries = 3
-for attempt in range(max_retries):
-    try:
-        payload = serializer(data, ctx)
-        break
-    except RegistryConnectionError:
-        if attempt == max_retries - 1:
-            raise
-        time.sleep(2 ** attempt)
+client = ApicurioRegistryClient(
+    url="http://registry:8080/apis/registry/v3",
+    group_id="my-group",
+    max_retries=3,               # default — set to 0 to disable
+    retry_backoff_ms=1000,       # base delay for the first retry (ms)
+    retry_max_backoff_ms=20000,  # maximum backoff cap (ms)
+)
 ```
 
-Note: this exception is only raised on the **first** serialization call (when the schema is fetched). Once the schema is cached, no further HTTP requests are made, so network errors cannot occur during serialization.
+Retry covers `httpx.TransportError` (network-level failure) and HTTP responses
+with status 429, 502, 503, and 504 (transient server errors). After all retries
+are exhausted, `RegistryConnectionError` is raised.
+
+**Do not** wrap calls in an additional retry loop — that would multiply the
+effective retry count and interfere with the built-in backoff.
+
+Note: this exception is only raised on the **first** serialization call (when the schema
+is fetched). Once the schema is cached, no further HTTP requests are made, so network
+errors cannot occur during serialization.
 
 ## Handling `SerializationError`
 
@@ -104,7 +112,8 @@ except SerializationError as e:
 
 ## Handling `ValueError`
 
-Raised by the underlying Avro encoder (fastavro) when the data does not match the schema. This is **not** an `apicurio-serdes` exception — it comes from fastavro directly.
+Raised by the underlying Avro encoder (fastavro) when the data does not match the schema.
+This is **not** an `apicurio-serdes` exception — it comes from fastavro directly.
 
 ```python
 try:
@@ -113,7 +122,8 @@ except ValueError as e:
     print(f"Data does not match schema: {e}")
 ```
 
-If `strict=True` is enabled on the serializer, `ValueError` is also raised when the data contains extra fields not defined in the schema.
+If `strict=True` is enabled on the serializer, `ValueError` is also raised when the data
+contains extra fields not defined in the schema.
 
 **Recovery:** Ensure the data dictionary has all required fields with the correct types.
 
@@ -140,8 +150,11 @@ except RuntimeError as e:
 
 In addition to Avro schema validation errors from fastavro, `ValueError` is raised in two new situations:
 
-- **32-bit schema ID overflow**: When using `CONFLUENT_PAYLOAD` wire format, the schema ID must fit in an unsigned 32-bit integer. If the registry-assigned ID exceeds this limit, use `WireFormat.KAFKA_HEADERS` instead.
-- **int64 range validation**: When registry response headers contain a `globalId` or `contentId` outside the signed 64-bit integer range.
+- **32-bit schema ID overflow**: When using `CONFLUENT_PAYLOAD` wire format, the schema
+  ID must fit in an unsigned 32-bit integer. If the registry-assigned ID exceeds this
+  limit, use `WireFormat.KAFKA_HEADERS` instead.
+- **int64 range validation**: When registry response headers contain a `globalId` or
+  `contentId` outside the signed 64-bit integer range.
 
 ```python
 try:
@@ -153,9 +166,11 @@ except ValueError as e:
         print(f"Data does not match schema: {e}")
 ```
 
-If `strict=True` is enabled on the serializer, `ValueError` is also raised when the data contains extra fields not defined in the schema.
+If `strict=True` is enabled on the serializer, `ValueError` is also raised when the data
+contains extra fields not defined in the schema.
 
-**Recovery:** Ensure the data dictionary has all required fields with the correct types, or switch wire format for large schema IDs.
+**Recovery:** Ensure the data dictionary has all required fields with the correct types,
+or switch wire format for large schema IDs.
 
 ## Putting It All Together
 

--- a/docs/how-to/error-handling.fr.md
+++ b/docs/how-to/error-handling.fr.md
@@ -1,6 +1,7 @@
 # Gestion des erreurs
 
-`apicurio-serdes` lève des types d'exceptions spécifiques pour chaque mode de défaillance, ainsi que des exceptions Python standard pour les erreurs de validation.
+`apicurio-serdes` lève des types d'exceptions spécifiques pour chaque mode de défaillance,
+ainsi que des exceptions Python standard pour les erreurs de validation.
 
 ## Vue d'ensemble des exceptions
 
@@ -60,24 +61,34 @@ except RegistryConnectionError as e:
 - L'URL est incorrecte (chemin `/apis/registry/v3` manquant)
 - Un pare-feu ou un problème réseau bloque la connexion
 
-**Stratégie de récupération — nouvelle tentative avec délai exponentiel :**
+**Nouvelle tentative intégrée :** Les deux clients effectuent automatiquement des
+nouvelles tentatives sur les défaillances transitoires — aucune boucle de nouvelle
+tentative manuelle n'est nécessaire. Configurez ce comportement à la construction :
 
 ```python
-import time
-from apicurio_serdes._errors import RegistryConnectionError
+from apicurio_serdes import ApicurioRegistryClient
 
-max_retries = 3
-for attempt in range(max_retries):
-    try:
-        payload = serializer(data, ctx)
-        break
-    except RegistryConnectionError:
-        if attempt == max_retries - 1:
-            raise
-        time.sleep(2 ** attempt)
+client = ApicurioRegistryClient(
+    url="http://registry:8080/apis/registry/v3",
+    group_id="my-group",
+    max_retries=3,               # défaut — mettre à 0 pour désactiver
+    retry_backoff_ms=1000,       # délai de base pour la première tentative (ms)
+    retry_max_backoff_ms=20000,  # délai maximum (ms)
+)
 ```
 
-Remarque : cette exception n'est levée que lors du **premier** appel de sérialisation (lorsque le schema est récupéré). Une fois le schema mis en cache, aucune requête HTTP supplémentaire n'est effectuée, les erreurs réseau ne peuvent donc pas survenir pendant la sérialisation.
+Les nouvelles tentatives couvrent les `httpx.TransportError` (échec au niveau réseau)
+et les réponses HTTP avec les codes 429, 502, 503 et 504 (erreurs serveur transitoires).
+Une fois toutes les tentatives épuisées, `RegistryConnectionError` est levée.
+
+**N'encapsulez pas** les appels dans une boucle de nouvelle tentative supplémentaire —
+cela multiplierait le nombre effectif de tentatives et interférerait avec le délai
+exponentiel intégré.
+
+Remarque : cette exception n'est levée que lors du **premier** appel de sérialisation
+(lorsque le schema est récupéré). Une fois le schema mis en cache, aucune requête HTTP
+supplémentaire n'est effectuée, les erreurs réseau ne peuvent donc pas survenir pendant
+la sérialisation.
 
 ## Gérer `SerializationError`
 
@@ -100,11 +111,14 @@ except SerializationError as e:
 - Le callable a tenté d'accéder à un attribut inexistant sur l'objet en entrée
 - Une erreur de validation Pydantic s'est produite dans `model_dump()`
 
-**Récupération :** Corrigez l'implémentation de `to_dict` ou validez les données en entrée avant la sérialisation.
+**Récupération :** Corrigez l'implémentation de `to_dict` ou validez les données en
+entrée avant la sérialisation.
 
 ## Gérer `ValueError`
 
-Levée par l'encodeur Avro sous-jacent (fastavro) lorsque les données ne correspondent pas au schema. Ce n'est **pas** une exception `apicurio-serdes` — elle provient directement de fastavro.
+Levée par l'encodeur Avro sous-jacent (fastavro) lorsque les données ne correspondent
+pas au schema. Ce n'est **pas** une exception `apicurio-serdes` — elle provient
+directement de fastavro.
 
 ```python
 try:
@@ -113,9 +127,11 @@ except ValueError as e:
     print(f"Data does not match schema: {e}")
 ```
 
-Si `strict=True` est activé sur le serializer, `ValueError` est également levée lorsque les données contiennent des champs supplémentaires non définis dans le schema.
+Si `strict=True` est activé sur le serializer, `ValueError` est également levée lorsque
+les données contiennent des champs supplémentaires non définis dans le schema.
 
-**Récupération :** Assurez-vous que le dictionnaire de données possède tous les champs requis avec les types corrects.
+**Récupération :** Assurez-vous que le dictionnaire de données possède tous les champs
+requis avec les types corrects.
 
 ## Gérer `RuntimeError` (client fermé)
 
@@ -131,17 +147,25 @@ except RuntimeError as e:
 
 **Causes fréquentes :**
 
-- Appeler `close()` ou sortir d'un gestionnaire de contexte, puis réutiliser le même client
+- Appeler `close()` ou sortir d'un gestionnaire de contexte, puis réutiliser le même
+  client
 - Partager un client entre threads/coroutines où un chemin le ferme prématurément
 
-**Récupération :** Créez une nouvelle instance d'`ApicurioRegistryClient` ou d'`AsyncApicurioRegistryClient`.
+**Récupération :** Créez une nouvelle instance d'`ApicurioRegistryClient` ou
+d'`AsyncApicurioRegistryClient`.
 
 ## Gérer `ValueError` (validation)
 
-En plus des erreurs de validation de schema Avro provenant de fastavro, `ValueError` est levée dans deux nouvelles situations :
+En plus des erreurs de validation de schema Avro provenant de fastavro, `ValueError` est
+levée dans deux nouvelles situations :
 
-- **Dépassement de l'identifiant de schema 32 bits** : avec le wire format `CONFLUENT_PAYLOAD`, l'identifiant de schema doit tenir dans un entier non signé de 32 bits. Si l'identifiant attribué par le registry dépasse cette limite, utilisez `WireFormat.KAFKA_HEADERS` à la place.
-- **Validation de la plage int64** : lorsque les en-têtes de réponse du registry contiennent un `globalId` ou `contentId` en dehors de la plage d'entiers signés de 64 bits.
+- **Dépassement de l'identifiant de schema 32 bits** : avec le wire format
+  `CONFLUENT_PAYLOAD`, l'identifiant de schema doit tenir dans un entier non signé de
+  32 bits. Si l'identifiant attribué par le registry dépasse cette limite, utilisez
+  `WireFormat.KAFKA_HEADERS` à la place.
+- **Validation de la plage int64** : lorsque les en-têtes de réponse du registry
+  contiennent un `globalId` ou `contentId` en dehors de la plage d'entiers signés de
+  64 bits.
 
 ```python
 try:
@@ -153,9 +177,12 @@ except ValueError as e:
         print(f"Les données ne correspondent pas au schema : {e}")
 ```
 
-Si `strict=True` est activé sur le serializer, `ValueError` est également levée lorsque les données contiennent des champs supplémentaires non définis dans le schema.
+Si `strict=True` est activé sur le serializer, `ValueError` est également levée lorsque
+les données contiennent des champs supplémentaires non définis dans le schema.
 
-**Récupération :** Assurez-vous que le dictionnaire de données possède tous les champs requis avec les types corrects, ou changez de wire format pour les grands identifiants de schema.
+**Récupération :** Assurez-vous que le dictionnaire de données possède tous les champs
+requis avec les types corrects, ou changez de wire format pour les grands identifiants
+de schema.
 
 ## Tout assembler
 

--- a/docs/user-guide/async-client.fr.md
+++ b/docs/user-guide/async-client.fr.md
@@ -85,7 +85,7 @@ async def produce(request):
 | Récupération de schema | `client.get_schema(id)` | `await client.get_schema(id)` |
 | Enregistrement de schema | `client.register_schema(id, schema)` | `await client.register_schema(id, schema)` |
 | Type de retour | `CachedSchema` | `CachedSchema` (même classe) |
-| Paramètres du constructeur | `url`, `group_id` | `url`, `group_id` (identiques) |
+| Paramètres du constructeur | `url`, `group_id`, `max_retries`, `retry_backoff_ms`, `retry_max_backoff_ms`, `http_client`, `auth` | identiques |
 | Sécurité du cache | `threading.RLock` | `asyncio.Lock` |
 | Nettoyage | (GC automatique) | `async with` ou `await client.aclose()` |
 | Erreurs | `SchemaNotFoundError`, `RegistryConnectionError` | Mêmes types d'erreurs |

--- a/docs/user-guide/async-client.md
+++ b/docs/user-guide/async-client.md
@@ -85,7 +85,7 @@ async def produce(request):
 | Schema fetch | `client.get_schema(id)` | `await client.get_schema(id)` |
 | Schema registration | `client.register_schema(id, schema)` | `await client.register_schema(id, schema)` |
 | Return type | `CachedSchema` | `CachedSchema` (same class) |
-| Constructor params | `url`, `group_id` | `url`, `group_id` (identical) |
+| Constructor params | `url`, `group_id`, `max_retries`, `retry_backoff_ms`, `retry_max_backoff_ms`, `http_client`, `auth` | identical |
 | Cache safety | `threading.RLock` | `asyncio.Lock` |
 | Cleanup | (automatic GC) | `async with` or `await client.aclose()` |
 | Errors | `SchemaNotFoundError`, `RegistryConnectionError` | Same error types |

--- a/src/apicurio_serdes/_async_client.py
+++ b/src/apicurio_serdes/_async_client.py
@@ -7,7 +7,7 @@ from typing import TYPE_CHECKING, Any
 
 import httpx
 
-from apicurio_serdes._base import CachedSchema, _RegistryClientBase
+from apicurio_serdes._base import CachedSchema, _RETRYABLE_STATUSES, _RegistryClientBase
 from apicurio_serdes._errors import RegistryConnectionError
 
 if TYPE_CHECKING:
@@ -19,26 +19,85 @@ class AsyncApicurioRegistryClient(_RegistryClientBase):
 
     Non-blocking counterpart to ApicurioRegistryClient. Uses
     httpx.AsyncClient for async I/O. Safe for concurrent use
-    from multiple coroutines within the same event loop.
+    from multiple coroutines within the same event loop. Includes
+    automatic retry on transient failures.
 
     Args:
         url: Base URL of the Apicurio Registry v3 API.
              Example: "http://registry:8080/apis/registry/v3"
         group_id: Schema group identifier. Applied to every
                   schema lookup made by this client instance.
-        auth: Optional httpx authentication handler. Pass a
-              :class:`~apicurio_serdes.BearerAuth` or
-              :class:`~apicurio_serdes.KeycloakAuth` instance for
-              authenticated registries. Defaults to ``None`` (no auth).
+        max_retries: Maximum number of retry attempts on transient
+                     failures (transport errors and HTTP 429/502/503/504).
+                     Defaults to 3. Set to 0 to disable retries.
+        retry_backoff_ms: Base backoff delay in milliseconds for the first
+                          retry. Subsequent retries use exponential backoff
+                          with full jitter. Defaults to 1000.
+        retry_max_backoff_ms: Maximum backoff delay cap in milliseconds.
+                              Defaults to 20000.
+        http_client: Optional pre-configured ``httpx.AsyncClient`` to use
+                     for all HTTP requests. When provided, the client is
+                     used as-is and will **not** be closed by :meth:`aclose`.
+                     When ``None`` (default), a new ``httpx.AsyncClient`` is
+                     created and managed internally.
+        auth: Optional httpx-compatible authentication handler. Ignored
+              when ``http_client`` is provided.
 
     Raises:
-        ValueError: If url or group_id is empty.
+        ValueError: If url or group_id is empty, or max_retries < 0.
     """
 
-    def __init__(self, url: str, group_id: str, auth: httpx.Auth | None = None) -> None:
-        super().__init__(url, group_id)
-        self._http_client = httpx.AsyncClient(base_url=url, auth=auth)
+    def __init__(
+        self,
+        url: str,
+        group_id: str,
+        *,
+        max_retries: int = 3,
+        retry_backoff_ms: int = 1000,
+        retry_max_backoff_ms: int = 20000,
+        http_client: httpx.AsyncClient | None = None,
+        auth: Any = None,
+    ) -> None:
+        super().__init__(
+            url,
+            group_id,
+            max_retries=max_retries,
+            retry_backoff_ms=retry_backoff_ms,
+            retry_max_backoff_ms=retry_max_backoff_ms,
+        )
+        self._owns_http_client = http_client is None
+        self._http_client = (
+            http_client
+            if http_client is not None
+            else httpx.AsyncClient(base_url=url, auth=auth)
+        )
         self._lock = asyncio.Lock()
+
+    async def _http_request(
+        self, method: str, url: str, **kwargs: Any
+    ) -> httpx.Response:
+        """Execute an HTTP request with retry on transient failures (async).
+
+        Retries on ``httpx.TransportError`` and on responses with status
+        codes in ``_RETRYABLE_STATUSES`` (429, 502, 503, 504).
+        Uses exponential backoff with full jitter between attempts.
+        """
+        delays = self._retry_delays()
+        while True:
+            try:
+                response = await self._http_client.request(method, url, **kwargs)
+            except httpx.TransportError as exc:
+                delay = next(delays, None)
+                if delay is None:
+                    raise RegistryConnectionError(self.url, exc) from exc
+                await asyncio.sleep(delay)
+                continue
+            if response.status_code in _RETRYABLE_STATUSES:
+                delay = next(delays, None)
+                if delay is not None:
+                    await asyncio.sleep(delay)
+                    continue
+            return response
 
     async def get_schema(self, artifact_id: str) -> CachedSchema:
         """Retrieve an Avro schema by artifact ID (async).
@@ -57,7 +116,7 @@ class AsyncApicurioRegistryClient(_RegistryClientBase):
         Raises:
             SchemaNotFoundError: If the artifact does not exist (HTTP 404).
             RegistryConnectionError: If the registry is unreachable or returns
-                an unexpected HTTP status code.
+                a persistent error after all retries are exhausted.
             RuntimeError: If the client has been closed.
         """
         self._check_closed()
@@ -69,13 +128,9 @@ class AsyncApicurioRegistryClient(_RegistryClientBase):
             if cache_key in self._schema_cache:
                 return self._schema_cache[cache_key]
 
-            try:
-                response = await self._http_client.get(
-                    self._schema_endpoint(artifact_id)
-                )
-            except httpx.TransportError as exc:
-                raise RegistryConnectionError(self.url, exc) from exc
-
+            response = await self._http_request(
+                "GET", self._schema_endpoint(artifact_id)
+            )
             cached = self._process_schema_response(response, artifact_id)
             self._schema_cache[cache_key] = cached
             return cached
@@ -154,15 +209,12 @@ class AsyncApicurioRegistryClient(_RegistryClientBase):
         async with self._lock:
             if cache_key in self._schema_cache:
                 return self._schema_cache[cache_key]
-            try:
-                response = await self._http_client.post(
-                    self._register_endpoint(),
-                    json=self._register_body(artifact_id, schema),
-                    params={"ifExists": if_exists},
-                )
-            except httpx.TransportError as exc:
-                raise RegistryConnectionError(self.url, exc) from exc
-
+            response = await self._http_request(
+                "POST",
+                self._register_endpoint(),
+                json=self._register_body(artifact_id, schema),
+                params={"ifExists": if_exists},
+            )
             cached = self._process_registration_response(response, artifact_id, schema)
             self._schema_cache[cache_key] = cached
             return cached
@@ -178,13 +230,9 @@ class AsyncApicurioRegistryClient(_RegistryClientBase):
             if cache_key in self._id_cache:
                 return self._id_cache[cache_key]
 
-            try:
-                response = await self._http_client.get(
-                    self._id_endpoint(id_type, id_value)
-                )
-            except httpx.TransportError as exc:
-                raise RegistryConnectionError(self.url, exc) from exc
-
+            response = await self._http_request(
+                "GET", self._id_endpoint(id_type, id_value)
+            )
             schema = self._process_id_response(response, id_type, id_value)
             self._id_cache[cache_key] = schema
             return schema
@@ -194,9 +242,12 @@ class AsyncApicurioRegistryClient(_RegistryClientBase):
 
         Call this when the client is no longer needed and you are not
         using it as an async context manager. Safe to call multiple times.
+        When a custom ``http_client`` was provided at construction, it
+        is **not** closed — the caller retains ownership.
         """
         self._closed = True
-        await self._http_client.aclose()
+        if self._owns_http_client:
+            await self._http_client.aclose()
 
     async def __aenter__(self) -> AsyncApicurioRegistryClient:
         """Enter the async context manager. Returns self."""

--- a/src/apicurio_serdes/_async_client.py
+++ b/src/apicurio_serdes/_async_client.py
@@ -7,7 +7,7 @@ from typing import TYPE_CHECKING, Any
 
 import httpx
 
-from apicurio_serdes._base import CachedSchema, _RETRYABLE_STATUSES, _RegistryClientBase
+from apicurio_serdes._base import _RETRYABLE_STATUSES, CachedSchema, _RegistryClientBase
 from apicurio_serdes._errors import RegistryConnectionError
 
 if TYPE_CHECKING:

--- a/src/apicurio_serdes/_base.py
+++ b/src/apicurio_serdes/_base.py
@@ -3,6 +3,8 @@
 from __future__ import annotations
 
 import json
+import random
+from collections.abc import Iterator
 from dataclasses import dataclass
 from typing import Any
 
@@ -13,6 +15,10 @@ from apicurio_serdes._errors import (
     SchemaNotFoundError,
     SchemaRegistrationError,
 )
+
+# HTTP status codes that indicate a transient server-side condition safe to retry.
+# 500 is excluded: ambiguous for mutations (server may have processed the request).
+_RETRYABLE_STATUSES: frozenset[int] = frozenset({429, 502, 503, 504})
 
 
 @dataclass(frozen=True)
@@ -38,13 +44,26 @@ class _RegistryClientBase:
     ``self._closed = True`` inside their own ``close()`` / ``aclose()``.
     """
 
-    def __init__(self, url: str, group_id: str) -> None:
+    def __init__(
+        self,
+        url: str,
+        group_id: str,
+        *,
+        max_retries: int = 3,
+        retry_backoff_ms: int = 1000,
+        retry_max_backoff_ms: int = 20000,
+    ) -> None:
         if not url:
             raise ValueError("url must not be empty")
         if not group_id:
             raise ValueError("group_id must not be empty")
+        if max_retries < 0:
+            raise ValueError(f"max_retries must be >= 0, got {max_retries}")
         self.url = url
         self.group_id = group_id
+        self.max_retries = max_retries
+        self.retry_backoff_ms = retry_backoff_ms
+        self.retry_max_backoff_ms = retry_max_backoff_ms
         self._schema_cache: dict[tuple[str, str], CachedSchema] = {}
         self._id_cache: dict[tuple[str, int], dict[str, Any]] = {}
         self._closed = False
@@ -61,6 +80,19 @@ class _RegistryClientBase:
     @staticmethod
     def _id_endpoint(id_type: str, id_value: int) -> str:
         return f"/ids/{id_type}s/{id_value}"
+
+    def _compute_delay(self, attempt: int) -> float:
+        """Full-jitter exponential backoff in seconds.
+
+        delay = random(0, min(retry_backoff_ms * 2^attempt, retry_max_backoff_ms)) / 1000
+        """
+        cap = min(self.retry_backoff_ms * (2**attempt), self.retry_max_backoff_ms)
+        return random.uniform(0, cap) / 1000.0
+
+    def _retry_delays(self) -> Iterator[float]:
+        """Yield one delay (seconds) per retry attempt, up to max_retries values."""
+        for attempt in range(self.max_retries):
+            yield self._compute_delay(attempt)
 
     def _process_schema_response(
         self, response: httpx.Response, artifact_id: str

--- a/src/apicurio_serdes/_base.py
+++ b/src/apicurio_serdes/_base.py
@@ -4,9 +4,11 @@ from __future__ import annotations
 
 import json
 import random
-from collections.abc import Iterator
 from dataclasses import dataclass
-from typing import Any
+from typing import TYPE_CHECKING, Any
+
+if TYPE_CHECKING:
+    from collections.abc import Iterator
 
 import httpx
 
@@ -84,7 +86,8 @@ class _RegistryClientBase:
     def _compute_delay(self, attempt: int) -> float:
         """Full-jitter exponential backoff in seconds.
 
-        delay = random(0, min(retry_backoff_ms * 2^attempt, retry_max_backoff_ms)) / 1000
+        delay = random(0, min(retry_backoff_ms * 2^attempt, retry_max_backoff_ms))
+                / 1000
         """
         cap = min(self.retry_backoff_ms * (2**attempt), self.retry_max_backoff_ms)
         return random.uniform(0, cap) / 1000.0

--- a/src/apicurio_serdes/_client.py
+++ b/src/apicurio_serdes/_client.py
@@ -2,13 +2,13 @@
 
 from __future__ import annotations
 
-import time
 import threading
+import time
 from typing import TYPE_CHECKING, Any
 
 import httpx
 
-from apicurio_serdes._base import CachedSchema, _RETRYABLE_STATUSES, _RegistryClientBase
+from apicurio_serdes._base import _RETRYABLE_STATUSES, CachedSchema, _RegistryClientBase
 from apicurio_serdes._errors import RegistryConnectionError
 
 if TYPE_CHECKING:

--- a/src/apicurio_serdes/_client.py
+++ b/src/apicurio_serdes/_client.py
@@ -2,12 +2,13 @@
 
 from __future__ import annotations
 
+import time
 import threading
 from typing import TYPE_CHECKING, Any
 
 import httpx
 
-from apicurio_serdes._base import CachedSchema, _RegistryClientBase
+from apicurio_serdes._base import CachedSchema, _RETRYABLE_STATUSES, _RegistryClientBase
 from apicurio_serdes._errors import RegistryConnectionError
 
 if TYPE_CHECKING:
@@ -21,20 +22,33 @@ class ApicurioRegistryClient(_RegistryClientBase):
     """HTTP client for the Apicurio Registry v3 native API.
 
     Handles schema retrieval by group_id / artifact_id with
-    built-in caching. Thread-safe for read operations.
+    built-in caching and automatic retry on transient failures.
+    Thread-safe for read operations.
 
     Args:
         url: Base URL of the Apicurio Registry v3 API.
              Example: ``"http://registry:8080/apis/registry/v3"``.
         group_id: Schema group identifier. Applied to every
                   schema lookup made by this client instance.
-        auth: Optional httpx authentication handler. Pass a
-              :class:`~apicurio_serdes.BearerAuth` or
-              :class:`~apicurio_serdes.KeycloakAuth` instance for
-              authenticated registries. Defaults to ``None`` (no auth).
+        max_retries: Maximum number of retry attempts on transient
+                     failures (transport errors and HTTP 429/502/503/504).
+                     Defaults to 3. Set to 0 to disable retries.
+        retry_backoff_ms: Base backoff delay in milliseconds for the first
+                          retry. Subsequent retries use exponential backoff
+                          with full jitter. Defaults to 1000.
+        retry_max_backoff_ms: Maximum backoff delay cap in milliseconds.
+                              Defaults to 20000.
+        http_client: Optional pre-configured ``httpx.Client`` to use for
+                     all HTTP requests. When provided, the client is used
+                     as-is and will **not** be closed by :meth:`close`.
+                     Use this to configure custom timeouts, proxies, mTLS,
+                     or transport-level retry. When ``None`` (default), a
+                     new ``httpx.Client`` is created and managed internally.
+        auth: Optional httpx-compatible authentication handler (e.g.
+              ``BearerAuth``). Ignored when ``http_client`` is provided.
 
     Raises:
-        ValueError: If *url* or *group_id* is empty.
+        ValueError: If *url* or *group_id* is empty, or *max_retries* < 0.
 
     Example:
         ```python
@@ -48,10 +62,55 @@ class ApicurioRegistryClient(_RegistryClientBase):
         ```
     """
 
-    def __init__(self, url: str, group_id: str, auth: httpx.Auth | None = None) -> None:
-        super().__init__(url, group_id)
-        self._http_client = httpx.Client(base_url=url, auth=auth)
+    def __init__(
+        self,
+        url: str,
+        group_id: str,
+        *,
+        max_retries: int = 3,
+        retry_backoff_ms: int = 1000,
+        retry_max_backoff_ms: int = 20000,
+        http_client: httpx.Client | None = None,
+        auth: Any = None,
+    ) -> None:
+        super().__init__(
+            url,
+            group_id,
+            max_retries=max_retries,
+            retry_backoff_ms=retry_backoff_ms,
+            retry_max_backoff_ms=retry_max_backoff_ms,
+        )
+        self._owns_http_client = http_client is None
+        self._http_client = (
+            http_client
+            if http_client is not None
+            else httpx.Client(base_url=url, auth=auth)
+        )
         self._lock = threading.RLock()
+
+    def _http_request(self, method: str, url: str, **kwargs: Any) -> httpx.Response:
+        """Execute an HTTP request with retry on transient failures.
+
+        Retries on ``httpx.TransportError`` and on responses with status
+        codes in ``_RETRYABLE_STATUSES`` (429, 502, 503, 504).
+        Uses exponential backoff with full jitter between attempts.
+        """
+        delays = self._retry_delays()
+        while True:
+            try:
+                response = self._http_client.request(method, url, **kwargs)
+            except httpx.TransportError as exc:
+                delay = next(delays, None)
+                if delay is None:
+                    raise RegistryConnectionError(self.url, exc) from exc
+                time.sleep(delay)
+                continue
+            if response.status_code in _RETRYABLE_STATUSES:
+                delay = next(delays, None)
+                if delay is not None:
+                    time.sleep(delay)
+                    continue
+            return response
 
     def get_schema(self, artifact_id: str) -> CachedSchema:
         """Retrieve an Avro schema by artifact ID.
@@ -67,7 +126,8 @@ class ApicurioRegistryClient(_RegistryClientBase):
 
         Raises:
             SchemaNotFoundError: If the artifact does not exist (HTTP 404).
-            RegistryConnectionError: If the registry is unreachable.
+            RegistryConnectionError: If the registry is unreachable or returns
+                a persistent error after all retries are exhausted.
             RuntimeError: If the client has been closed.
         """
         self._check_closed()
@@ -80,11 +140,7 @@ class ApicurioRegistryClient(_RegistryClientBase):
             if cache_key in self._schema_cache:
                 return self._schema_cache[cache_key]
 
-            try:
-                response = self._http_client.get(self._schema_endpoint(artifact_id))
-            except httpx.TransportError as exc:
-                raise RegistryConnectionError(self.url, exc) from exc
-
+            response = self._http_request("GET", self._schema_endpoint(artifact_id))
             cached = self._process_schema_response(response, artifact_id)
             self._schema_cache[cache_key] = cached
             return cached
@@ -165,15 +221,12 @@ class ApicurioRegistryClient(_RegistryClientBase):
         with self._lock:
             if cache_key in self._schema_cache:
                 return self._schema_cache[cache_key]
-            try:
-                response = self._http_client.post(
-                    self._register_endpoint(),
-                    json=self._register_body(artifact_id, schema),
-                    params={"ifExists": if_exists},
-                )
-            except httpx.TransportError as exc:
-                raise RegistryConnectionError(self.url, exc) from exc
-
+            response = self._http_request(
+                "POST",
+                self._register_endpoint(),
+                json=self._register_body(artifact_id, schema),
+                params={"ifExists": if_exists},
+            )
             cached = self._process_registration_response(response, artifact_id, schema)
             self._schema_cache[cache_key] = cached
             return cached
@@ -189,11 +242,7 @@ class ApicurioRegistryClient(_RegistryClientBase):
             if cache_key in self._id_cache:
                 return self._id_cache[cache_key]
 
-            try:
-                response = self._http_client.get(self._id_endpoint(id_type, id_value))
-            except httpx.TransportError as exc:
-                raise RegistryConnectionError(self.url, exc) from exc
-
+            response = self._http_request("GET", self._id_endpoint(id_type, id_value))
             schema = self._process_id_response(response, id_type, id_value)
             self._id_cache[cache_key] = schema
             return schema
@@ -203,9 +252,12 @@ class ApicurioRegistryClient(_RegistryClientBase):
 
         Call this when the client is no longer needed and you are not
         using it as a context manager. Safe to call multiple times.
+        When a custom ``http_client`` was provided at construction, it
+        is **not** closed — the caller retains ownership.
         """
         self._closed = True
-        self._http_client.close()
+        if self._owns_http_client:
+            self._http_client.close()
 
     def __enter__(self) -> ApicurioRegistryClient:
         """Enter the context manager. Returns self."""

--- a/tests/test_async_client.py
+++ b/tests/test_async_client.py
@@ -790,3 +790,366 @@ async def test_async_client_accepts_bearer_auth(
     )
     await client.get_schema("Auth")
     assert route.calls[0].request.headers["authorization"] == "Bearer async-wire"
+
+
+# ── Retry and escape hatch tests (#37) ──
+
+
+from unittest.mock import AsyncMock, MagicMock, patch
+
+
+def _async_flaky_schema_handler(n_failures: int) -> Any:
+    """Side-effect: raises ConnectError n_failures times, then returns 200."""
+    count = 0
+
+    def _handler(request: httpx.Request) -> httpx.Response:
+        nonlocal count
+        count += 1
+        if count <= n_failures:
+            raise httpx.ConnectError("transient failure")
+        return httpx.Response(
+            200,
+            content=json.dumps(USER_EVENT_SCHEMA_JSON).encode(),
+            headers={
+                "X-Registry-GlobalId": str(GLOBAL_ID),
+                "X-Registry-ContentId": str(CONTENT_ID),
+            },
+        )
+
+    return _handler
+
+
+def _async_flaky_status_schema_handler(fail_status: int, n_failures: int) -> Any:
+    """Side-effect: returns fail_status n_failures times, then returns 200."""
+    count = 0
+
+    def _handler(request: httpx.Request) -> httpx.Response:
+        nonlocal count
+        count += 1
+        if count <= n_failures:
+            return httpx.Response(fail_status)
+        return httpx.Response(
+            200,
+            content=json.dumps(USER_EVENT_SCHEMA_JSON).encode(),
+            headers={
+                "X-Registry-GlobalId": str(GLOBAL_ID),
+                "X-Registry-ContentId": str(CONTENT_ID),
+            },
+        )
+
+    return _handler
+
+
+def _async_flaky_id_handler(n_failures: int) -> Any:
+    """Side-effect: ConnectError n times then valid schema response (ID endpoint)."""
+    count = 0
+
+    def _handler(request: httpx.Request) -> httpx.Response:
+        nonlocal count
+        count += 1
+        if count <= n_failures:
+            raise httpx.ConnectError("transient failure")
+        return httpx.Response(200, content=json.dumps(USER_EVENT_SCHEMA_JSON).encode())
+
+    return _handler
+
+
+def _async_flaky_register_handler(n_failures: int) -> Any:
+    """Side-effect: ConnectError n times then valid register response."""
+    count = 0
+
+    def _handler(request: httpx.Request) -> httpx.Response:
+        nonlocal count
+        count += 1
+        if count <= n_failures:
+            raise httpx.ConnectError("transient failure")
+        return httpx.Response(
+            200,
+            json={
+                "artifact": {
+                    "groupId": GROUP_ID,
+                    "artifactId": "UserEvent",
+                    "artifactType": "AVRO",
+                },
+                "version": {
+                    "globalId": GLOBAL_ID,
+                    "contentId": CONTENT_ID,
+                    "artifactType": "AVRO",
+                },
+            },
+        )
+
+    return _handler
+
+
+# Constructor parameter tests
+
+
+def test_async_init_default_max_retries() -> None:
+    """Default max_retries is 3."""
+    client = AsyncApicurioRegistryClient(url=REGISTRY_URL, group_id=GROUP_ID)
+    assert client.max_retries == 3
+
+
+def test_async_init_default_retry_backoff_ms() -> None:
+    """Default retry_backoff_ms is 1000."""
+    client = AsyncApicurioRegistryClient(url=REGISTRY_URL, group_id=GROUP_ID)
+    assert client.retry_backoff_ms == 1000
+
+
+def test_async_init_default_retry_max_backoff_ms() -> None:
+    """Default retry_max_backoff_ms is 20000."""
+    client = AsyncApicurioRegistryClient(url=REGISTRY_URL, group_id=GROUP_ID)
+    assert client.retry_max_backoff_ms == 20000
+
+
+def test_async_init_max_retries_zero_valid() -> None:
+    """max_retries=0 is valid."""
+    client = AsyncApicurioRegistryClient(
+        url=REGISTRY_URL, group_id=GROUP_ID, max_retries=0
+    )
+    assert client.max_retries == 0
+
+
+def test_async_init_max_retries_negative_raises_value_error() -> None:
+    """max_retries=-1 raises ValueError."""
+    with pytest.raises(ValueError, match="max_retries"):
+        AsyncApicurioRegistryClient(
+            url=REGISTRY_URL, group_id=GROUP_ID, max_retries=-1
+        )
+
+
+def test_async_init_signature_matches_sync() -> None:
+    """Async and sync client __init__ have the same parameter names."""
+    import inspect
+
+    from apicurio_serdes import ApicurioRegistryClient
+
+    sync_params = set(inspect.signature(ApicurioRegistryClient.__init__).parameters) - {
+        "self"
+    }
+    async_params = set(
+        inspect.signature(AsyncApicurioRegistryClient.__init__).parameters
+    ) - {"self"}
+    assert sync_params == async_params
+
+
+# Retry on transport error
+
+
+async def test_async_get_schema_retries_on_connect_error_then_succeeds(
+    mock_registry: respx.MockRouter,
+) -> None:
+    """ConnectError on first attempt retried; schema returned on second attempt."""
+    url = f"{REGISTRY_URL}/groups/{GROUP_ID}/artifacts/UserEvent/versions/latest/content"
+    mock_registry.get(url).mock(side_effect=_async_flaky_schema_handler(1))
+    client = AsyncApicurioRegistryClient(url=REGISTRY_URL, group_id=GROUP_ID)
+    with patch(
+        "apicurio_serdes._async_client.asyncio.sleep", new_callable=AsyncMock
+    ):
+        result = await client.get_schema("UserEvent")
+    assert result.schema == USER_EVENT_SCHEMA_JSON
+
+
+async def test_async_get_schema_exhausts_retries_raises_connection_error(
+    mock_registry: respx.MockRouter,
+) -> None:
+    """All attempts fail; RegistryConnectionError raised after max_retries exhausted."""
+    from apicurio_serdes._errors import RegistryConnectionError
+
+    url = f"{REGISTRY_URL}/groups/{GROUP_ID}/artifacts/UserEvent/versions/latest/content"
+    route = mock_registry.get(url).mock(side_effect=_async_flaky_schema_handler(99))
+    client = AsyncApicurioRegistryClient(
+        url=REGISTRY_URL, group_id=GROUP_ID, max_retries=2
+    )
+    with patch(
+        "apicurio_serdes._async_client.asyncio.sleep", new_callable=AsyncMock
+    ):
+        with pytest.raises(RegistryConnectionError):
+            await client.get_schema("UserEvent")
+    assert route.call_count == 3
+
+
+async def test_async_get_schema_by_global_id_retries_on_connect_error(
+    mock_registry: respx.MockRouter,
+) -> None:
+    """ID lookup retried on ConnectError."""
+    mock_registry.get(
+        url__startswith=f"{REGISTRY_URL}/ids/globalIds/"
+    ).mock(side_effect=_async_flaky_id_handler(1))
+    client = AsyncApicurioRegistryClient(url=REGISTRY_URL, group_id=GROUP_ID)
+    with patch(
+        "apicurio_serdes._async_client.asyncio.sleep", new_callable=AsyncMock
+    ):
+        result = await client.get_schema_by_global_id(GLOBAL_ID)
+    assert result == USER_EVENT_SCHEMA_JSON
+
+
+async def test_async_register_schema_retries_on_connect_error(
+    mock_registry: respx.MockRouter,
+) -> None:
+    """register_schema retried on ConnectError."""
+    mock_registry.post(
+        url__startswith=f"{REGISTRY_URL}/groups/"
+    ).mock(side_effect=_async_flaky_register_handler(1))
+    client = AsyncApicurioRegistryClient(url=REGISTRY_URL, group_id=GROUP_ID)
+    with patch(
+        "apicurio_serdes._async_client.asyncio.sleep", new_callable=AsyncMock
+    ):
+        result = await client.register_schema("UserEvent", USER_EVENT_SCHEMA_JSON)
+    assert result.global_id == GLOBAL_ID
+
+
+# Retry on retryable HTTP status codes
+
+
+@pytest.mark.parametrize("fail_status", [429, 502, 503, 504])
+async def test_async_get_schema_retries_on_retryable_status(
+    mock_registry: respx.MockRouter, fail_status: int
+) -> None:
+    """Schema GET retried on 429/502/503/504."""
+    url = f"{REGISTRY_URL}/groups/{GROUP_ID}/artifacts/UserEvent/versions/latest/content"
+    mock_registry.get(url).mock(
+        side_effect=_async_flaky_status_schema_handler(fail_status, 1)
+    )
+    client = AsyncApicurioRegistryClient(url=REGISTRY_URL, group_id=GROUP_ID)
+    with patch(
+        "apicurio_serdes._async_client.asyncio.sleep", new_callable=AsyncMock
+    ):
+        result = await client.get_schema("UserEvent")
+    assert result.schema == USER_EVENT_SCHEMA_JSON
+
+
+# No retry on non-retryable errors
+
+
+async def test_async_get_schema_no_retry_on_404(
+    mock_registry: respx.MockRouter,
+) -> None:
+    """404 raises SchemaNotFoundError immediately — no retry."""
+    from apicurio_serdes._errors import SchemaNotFoundError
+
+    url = f"{REGISTRY_URL}/groups/{GROUP_ID}/artifacts/Missing/versions/latest/content"
+    route = mock_registry.get(url).mock(return_value=httpx.Response(404, json={}))
+    client = AsyncApicurioRegistryClient(url=REGISTRY_URL, group_id=GROUP_ID)
+    with pytest.raises(SchemaNotFoundError):
+        await client.get_schema("Missing")
+    assert route.call_count == 1
+
+
+async def test_async_get_schema_no_retry_on_400(
+    mock_registry: respx.MockRouter,
+) -> None:
+    """400 raises RegistryConnectionError immediately — no retry."""
+    from apicurio_serdes._errors import RegistryConnectionError
+
+    url = f"{REGISTRY_URL}/groups/{GROUP_ID}/artifacts/Bad/versions/latest/content"
+    route = mock_registry.get(url).mock(return_value=httpx.Response(400))
+    client = AsyncApicurioRegistryClient(url=REGISTRY_URL, group_id=GROUP_ID)
+    with pytest.raises(RegistryConnectionError):
+        await client.get_schema("Bad")
+    assert route.call_count == 1
+
+
+async def test_async_get_schema_no_retry_on_500(
+    mock_registry: respx.MockRouter,
+) -> None:
+    """500 raises RegistryConnectionError immediately — not retried."""
+    from apicurio_serdes._errors import RegistryConnectionError
+
+    url = f"{REGISTRY_URL}/groups/{GROUP_ID}/artifacts/Broken/versions/latest/content"
+    route = mock_registry.get(url).mock(return_value=httpx.Response(500))
+    client = AsyncApicurioRegistryClient(url=REGISTRY_URL, group_id=GROUP_ID)
+    with pytest.raises(RegistryConnectionError):
+        await client.get_schema("Broken")
+    assert route.call_count == 1
+
+
+async def test_async_get_schema_max_retries_zero_no_retry(
+    mock_registry: respx.MockRouter,
+) -> None:
+    """max_retries=0 disables retry; ConnectError raises after 1 attempt."""
+    from apicurio_serdes._errors import RegistryConnectionError
+
+    url = f"{REGISTRY_URL}/groups/{GROUP_ID}/artifacts/UserEvent/versions/latest/content"
+    route = mock_registry.get(url).mock(side_effect=httpx.ConnectError("refused"))
+    client = AsyncApicurioRegistryClient(
+        url=REGISTRY_URL, group_id=GROUP_ID, max_retries=0
+    )
+    with pytest.raises(RegistryConnectionError):
+        await client.get_schema("UserEvent")
+    assert route.call_count == 1
+
+
+async def test_async_get_schema_exhausts_retries_on_503_raises_connection_error(
+    mock_registry: respx.MockRouter,
+) -> None:
+    """When all retries on 503 are exhausted, RegistryConnectionError is raised."""
+    from apicurio_serdes._errors import RegistryConnectionError
+
+    url = f"{REGISTRY_URL}/groups/{GROUP_ID}/artifacts/UserEvent/versions/latest/content"
+    mock_registry.get(url).mock(return_value=httpx.Response(503))
+    client = AsyncApicurioRegistryClient(
+        url=REGISTRY_URL, group_id=GROUP_ID, max_retries=1
+    )
+    with patch(
+        "apicurio_serdes._async_client.asyncio.sleep", new_callable=AsyncMock
+    ):
+        with pytest.raises(RegistryConnectionError):
+            await client.get_schema("UserEvent")
+
+
+# Backoff
+
+
+async def test_async_get_schema_sleep_called_between_retries(
+    mock_registry: respx.MockRouter,
+) -> None:
+    """asyncio.sleep is called with a non-negative delay between retry attempts."""
+    url = f"{REGISTRY_URL}/groups/{GROUP_ID}/artifacts/UserEvent/versions/latest/content"
+    mock_registry.get(url).mock(side_effect=_async_flaky_schema_handler(1))
+    client = AsyncApicurioRegistryClient(url=REGISTRY_URL, group_id=GROUP_ID)
+    with patch(
+        "apicurio_serdes._async_client.asyncio.sleep", new_callable=AsyncMock
+    ) as mock_sleep:
+        await client.get_schema("UserEvent")
+    mock_sleep.assert_called_once()
+    delay = mock_sleep.call_args[0][0]
+    assert delay >= 0
+
+
+# Escape hatch: custom http_client
+
+
+async def test_async_custom_http_client_is_used() -> None:
+    """User-provided AsyncClient is used for HTTP requests."""
+    mock_client = MagicMock(spec=httpx.AsyncClient)
+    _req = httpx.Request("GET", f"{REGISTRY_URL}/groups/{GROUP_ID}/artifacts/UserEvent/versions/latest/content")
+    mock_client.request = AsyncMock(
+        return_value=httpx.Response(
+            200,
+            content=json.dumps(USER_EVENT_SCHEMA_JSON).encode(),
+            headers={
+                "X-Registry-GlobalId": str(GLOBAL_ID),
+                "X-Registry-ContentId": str(CONTENT_ID),
+            },
+            request=_req,
+        )
+    )
+    client = AsyncApicurioRegistryClient(
+        url=REGISTRY_URL, group_id=GROUP_ID, http_client=mock_client
+    )
+    result = await client.get_schema("UserEvent")
+    assert result.schema == USER_EVENT_SCHEMA_JSON
+    assert mock_client.request.called
+
+
+async def test_async_custom_http_client_not_closed_on_aclose() -> None:
+    """User-provided AsyncClient is not closed when aclose() is called."""
+    mock_client = MagicMock(spec=httpx.AsyncClient)
+    mock_client.aclose = AsyncMock()
+    client = AsyncApicurioRegistryClient(
+        url=REGISTRY_URL, group_id=GROUP_ID, http_client=mock_client
+    )
+    await client.aclose()
+    mock_client.aclose.assert_not_called()

--- a/tests/test_async_client.py
+++ b/tests/test_async_client.py
@@ -914,9 +914,7 @@ def test_async_init_max_retries_zero_valid() -> None:
 def test_async_init_max_retries_negative_raises_value_error() -> None:
     """max_retries=-1 raises ValueError."""
     with pytest.raises(ValueError, match="max_retries"):
-        AsyncApicurioRegistryClient(
-            url=REGISTRY_URL, group_id=GROUP_ID, max_retries=-1
-        )
+        AsyncApicurioRegistryClient(url=REGISTRY_URL, group_id=GROUP_ID, max_retries=-1)
 
 
 def test_async_init_signature_matches_sync() -> None:
@@ -941,12 +939,12 @@ async def test_async_get_schema_retries_on_connect_error_then_succeeds(
     mock_registry: respx.MockRouter,
 ) -> None:
     """ConnectError on first attempt retried; schema returned on second attempt."""
-    url = f"{REGISTRY_URL}/groups/{GROUP_ID}/artifacts/UserEvent/versions/latest/content"
+    url = (
+        f"{REGISTRY_URL}/groups/{GROUP_ID}/artifacts/UserEvent/versions/latest/content"
+    )
     mock_registry.get(url).mock(side_effect=_async_flaky_schema_handler(1))
     client = AsyncApicurioRegistryClient(url=REGISTRY_URL, group_id=GROUP_ID)
-    with patch(
-        "apicurio_serdes._async_client.asyncio.sleep", new_callable=AsyncMock
-    ):
+    with patch("apicurio_serdes._async_client.asyncio.sleep", new_callable=AsyncMock):
         result = await client.get_schema("UserEvent")
     assert result.schema == USER_EVENT_SCHEMA_JSON
 
@@ -957,16 +955,18 @@ async def test_async_get_schema_exhausts_retries_raises_connection_error(
     """All attempts fail; RegistryConnectionError raised after max_retries exhausted."""
     from apicurio_serdes._errors import RegistryConnectionError
 
-    url = f"{REGISTRY_URL}/groups/{GROUP_ID}/artifacts/UserEvent/versions/latest/content"
+    url = (
+        f"{REGISTRY_URL}/groups/{GROUP_ID}/artifacts/UserEvent/versions/latest/content"
+    )
     route = mock_registry.get(url).mock(side_effect=_async_flaky_schema_handler(99))
     client = AsyncApicurioRegistryClient(
         url=REGISTRY_URL, group_id=GROUP_ID, max_retries=2
     )
-    with patch(
-        "apicurio_serdes._async_client.asyncio.sleep", new_callable=AsyncMock
+    with (
+        patch("apicurio_serdes._async_client.asyncio.sleep", new_callable=AsyncMock),
+        pytest.raises(RegistryConnectionError),
     ):
-        with pytest.raises(RegistryConnectionError):
-            await client.get_schema("UserEvent")
+        await client.get_schema("UserEvent")
     assert route.call_count == 3
 
 
@@ -974,13 +974,11 @@ async def test_async_get_schema_by_global_id_retries_on_connect_error(
     mock_registry: respx.MockRouter,
 ) -> None:
     """ID lookup retried on ConnectError."""
-    mock_registry.get(
-        url__startswith=f"{REGISTRY_URL}/ids/globalIds/"
-    ).mock(side_effect=_async_flaky_id_handler(1))
+    mock_registry.get(url__startswith=f"{REGISTRY_URL}/ids/globalIds/").mock(
+        side_effect=_async_flaky_id_handler(1)
+    )
     client = AsyncApicurioRegistryClient(url=REGISTRY_URL, group_id=GROUP_ID)
-    with patch(
-        "apicurio_serdes._async_client.asyncio.sleep", new_callable=AsyncMock
-    ):
+    with patch("apicurio_serdes._async_client.asyncio.sleep", new_callable=AsyncMock):
         result = await client.get_schema_by_global_id(GLOBAL_ID)
     assert result == USER_EVENT_SCHEMA_JSON
 
@@ -989,13 +987,11 @@ async def test_async_register_schema_retries_on_connect_error(
     mock_registry: respx.MockRouter,
 ) -> None:
     """register_schema retried on ConnectError."""
-    mock_registry.post(
-        url__startswith=f"{REGISTRY_URL}/groups/"
-    ).mock(side_effect=_async_flaky_register_handler(1))
+    mock_registry.post(url__startswith=f"{REGISTRY_URL}/groups/").mock(
+        side_effect=_async_flaky_register_handler(1)
+    )
     client = AsyncApicurioRegistryClient(url=REGISTRY_URL, group_id=GROUP_ID)
-    with patch(
-        "apicurio_serdes._async_client.asyncio.sleep", new_callable=AsyncMock
-    ):
+    with patch("apicurio_serdes._async_client.asyncio.sleep", new_callable=AsyncMock):
         result = await client.register_schema("UserEvent", USER_EVENT_SCHEMA_JSON)
     assert result.global_id == GLOBAL_ID
 
@@ -1008,14 +1004,14 @@ async def test_async_get_schema_retries_on_retryable_status(
     mock_registry: respx.MockRouter, fail_status: int
 ) -> None:
     """Schema GET retried on 429/502/503/504."""
-    url = f"{REGISTRY_URL}/groups/{GROUP_ID}/artifacts/UserEvent/versions/latest/content"
+    url = (
+        f"{REGISTRY_URL}/groups/{GROUP_ID}/artifacts/UserEvent/versions/latest/content"
+    )
     mock_registry.get(url).mock(
         side_effect=_async_flaky_status_schema_handler(fail_status, 1)
     )
     client = AsyncApicurioRegistryClient(url=REGISTRY_URL, group_id=GROUP_ID)
-    with patch(
-        "apicurio_serdes._async_client.asyncio.sleep", new_callable=AsyncMock
-    ):
+    with patch("apicurio_serdes._async_client.asyncio.sleep", new_callable=AsyncMock):
         result = await client.get_schema("UserEvent")
     assert result.schema == USER_EVENT_SCHEMA_JSON
 
@@ -1071,7 +1067,9 @@ async def test_async_get_schema_max_retries_zero_no_retry(
     """max_retries=0 disables retry; ConnectError raises after 1 attempt."""
     from apicurio_serdes._errors import RegistryConnectionError
 
-    url = f"{REGISTRY_URL}/groups/{GROUP_ID}/artifacts/UserEvent/versions/latest/content"
+    url = (
+        f"{REGISTRY_URL}/groups/{GROUP_ID}/artifacts/UserEvent/versions/latest/content"
+    )
     route = mock_registry.get(url).mock(side_effect=httpx.ConnectError("refused"))
     client = AsyncApicurioRegistryClient(
         url=REGISTRY_URL, group_id=GROUP_ID, max_retries=0
@@ -1087,16 +1085,18 @@ async def test_async_get_schema_exhausts_retries_on_503_raises_connection_error(
     """When all retries on 503 are exhausted, RegistryConnectionError is raised."""
     from apicurio_serdes._errors import RegistryConnectionError
 
-    url = f"{REGISTRY_URL}/groups/{GROUP_ID}/artifacts/UserEvent/versions/latest/content"
+    url = (
+        f"{REGISTRY_URL}/groups/{GROUP_ID}/artifacts/UserEvent/versions/latest/content"
+    )
     mock_registry.get(url).mock(return_value=httpx.Response(503))
     client = AsyncApicurioRegistryClient(
         url=REGISTRY_URL, group_id=GROUP_ID, max_retries=1
     )
-    with patch(
-        "apicurio_serdes._async_client.asyncio.sleep", new_callable=AsyncMock
+    with (
+        patch("apicurio_serdes._async_client.asyncio.sleep", new_callable=AsyncMock),
+        pytest.raises(RegistryConnectionError),
     ):
-        with pytest.raises(RegistryConnectionError):
-            await client.get_schema("UserEvent")
+        await client.get_schema("UserEvent")
 
 
 # Backoff
@@ -1106,7 +1106,9 @@ async def test_async_get_schema_sleep_called_between_retries(
     mock_registry: respx.MockRouter,
 ) -> None:
     """asyncio.sleep is called with a non-negative delay between retry attempts."""
-    url = f"{REGISTRY_URL}/groups/{GROUP_ID}/artifacts/UserEvent/versions/latest/content"
+    url = (
+        f"{REGISTRY_URL}/groups/{GROUP_ID}/artifacts/UserEvent/versions/latest/content"
+    )
     mock_registry.get(url).mock(side_effect=_async_flaky_schema_handler(1))
     client = AsyncApicurioRegistryClient(url=REGISTRY_URL, group_id=GROUP_ID)
     with patch(
@@ -1124,7 +1126,10 @@ async def test_async_get_schema_sleep_called_between_retries(
 async def test_async_custom_http_client_is_used() -> None:
     """User-provided AsyncClient is used for HTTP requests."""
     mock_client = MagicMock(spec=httpx.AsyncClient)
-    _req = httpx.Request("GET", f"{REGISTRY_URL}/groups/{GROUP_ID}/artifacts/UserEvent/versions/latest/content")
+    _req = httpx.Request(
+        "GET",
+        f"{REGISTRY_URL}/groups/{GROUP_ID}/artifacts/UserEvent/versions/latest/content",
+    )
     mock_client.request = AsyncMock(
         return_value=httpx.Response(
             200,

--- a/tests/test_async_client.py
+++ b/tests/test_async_client.py
@@ -4,6 +4,7 @@ from __future__ import annotations
 
 import json
 from typing import Any
+from unittest.mock import AsyncMock, MagicMock, patch
 
 import httpx
 import pytest
@@ -793,9 +794,6 @@ async def test_async_client_accepts_bearer_auth(
 
 
 # ── Retry and escape hatch tests (#37) ──
-
-
-from unittest.mock import AsyncMock, MagicMock, patch
 
 
 def _async_flaky_schema_handler(n_failures: int) -> Any:

--- a/tests/test_client.py
+++ b/tests/test_client.py
@@ -984,9 +984,11 @@ def test_get_schema_exhausts_retries_raises_connection_error(
     )
     route = mock_registry.get(url).mock(side_effect=_flaky_schema_handler(99))
     client = ApicurioRegistryClient(url=REGISTRY_URL, group_id=GROUP_ID, max_retries=2)
-    with patch("apicurio_serdes._client.time.sleep"):
-        with pytest.raises(RegistryConnectionError):
-            client.get_schema("UserEvent")
+    with (
+        patch("apicurio_serdes._client.time.sleep"),
+        pytest.raises(RegistryConnectionError),
+    ):
+        client.get_schema("UserEvent")
     assert route.call_count == 3  # 1 initial + 2 retries
 
 
@@ -1102,9 +1104,11 @@ def test_get_schema_exhausts_retries_on_503_raises_connection_error(
     )
     mock_registry.get(url).mock(return_value=httpx.Response(503))
     client = ApicurioRegistryClient(url=REGISTRY_URL, group_id=GROUP_ID, max_retries=1)
-    with patch("apicurio_serdes._client.time.sleep"):
-        with pytest.raises(RegistryConnectionError):
-            client.get_schema("UserEvent")
+    with (
+        patch("apicurio_serdes._client.time.sleep"),
+        pytest.raises(RegistryConnectionError),
+    ):
+        client.get_schema("UserEvent")
 
 
 # Backoff

--- a/tests/test_client.py
+++ b/tests/test_client.py
@@ -826,3 +826,329 @@ def test_client_accepts_bearer_auth(mock_registry: respx.MockRouter) -> None:
     )
     client.get_schema("Auth")
     assert route.calls[0].request.headers["authorization"] == "Bearer wire-tok"
+
+
+# ── Retry and escape hatch tests (#37) ──
+
+
+import json
+from unittest.mock import MagicMock, patch
+
+
+def _flaky_schema_handler(n_failures: int) -> Any:
+    """Side-effect handler: raises ConnectError n_failures times, then returns 200."""
+    count = 0
+
+    def _handler(request: httpx.Request) -> httpx.Response:
+        nonlocal count
+        count += 1
+        if count <= n_failures:
+            raise httpx.ConnectError("transient failure")
+        return httpx.Response(
+            200,
+            content=json.dumps(USER_EVENT_SCHEMA_JSON).encode(),
+            headers={
+                "X-Registry-GlobalId": str(GLOBAL_ID),
+                "X-Registry-ContentId": str(CONTENT_ID),
+            },
+        )
+
+    return _handler
+
+
+def _flaky_status_schema_handler(fail_status: int, n_failures: int) -> Any:
+    """Side-effect handler: returns fail_status n_failures times, then returns 200."""
+    count = 0
+
+    def _handler(request: httpx.Request) -> httpx.Response:
+        nonlocal count
+        count += 1
+        if count <= n_failures:
+            return httpx.Response(fail_status)
+        return httpx.Response(
+            200,
+            content=json.dumps(USER_EVENT_SCHEMA_JSON).encode(),
+            headers={
+                "X-Registry-GlobalId": str(GLOBAL_ID),
+                "X-Registry-ContentId": str(CONTENT_ID),
+            },
+        )
+
+    return _handler
+
+
+def _flaky_id_handler(n_failures: int) -> Any:
+    """Side-effect: ConnectError n times then valid schema response (ID endpoint)."""
+    count = 0
+
+    def _handler(request: httpx.Request) -> httpx.Response:
+        nonlocal count
+        count += 1
+        if count <= n_failures:
+            raise httpx.ConnectError("transient failure")
+        return httpx.Response(
+            200, content=json.dumps(USER_EVENT_SCHEMA_JSON).encode()
+        )
+
+    return _handler
+
+
+def _flaky_register_handler(n_failures: int) -> Any:
+    """Side-effect: ConnectError n times then valid register response."""
+    count = 0
+
+    def _handler(request: httpx.Request) -> httpx.Response:
+        nonlocal count
+        count += 1
+        if count <= n_failures:
+            raise httpx.ConnectError("transient failure")
+        return httpx.Response(
+            200,
+            json={
+                "artifact": {
+                    "groupId": GROUP_ID,
+                    "artifactId": "UserEvent",
+                    "artifactType": "AVRO",
+                },
+                "version": {
+                    "globalId": GLOBAL_ID,
+                    "contentId": CONTENT_ID,
+                    "artifactType": "AVRO",
+                },
+            },
+        )
+
+    return _handler
+
+
+# Constructor parameter tests
+
+
+def test_init_default_max_retries() -> None:
+    """Default max_retries is 3."""
+    client = ApicurioRegistryClient(url=REGISTRY_URL, group_id=GROUP_ID)
+    assert client.max_retries == 3
+
+
+def test_init_default_retry_backoff_ms() -> None:
+    """Default retry_backoff_ms is 1000."""
+    client = ApicurioRegistryClient(url=REGISTRY_URL, group_id=GROUP_ID)
+    assert client.retry_backoff_ms == 1000
+
+
+def test_init_default_retry_max_backoff_ms() -> None:
+    """Default retry_max_backoff_ms is 20000."""
+    client = ApicurioRegistryClient(url=REGISTRY_URL, group_id=GROUP_ID)
+    assert client.retry_max_backoff_ms == 20000
+
+
+def test_init_custom_max_retries() -> None:
+    """Custom max_retries is stored."""
+    client = ApicurioRegistryClient(url=REGISTRY_URL, group_id=GROUP_ID, max_retries=5)
+    assert client.max_retries == 5
+
+
+def test_init_max_retries_zero_valid() -> None:
+    """max_retries=0 disables retries without error."""
+    client = ApicurioRegistryClient(url=REGISTRY_URL, group_id=GROUP_ID, max_retries=0)
+    assert client.max_retries == 0
+
+
+def test_init_max_retries_negative_raises_value_error() -> None:
+    """max_retries=-1 raises ValueError."""
+    with pytest.raises(ValueError, match="max_retries"):
+        ApicurioRegistryClient(url=REGISTRY_URL, group_id=GROUP_ID, max_retries=-1)
+
+
+# Retry on transport error
+
+
+def test_get_schema_retries_on_connect_error_then_succeeds(
+    mock_registry: respx.MockRouter,
+) -> None:
+    """ConnectError on first attempt retried; schema returned on second attempt."""
+    url = f"{REGISTRY_URL}/groups/{GROUP_ID}/artifacts/UserEvent/versions/latest/content"
+    mock_registry.get(url).mock(side_effect=_flaky_schema_handler(1))
+    client = ApicurioRegistryClient(url=REGISTRY_URL, group_id=GROUP_ID)
+    with patch("apicurio_serdes._client.time.sleep"):
+        result = client.get_schema("UserEvent")
+    assert result.schema == USER_EVENT_SCHEMA_JSON
+
+
+def test_get_schema_exhausts_retries_raises_connection_error(
+    mock_registry: respx.MockRouter,
+) -> None:
+    """ConnectError on all attempts raises RegistryConnectionError after max_retries."""
+    from apicurio_serdes._errors import RegistryConnectionError
+
+    url = f"{REGISTRY_URL}/groups/{GROUP_ID}/artifacts/UserEvent/versions/latest/content"
+    route = mock_registry.get(url).mock(side_effect=_flaky_schema_handler(99))
+    client = ApicurioRegistryClient(url=REGISTRY_URL, group_id=GROUP_ID, max_retries=2)
+    with patch("apicurio_serdes._client.time.sleep"):
+        with pytest.raises(RegistryConnectionError):
+            client.get_schema("UserEvent")
+    assert route.call_count == 3  # 1 initial + 2 retries
+
+
+def test_get_schema_by_global_id_retries_on_connect_error(
+    mock_registry: respx.MockRouter,
+) -> None:
+    """ID lookup retried on ConnectError."""
+    mock_registry.get(
+        url__startswith=f"{REGISTRY_URL}/ids/globalIds/"
+    ).mock(side_effect=_flaky_id_handler(1))
+    client = ApicurioRegistryClient(url=REGISTRY_URL, group_id=GROUP_ID)
+    with patch("apicurio_serdes._client.time.sleep"):
+        result = client.get_schema_by_global_id(GLOBAL_ID)
+    assert result == USER_EVENT_SCHEMA_JSON
+
+
+def test_register_schema_retries_on_connect_error(
+    mock_registry: respx.MockRouter,
+) -> None:
+    """register_schema retried on ConnectError."""
+    mock_registry.post(
+        url__startswith=f"{REGISTRY_URL}/groups/"
+    ).mock(side_effect=_flaky_register_handler(1))
+    client = ApicurioRegistryClient(url=REGISTRY_URL, group_id=GROUP_ID)
+    with patch("apicurio_serdes._client.time.sleep"):
+        result = client.register_schema("UserEvent", USER_EVENT_SCHEMA_JSON)
+    assert result.global_id == GLOBAL_ID
+
+
+# Retry on retryable HTTP status codes
+
+
+@pytest.mark.parametrize("fail_status", [429, 502, 503, 504])
+def test_get_schema_retries_on_retryable_status(
+    mock_registry: respx.MockRouter, fail_status: int
+) -> None:
+    """Schema GET retried on 429/502/503/504, succeeds on next attempt."""
+    url = f"{REGISTRY_URL}/groups/{GROUP_ID}/artifacts/UserEvent/versions/latest/content"
+    mock_registry.get(url).mock(
+        side_effect=_flaky_status_schema_handler(fail_status, 1)
+    )
+    client = ApicurioRegistryClient(url=REGISTRY_URL, group_id=GROUP_ID)
+    with patch("apicurio_serdes._client.time.sleep"):
+        result = client.get_schema("UserEvent")
+    assert result.schema == USER_EVENT_SCHEMA_JSON
+
+
+# No retry on non-retryable errors
+
+
+def test_get_schema_no_retry_on_404(mock_registry: respx.MockRouter) -> None:
+    """404 raises SchemaNotFoundError immediately — no retry."""
+    from apicurio_serdes._errors import SchemaNotFoundError
+
+    url = f"{REGISTRY_URL}/groups/{GROUP_ID}/artifacts/Missing/versions/latest/content"
+    route = mock_registry.get(url).mock(return_value=httpx.Response(404, json={}))
+    client = ApicurioRegistryClient(url=REGISTRY_URL, group_id=GROUP_ID)
+    with pytest.raises(SchemaNotFoundError):
+        client.get_schema("Missing")
+    assert route.call_count == 1
+
+
+def test_get_schema_no_retry_on_400(mock_registry: respx.MockRouter) -> None:
+    """400 raises RegistryConnectionError immediately — no retry."""
+    from apicurio_serdes._errors import RegistryConnectionError
+
+    url = f"{REGISTRY_URL}/groups/{GROUP_ID}/artifacts/Bad/versions/latest/content"
+    route = mock_registry.get(url).mock(return_value=httpx.Response(400))
+    client = ApicurioRegistryClient(url=REGISTRY_URL, group_id=GROUP_ID)
+    with pytest.raises(RegistryConnectionError):
+        client.get_schema("Bad")
+    assert route.call_count == 1
+
+
+def test_get_schema_no_retry_on_500(mock_registry: respx.MockRouter) -> None:
+    """500 raises RegistryConnectionError immediately — not retried (ambiguous)."""
+    from apicurio_serdes._errors import RegistryConnectionError
+
+    url = f"{REGISTRY_URL}/groups/{GROUP_ID}/artifacts/Broken/versions/latest/content"
+    route = mock_registry.get(url).mock(return_value=httpx.Response(500))
+    client = ApicurioRegistryClient(url=REGISTRY_URL, group_id=GROUP_ID)
+    with pytest.raises(RegistryConnectionError):
+        client.get_schema("Broken")
+    assert route.call_count == 1
+
+
+def test_get_schema_max_retries_zero_no_retry(
+    mock_registry: respx.MockRouter,
+) -> None:
+    """max_retries=0 disables retry; ConnectError raises immediately after 1 attempt."""
+    from apicurio_serdes._errors import RegistryConnectionError
+
+    url = f"{REGISTRY_URL}/groups/{GROUP_ID}/artifacts/UserEvent/versions/latest/content"
+    route = mock_registry.get(url).mock(side_effect=httpx.ConnectError("refused"))
+    client = ApicurioRegistryClient(
+        url=REGISTRY_URL, group_id=GROUP_ID, max_retries=0
+    )
+    with pytest.raises(RegistryConnectionError):
+        client.get_schema("UserEvent")
+    assert route.call_count == 1
+
+
+def test_get_schema_exhausts_retries_on_503_raises_connection_error(
+    mock_registry: respx.MockRouter,
+) -> None:
+    """When all retries on 503 are exhausted, RegistryConnectionError is raised."""
+    from apicurio_serdes._errors import RegistryConnectionError
+
+    url = f"{REGISTRY_URL}/groups/{GROUP_ID}/artifacts/UserEvent/versions/latest/content"
+    mock_registry.get(url).mock(return_value=httpx.Response(503))
+    client = ApicurioRegistryClient(url=REGISTRY_URL, group_id=GROUP_ID, max_retries=1)
+    with patch("apicurio_serdes._client.time.sleep"):
+        with pytest.raises(RegistryConnectionError):
+            client.get_schema("UserEvent")
+
+
+# Backoff
+
+
+def test_get_schema_sleep_called_between_retries(
+    mock_registry: respx.MockRouter,
+) -> None:
+    """time.sleep is called with a positive delay between retry attempts."""
+    url = f"{REGISTRY_URL}/groups/{GROUP_ID}/artifacts/UserEvent/versions/latest/content"
+    mock_registry.get(url).mock(side_effect=_flaky_schema_handler(1))
+    client = ApicurioRegistryClient(url=REGISTRY_URL, group_id=GROUP_ID)
+    with patch("apicurio_serdes._client.time.sleep") as mock_sleep:
+        client.get_schema("UserEvent")
+    mock_sleep.assert_called_once()
+    delay = mock_sleep.call_args[0][0]
+    assert delay >= 0
+
+
+# Escape hatch: custom http_client
+
+
+def test_custom_http_client_is_used() -> None:
+    """User-provided http_client is used for HTTP requests."""
+    mock_client = MagicMock(spec=httpx.Client)
+    _req = httpx.Request("GET", f"{REGISTRY_URL}/groups/{GROUP_ID}/artifacts/UserEvent/versions/latest/content")
+    mock_client.request.return_value = httpx.Response(
+        200,
+        content=json.dumps(USER_EVENT_SCHEMA_JSON).encode(),
+        headers={
+            "X-Registry-GlobalId": str(GLOBAL_ID),
+            "X-Registry-ContentId": str(CONTENT_ID),
+        },
+        request=_req,
+    )
+    client = ApicurioRegistryClient(
+        url=REGISTRY_URL, group_id=GROUP_ID, http_client=mock_client
+    )
+    result = client.get_schema("UserEvent")
+    assert result.schema == USER_EVENT_SCHEMA_JSON
+    assert mock_client.request.called
+
+
+def test_custom_http_client_not_closed_on_close() -> None:
+    """User-provided http_client is not closed when client.close() is called."""
+    mock_client = MagicMock(spec=httpx.Client)
+    client = ApicurioRegistryClient(
+        url=REGISTRY_URL, group_id=GROUP_ID, http_client=mock_client
+    )
+    client.close()
+    mock_client.close.assert_not_called()

--- a/tests/test_client.py
+++ b/tests/test_client.py
@@ -2,8 +2,10 @@
 
 from __future__ import annotations
 
+import json
 from concurrent.futures import ThreadPoolExecutor
 from typing import Any
+from unittest.mock import MagicMock, patch
 
 import httpx
 import pytest
@@ -829,10 +831,6 @@ def test_client_accepts_bearer_auth(mock_registry: respx.MockRouter) -> None:
 
 
 # ── Retry and escape hatch tests (#37) ──
-
-
-import json
-from unittest.mock import MagicMock, patch
 
 
 def _flaky_schema_handler(n_failures: int) -> Any:

--- a/tests/test_client.py
+++ b/tests/test_client.py
@@ -886,9 +886,7 @@ def _flaky_id_handler(n_failures: int) -> Any:
         count += 1
         if count <= n_failures:
             raise httpx.ConnectError("transient failure")
-        return httpx.Response(
-            200, content=json.dumps(USER_EVENT_SCHEMA_JSON).encode()
-        )
+        return httpx.Response(200, content=json.dumps(USER_EVENT_SCHEMA_JSON).encode())
 
     return _handler
 
@@ -967,7 +965,9 @@ def test_get_schema_retries_on_connect_error_then_succeeds(
     mock_registry: respx.MockRouter,
 ) -> None:
     """ConnectError on first attempt retried; schema returned on second attempt."""
-    url = f"{REGISTRY_URL}/groups/{GROUP_ID}/artifacts/UserEvent/versions/latest/content"
+    url = (
+        f"{REGISTRY_URL}/groups/{GROUP_ID}/artifacts/UserEvent/versions/latest/content"
+    )
     mock_registry.get(url).mock(side_effect=_flaky_schema_handler(1))
     client = ApicurioRegistryClient(url=REGISTRY_URL, group_id=GROUP_ID)
     with patch("apicurio_serdes._client.time.sleep"):
@@ -981,7 +981,9 @@ def test_get_schema_exhausts_retries_raises_connection_error(
     """ConnectError on all attempts raises RegistryConnectionError after max_retries."""
     from apicurio_serdes._errors import RegistryConnectionError
 
-    url = f"{REGISTRY_URL}/groups/{GROUP_ID}/artifacts/UserEvent/versions/latest/content"
+    url = (
+        f"{REGISTRY_URL}/groups/{GROUP_ID}/artifacts/UserEvent/versions/latest/content"
+    )
     route = mock_registry.get(url).mock(side_effect=_flaky_schema_handler(99))
     client = ApicurioRegistryClient(url=REGISTRY_URL, group_id=GROUP_ID, max_retries=2)
     with patch("apicurio_serdes._client.time.sleep"):
@@ -994,9 +996,9 @@ def test_get_schema_by_global_id_retries_on_connect_error(
     mock_registry: respx.MockRouter,
 ) -> None:
     """ID lookup retried on ConnectError."""
-    mock_registry.get(
-        url__startswith=f"{REGISTRY_URL}/ids/globalIds/"
-    ).mock(side_effect=_flaky_id_handler(1))
+    mock_registry.get(url__startswith=f"{REGISTRY_URL}/ids/globalIds/").mock(
+        side_effect=_flaky_id_handler(1)
+    )
     client = ApicurioRegistryClient(url=REGISTRY_URL, group_id=GROUP_ID)
     with patch("apicurio_serdes._client.time.sleep"):
         result = client.get_schema_by_global_id(GLOBAL_ID)
@@ -1007,9 +1009,9 @@ def test_register_schema_retries_on_connect_error(
     mock_registry: respx.MockRouter,
 ) -> None:
     """register_schema retried on ConnectError."""
-    mock_registry.post(
-        url__startswith=f"{REGISTRY_URL}/groups/"
-    ).mock(side_effect=_flaky_register_handler(1))
+    mock_registry.post(url__startswith=f"{REGISTRY_URL}/groups/").mock(
+        side_effect=_flaky_register_handler(1)
+    )
     client = ApicurioRegistryClient(url=REGISTRY_URL, group_id=GROUP_ID)
     with patch("apicurio_serdes._client.time.sleep"):
         result = client.register_schema("UserEvent", USER_EVENT_SCHEMA_JSON)
@@ -1024,7 +1026,9 @@ def test_get_schema_retries_on_retryable_status(
     mock_registry: respx.MockRouter, fail_status: int
 ) -> None:
     """Schema GET retried on 429/502/503/504, succeeds on next attempt."""
-    url = f"{REGISTRY_URL}/groups/{GROUP_ID}/artifacts/UserEvent/versions/latest/content"
+    url = (
+        f"{REGISTRY_URL}/groups/{GROUP_ID}/artifacts/UserEvent/versions/latest/content"
+    )
     mock_registry.get(url).mock(
         side_effect=_flaky_status_schema_handler(fail_status, 1)
     )
@@ -1079,11 +1083,11 @@ def test_get_schema_max_retries_zero_no_retry(
     """max_retries=0 disables retry; ConnectError raises immediately after 1 attempt."""
     from apicurio_serdes._errors import RegistryConnectionError
 
-    url = f"{REGISTRY_URL}/groups/{GROUP_ID}/artifacts/UserEvent/versions/latest/content"
-    route = mock_registry.get(url).mock(side_effect=httpx.ConnectError("refused"))
-    client = ApicurioRegistryClient(
-        url=REGISTRY_URL, group_id=GROUP_ID, max_retries=0
+    url = (
+        f"{REGISTRY_URL}/groups/{GROUP_ID}/artifacts/UserEvent/versions/latest/content"
     )
+    route = mock_registry.get(url).mock(side_effect=httpx.ConnectError("refused"))
+    client = ApicurioRegistryClient(url=REGISTRY_URL, group_id=GROUP_ID, max_retries=0)
     with pytest.raises(RegistryConnectionError):
         client.get_schema("UserEvent")
     assert route.call_count == 1
@@ -1095,7 +1099,9 @@ def test_get_schema_exhausts_retries_on_503_raises_connection_error(
     """When all retries on 503 are exhausted, RegistryConnectionError is raised."""
     from apicurio_serdes._errors import RegistryConnectionError
 
-    url = f"{REGISTRY_URL}/groups/{GROUP_ID}/artifacts/UserEvent/versions/latest/content"
+    url = (
+        f"{REGISTRY_URL}/groups/{GROUP_ID}/artifacts/UserEvent/versions/latest/content"
+    )
     mock_registry.get(url).mock(return_value=httpx.Response(503))
     client = ApicurioRegistryClient(url=REGISTRY_URL, group_id=GROUP_ID, max_retries=1)
     with patch("apicurio_serdes._client.time.sleep"):
@@ -1110,7 +1116,9 @@ def test_get_schema_sleep_called_between_retries(
     mock_registry: respx.MockRouter,
 ) -> None:
     """time.sleep is called with a positive delay between retry attempts."""
-    url = f"{REGISTRY_URL}/groups/{GROUP_ID}/artifacts/UserEvent/versions/latest/content"
+    url = (
+        f"{REGISTRY_URL}/groups/{GROUP_ID}/artifacts/UserEvent/versions/latest/content"
+    )
     mock_registry.get(url).mock(side_effect=_flaky_schema_handler(1))
     client = ApicurioRegistryClient(url=REGISTRY_URL, group_id=GROUP_ID)
     with patch("apicurio_serdes._client.time.sleep") as mock_sleep:
@@ -1126,7 +1134,10 @@ def test_get_schema_sleep_called_between_retries(
 def test_custom_http_client_is_used() -> None:
     """User-provided http_client is used for HTTP requests."""
     mock_client = MagicMock(spec=httpx.Client)
-    _req = httpx.Request("GET", f"{REGISTRY_URL}/groups/{GROUP_ID}/artifacts/UserEvent/versions/latest/content")
+    _req = httpx.Request(
+        "GET",
+        f"{REGISTRY_URL}/groups/{GROUP_ID}/artifacts/UserEvent/versions/latest/content",
+    )
     mock_client.request.return_value = httpx.Response(
         200,
         content=json.dumps(USER_EVENT_SCHEMA_JSON).encode(),


### PR DESCRIPTION
## Summary

- Add `max_retries` (default 3), `retry_backoff_ms` (default 1000ms), `retry_max_backoff_ms` (default 20000ms) to both `ApicurioRegistryClient` and `AsyncApicurioRegistryClient`
- Retry on `httpx.TransportError` and HTTP 429/502/503/504 with full-jitter exponential backoff; 500 and other 4xx are not retried
- Add `http_client` keyword-only parameter as a power-user escape hatch (user-provided client is not closed by `close()`/`aclose()`)
- Supersedes ADR-014 via new ADR-020; aligns with Confluent Python and Apicurio Java defaults

## Test plan

- [ ] 446 tests pass, 100% coverage
- [ ] Retry on transport error (ConnectError) — retried, succeeds on 2nd attempt
- [ ] Retry exhausted — RegistryConnectionError after max_retries+1 attempts
- [ ] Retry on 429/502/503/504 — retried successfully
- [ ] No retry on 404/400/500 — immediate failure after 1 attempt
- [ ] `max_retries=0` disables retry
- [ ] `time.sleep` / `asyncio.sleep` called between retries
- [ ] Custom `http_client` used for requests; not closed on `close()`

🤖 Generated with [Claude Code](https://claude.com/claude-code)