### PR TITLE
feat(ci): add SLSA Level 3 provenance to GitHub releases (#64)

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -3,16 +3,7 @@ name: Publish
 on:
   release:
     types: [published]
-  workflow_dispatch:
-    inputs:
-      target:
-        description: "Publish target (testpypi only, or full)"
-        required: false
-        default: testpypi
-        type: choice
-        options:
-          - testpypi
-          - full
+  workflow_dispatch: {}
 
 permissions: {}
 
@@ -41,6 +32,7 @@ jobs:
 
   provenance:
     needs: build
+    if: github.event_name == 'release'
     permissions:
       actions: read
       id-token: write
@@ -94,7 +86,8 @@ jobs:
           skip-existing: true
 
   validate-testpypi:
-    needs: [build, publish-testpypi]
+    needs: publish-testpypi
+    if: startsWith(github.ref, 'refs/tags/')
     runs-on: ubuntu-latest
     timeout-minutes: 10
     steps:
@@ -130,7 +123,7 @@ jobs:
 
   publish-pypi:
     needs: [validate-testpypi, provenance]
-    if: github.event_name == 'release' || inputs.target == 'full'
+    if: github.event_name == 'release'
     runs-on: ubuntu-latest
     timeout-minutes: 10
     environment: pypi

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -10,6 +10,8 @@ jobs:
   build:
     runs-on: ubuntu-latest
     timeout-minutes: 10
+    outputs:
+      hashes: ${{ steps.hashes.outputs.hashes }}
     steps:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd  # v6.0.2
         with:
@@ -19,10 +21,24 @@ jobs:
           python-version: "3.13"
       - uses: astral-sh/setup-uv@37802adc94f370d6bfd71619e3f0bf239e1f3b78  # v7.6.0
       - run: uv build
+      - name: Compute artifact hashes
+        id: hashes
+        run: echo "hashes=$(sha256sum dist/* | base64 -w0)" >> "$GITHUB_OUTPUT"
       - uses: actions/upload-artifact@bbbca2ddaa5d8feaa63e36b76fdaad77386f024f  # v7.0.0
         with:
           name: dist
           path: dist/
+
+  provenance:
+    needs: build
+    permissions:
+      actions: read
+      id-token: write
+      contents: write
+    uses: slsa-framework/slsa-github-generator/.github/workflows/generator_generic_slsa3.yml@v2
+    with:
+      base64-subjects: "${{ needs.build.outputs.hashes }}"
+      upload-assets: true
 
   sign-release:
     needs: build

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -45,10 +45,10 @@ jobs:
       actions: read
       id-token: write
       contents: write
-    uses: slsa-framework/slsa-github-generator/.github/workflows/generator_generic_slsa3.yml@v2
+    uses: slsa-framework/slsa-github-generator/.github/workflows/generator_generic_slsa3.yml@v2.1.0
     with:
       base64-subjects: "${{ needs.build.outputs.hashes }}"
-      upload-assets: ${{ github.event_name == 'release' }}
+      upload-assets: true
 
   sign-release:
     needs: build

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -3,6 +3,16 @@ name: Publish
 on:
   release:
     types: [published]
+  workflow_dispatch:
+    inputs:
+      target:
+        description: "Publish target (testpypi only, or full)"
+        required: false
+        default: testpypi
+        type: choice
+        options:
+          - testpypi
+          - full
 
 permissions: {}
 
@@ -38,10 +48,11 @@ jobs:
     uses: slsa-framework/slsa-github-generator/.github/workflows/generator_generic_slsa3.yml@v2
     with:
       base64-subjects: "${{ needs.build.outputs.hashes }}"
-      upload-assets: true
+      upload-assets: ${{ github.event_name == 'release' }}
 
   sign-release:
     needs: build
+    if: github.event_name == 'release'
     runs-on: ubuntu-latest
     timeout-minutes: 10
     permissions:
@@ -118,7 +129,8 @@ jobs:
           python -c "import apicurio_serdes; print(apicurio_serdes.__name__)"
 
   publish-pypi:
-    needs: validate-testpypi
+    needs: [validate-testpypi, provenance]
+    if: github.event_name == 'release' || inputs.target == 'full'
     runs-on: ubuntu-latest
     timeout-minutes: 10
     environment: pypi


### PR DESCRIPTION
## Summary

- Adds a `provenance` job to `publish.yml` using `slsa-framework/slsa-github-generator` (`generator_generic_slsa3`)
- `build` job now computes SHA-256 hashes of built dist artifacts and exposes them as a `hashes` output
- `provenance` job generates a signed `.intoto.jsonl` provenance file via GitHub Actions OIDC and attaches it to the release automatically

This satisfies the OpenSSF Scorecard `releasesHaveProvenance` probe, bringing the Signed-Releases score from 8/10 to 10/10 for future releases. Past releases cannot be retroactively updated.

## Test plan

- [ ] Workflow syntax validates (no CI failures on push)
- [ ] On next release: `.intoto.jsonl` file attached to GitHub release assets
- [ ] OpenSSF Scorecard `releasesHaveProvenance` probe satisfied

🤖 Generated with [Claude Code](https://claude.com/claude-code)