### PR TITLE
docs: fill documentation gaps for v0.4.0 release

### DIFF
--- a/docs/api-reference/index.fr.md
+++ b/docs/api-reference/index.fr.md
@@ -29,6 +29,16 @@ d'`apicurio-serdes`.
 
 ::: apicurio_serdes.serialization.WireFormat
 
+## Authentification
+
+### BearerAuth
+
+::: apicurio_serdes._auth.BearerAuth
+
+### KeycloakAuth
+
+::: apicurio_serdes._auth.KeycloakAuth
+
 ## Avro
 
 ### AvroSerializer
@@ -43,6 +53,22 @@ d'`apicurio-serdes`.
 
 ::: apicurio_serdes.avro._async_deserializer.AsyncAvroDeserializer
 
+### TopicIdStrategy
+
+::: apicurio_serdes.avro._strategies.TopicIdStrategy
+
+### SimpleTopicIdStrategy
+
+::: apicurio_serdes.avro._strategies.SimpleTopicIdStrategy
+
+### QualifiedRecordIdStrategy
+
+::: apicurio_serdes.avro._strategies.QualifiedRecordIdStrategy
+
+### TopicRecordIdStrategy
+
+::: apicurio_serdes.avro._strategies.TopicRecordIdStrategy
+
 ## Exceptions
 
 ### SchemaNotFoundError
@@ -53,10 +79,22 @@ d'`apicurio-serdes`.
 
 ::: apicurio_serdes._errors.RegistryConnectionError
 
+### SchemaRegistrationError
+
+::: apicurio_serdes._errors.SchemaRegistrationError
+
 ### SerializationError
 
 ::: apicurio_serdes._errors.SerializationError
 
+### ResolverError
+
+::: apicurio_serdes._errors.ResolverError
+
 ### DeserializationError
 
 ::: apicurio_serdes._errors.DeserializationError
+
+### AuthenticationError
+
+::: apicurio_serdes._errors.AuthenticationError

--- a/docs/api-reference/index.md
+++ b/docs/api-reference/index.md
@@ -28,6 +28,16 @@ Complete reference for all public classes, methods, and exceptions in `apicurio-
 
 ::: apicurio_serdes.serialization.WireFormat
 
+## Authentication
+
+### BearerAuth
+
+::: apicurio_serdes._auth.BearerAuth
+
+### KeycloakAuth
+
+::: apicurio_serdes._auth.KeycloakAuth
+
 ## Avro
 
 ### AvroSerializer
@@ -42,6 +52,22 @@ Complete reference for all public classes, methods, and exceptions in `apicurio-
 
 ::: apicurio_serdes.avro._async_deserializer.AsyncAvroDeserializer
 
+### TopicIdStrategy
+
+::: apicurio_serdes.avro._strategies.TopicIdStrategy
+
+### SimpleTopicIdStrategy
+
+::: apicurio_serdes.avro._strategies.SimpleTopicIdStrategy
+
+### QualifiedRecordIdStrategy
+
+::: apicurio_serdes.avro._strategies.QualifiedRecordIdStrategy
+
+### TopicRecordIdStrategy
+
+::: apicurio_serdes.avro._strategies.TopicRecordIdStrategy
+
 ## Exceptions
 
 ### SchemaNotFoundError
@@ -52,10 +78,22 @@ Complete reference for all public classes, methods, and exceptions in `apicurio-
 
 ::: apicurio_serdes._errors.RegistryConnectionError
 
+### SchemaRegistrationError
+
+::: apicurio_serdes._errors.SchemaRegistrationError
+
 ### SerializationError
 
 ::: apicurio_serdes._errors.SerializationError
 
+### ResolverError
+
+::: apicurio_serdes._errors.ResolverError
+
 ### DeserializationError
 
 ::: apicurio_serdes._errors.DeserializationError
+
+### AuthenticationError
+
+::: apicurio_serdes._errors.AuthenticationError

--- a/docs/how-to/authentication.en.md
+++ b/docs/how-to/authentication.en.md
@@ -32,7 +32,11 @@ like GCP OIDC identity tokens or Vault leases:
 ```python
 from apicurio_serdes import BearerAuth
 
-auth = BearerAuth(token_provider=lambda: fetch_oidc_token())
+def get_token() -> str:
+    # replace with your actual token-fetching logic
+    return fetch_oidc_token()
+
+auth = BearerAuth(token_provider=get_token)
 ```
 
 `token` and `token_provider` are mutually exclusive; exactly one must be supplied.
@@ -87,7 +91,8 @@ async with AsyncApicurioRegistryClient(
 ## Using a custom `httpx` client (escape hatch)
 
 Neither handler fits? Supply a pre-configured `httpx.Client` via `http_client` instead.
-The client is used as-is and `close()` won't touch it:
+The client is used as-is — `close()` **won't** close it. You are responsible for
+closing it yourself.
 
 ```python
 import httpx

--- a/docs/how-to/authentication.en.md
+++ b/docs/how-to/authentication.en.md
@@ -1,0 +1,122 @@
+# Authentication
+
+Pass an `auth` argument to either client to connect to a protected registry.
+Two handlers are built in: `BearerAuth` for static or provider-supplied tokens,
+and `KeycloakAuth` for OAuth2 client credentials against a Keycloak endpoint.
+
+The `auth` parameter is mutually exclusive with `http_client` — if you supply
+your own httpx client, configure auth on it directly.
+
+## `BearerAuth` — static or dynamic token
+
+### Static token
+
+```python
+from apicurio_serdes import ApicurioRegistryClient, BearerAuth
+
+auth = BearerAuth(token="my-static-token")
+
+client = ApicurioRegistryClient(
+    url="http://registry:8080/apis/registry/v3",
+    group_id="com.example.schemas",
+    auth=auth,
+)
+```
+
+### Dynamic token (refreshed per request)
+
+Pass a zero-argument callable via `token_provider` instead. It is called on every
+request, so it can return a fresh token each time — useful for short-lived credentials
+like GCP OIDC identity tokens or Vault leases:
+
+```python
+from apicurio_serdes import BearerAuth
+
+auth = BearerAuth(token_provider=lambda: fetch_oidc_token())
+```
+
+`token` and `token_provider` are mutually exclusive; exactly one must be supplied.
+
+## `KeycloakAuth` — OAuth2 client credentials
+
+For Keycloak-protected registries, `KeycloakAuth` handles the client credentials
+flow including token refresh. Give it a token URL, a client ID, and a secret:
+
+```python
+from apicurio_serdes import ApicurioRegistryClient, KeycloakAuth
+
+auth = KeycloakAuth(
+    token_url="https://keycloak.example.com/realms/myrealm/protocol/openid-connect/token",
+    client_id="my-client",
+    client_secret="secret",
+    scope="openid",          # optional
+)
+
+client = ApicurioRegistryClient(
+    url="http://registry:8080/apis/registry/v3",
+    group_id="com.example.schemas",
+    auth=auth,
+)
+```
+
+The token is fetched on the first request. After that, `KeycloakAuth` refreshes it
+automatically when less than 20% of its TTL remains. The async client gets its own
+non-blocking refresh path so it never blocks the event loop.
+
+## Using with `AsyncApicurioRegistryClient`
+
+Both `BearerAuth` and `KeycloakAuth` work unchanged with the async client:
+
+```python
+from apicurio_serdes import AsyncApicurioRegistryClient, KeycloakAuth
+
+auth = KeycloakAuth(
+    token_url="https://keycloak.example.com/realms/myrealm/protocol/openid-connect/token",
+    client_id="my-client",
+    client_secret="secret",
+)
+
+async with AsyncApicurioRegistryClient(
+    url="http://registry:8080/apis/registry/v3",
+    group_id="com.example.schemas",
+    auth=auth,
+) as client:
+    ...
+```
+
+## Using a custom `httpx` client (escape hatch)
+
+Neither handler fits? Supply a pre-configured `httpx.Client` via `http_client` instead.
+The client is used as-is and `close()` won't touch it:
+
+```python
+import httpx
+from apicurio_serdes import ApicurioRegistryClient
+
+http_client = httpx.Client(
+    headers={"X-Api-Key": "my-api-key"},
+    verify="/path/to/custom-ca.pem",
+)
+
+client = ApicurioRegistryClient(
+    url="http://registry:8080/apis/registry/v3",
+    group_id="com.example.schemas",
+    http_client=http_client,
+)
+```
+
+## Error handling
+
+Authentication failures raise `AuthenticationError`:
+
+```python
+from apicurio_serdes._errors import AuthenticationError
+
+try:
+    payload = serializer(data, ctx)
+except AuthenticationError as e:
+    print(f"Authentication failed: {e}")
+```
+
+See [Error Handling](./error-handling.md#handling-authenticationerror) for
+common causes and recovery steps.

--- a/docs/how-to/authentication.fr.md
+++ b/docs/how-to/authentication.fr.md
@@ -1,0 +1,127 @@
+# Authentification
+
+Passez un argument `auth` à l'un ou l'autre client pour vous connecter à un registry
+protégé. Deux gestionnaires sont intégrés : `BearerAuth` pour les tokens statiques ou
+fournis par un provider, et `KeycloakAuth` pour les identifiants clients OAuth2 contre
+un endpoint Keycloak.
+
+Le paramètre `auth` est mutuellement exclusif avec `http_client` — si vous fournissez
+votre propre client httpx, configurez l'authentification directement dessus.
+
+## `BearerAuth` — token statique ou dynamique
+
+### Token statique
+
+```python
+from apicurio_serdes import ApicurioRegistryClient, BearerAuth
+
+auth = BearerAuth(token="my-static-token")
+
+client = ApicurioRegistryClient(
+    url="http://registry:8080/apis/registry/v3",
+    group_id="com.example.schemas",
+    auth=auth,
+)
+```
+
+### Token dynamique (rafraîchi à chaque requête)
+
+Passez un callable sans argument via `token_provider` à la place. Il est appelé à chaque
+requête et peut retourner un token frais à chaque fois — utile pour les identifiants
+de courte durée comme les tokens OIDC GCP ou les baux Vault :
+
+```python
+from apicurio_serdes import BearerAuth
+
+auth = BearerAuth(token_provider=lambda: fetch_oidc_token())
+```
+
+`token` et `token_provider` sont mutuellement exclusifs ; exactement l'un des deux doit
+être fourni.
+
+## `KeycloakAuth` — identifiants clients OAuth2
+
+Pour les registries protégés par Keycloak, `KeycloakAuth` gère le flux des identifiants
+clients, y compris le rafraîchissement du token. Fournissez-lui une URL de token, un
+identifiant client et un secret :
+
+```python
+from apicurio_serdes import ApicurioRegistryClient, KeycloakAuth
+
+auth = KeycloakAuth(
+    token_url="https://keycloak.example.com/realms/myrealm/protocol/openid-connect/token",
+    client_id="my-client",
+    client_secret="secret",
+    scope="openid",          # optionnel
+)
+
+client = ApicurioRegistryClient(
+    url="http://registry:8080/apis/registry/v3",
+    group_id="com.example.schemas",
+    auth=auth,
+)
+```
+
+Le token est récupéré lors de la première requête. Ensuite, `KeycloakAuth` le rafraîchit
+automatiquement lorsqu'il reste moins de 20% de son TTL. Le client asynchrone dispose de
+son propre chemin de rafraîchissement non bloquant pour ne jamais bloquer la boucle
+d'événements.
+
+## Utilisation avec `AsyncApicurioRegistryClient`
+
+`BearerAuth` et `KeycloakAuth` fonctionnent sans modification avec le client asynchrone :
+
+```python
+from apicurio_serdes import AsyncApicurioRegistryClient, KeycloakAuth
+
+auth = KeycloakAuth(
+    token_url="https://keycloak.example.com/realms/myrealm/protocol/openid-connect/token",
+    client_id="my-client",
+    client_secret="secret",
+)
+
+async with AsyncApicurioRegistryClient(
+    url="http://registry:8080/apis/registry/v3",
+    group_id="com.example.schemas",
+    auth=auth,
+) as client:
+    ...
+```
+
+## Utilisation d'un client `httpx` personnalisé (trappe de sortie)
+
+Aucun des gestionnaires ne convient ? Fournissez directement un `httpx.Client`
+préconfiguré via `http_client`. Le client est utilisé tel quel et `close()` ne le
+touchera pas :
+
+```python
+import httpx
+from apicurio_serdes import ApicurioRegistryClient
+
+http_client = httpx.Client(
+    headers={"X-Api-Key": "my-api-key"},
+    verify="/chemin/vers/ca-personnalise.pem",
+)
+
+client = ApicurioRegistryClient(
+    url="http://registry:8080/apis/registry/v3",
+    group_id="com.example.schemas",
+    http_client=http_client,
+)
+```
+
+## Gestion des erreurs
+
+Les échecs d'authentification lèvent `AuthenticationError` :
+
+```python
+from apicurio_serdes._errors import AuthenticationError
+
+try:
+    payload = serializer(data, ctx)
+except AuthenticationError as e:
+    print(f"Authentification échouée : {e}")
+```
+
+Voir [Gestion des erreurs](./error-handling.md#gerer-authenticationerror) pour les
+causes fréquentes et les étapes de récupération.

--- a/docs/how-to/authentication.fr.md
+++ b/docs/how-to/authentication.fr.md
@@ -33,7 +33,11 @@ de courte durée comme les tokens OIDC GCP ou les baux Vault :
 ```python
 from apicurio_serdes import BearerAuth
 
-auth = BearerAuth(token_provider=lambda: fetch_oidc_token())
+def get_token() -> str:
+    # remplacez par votre logique réelle de récupération de token
+    return fetch_oidc_token()
+
+auth = BearerAuth(token_provider=get_token)
 ```
 
 `token` et `token_provider` sont mutuellement exclusifs ; exactement l'un des deux doit
@@ -91,8 +95,8 @@ async with AsyncApicurioRegistryClient(
 ## Utilisation d'un client `httpx` personnalisé (trappe de sortie)
 
 Aucun des gestionnaires ne convient ? Fournissez directement un `httpx.Client`
-préconfiguré via `http_client`. Le client est utilisé tel quel et `close()` ne le
-touchera pas :
+préconfiguré via `http_client`. Le client est utilisé tel quel — `close()` **ne le
+fermera pas**. C'est à vous de le fermer.
 
 ```python
 import httpx

--- a/docs/how-to/error-handling.en.md
+++ b/docs/how-to/error-handling.en.md
@@ -9,8 +9,11 @@ Python exceptions for validation errors.
 |-----------|-------------------|----------------|
 | `SchemaNotFoundError` | The artifact or schema ID does not exist in the registry (HTTP 404) | `group_id`, `artifact_id` or `id_type`, `id_value` |
 | `RegistryConnectionError` | The registry is unreachable (network error) | `url` |
+| `SchemaRegistrationError` | The registry rejected a schema registration request (4xx/5xx or bad response body) | `artifact_id`, `cause` |
 | `SerializationError` | The `to_dict` callable raised an exception | `cause` |
+| `ResolverError` | The `artifact_resolver` callable raised an exception or returned a non-string | `cause` |
 | `DeserializationError` | Wire format invalid, Avro decode failure, or `from_dict` hook failure | `cause` |
+| `AuthenticationError` | The token endpoint is unreachable, returned a non-200 response, or the response body is malformed | — |
 | `RuntimeError` | The registry client has been closed | — |
 | `ValueError` | Schema ID exceeds 32-bit limit (CONFLUENT_PAYLOAD), or registry response IDs outside int64 range | — |
 
@@ -171,6 +174,76 @@ contains extra fields not defined in the schema.
 
 **Recovery:** Ensure the data dictionary has all required fields with the correct types,
 or switch wire format for large schema IDs.
+
+## Handling `SchemaRegistrationError`
+
+Raised when `auto_register=True` and the registry rejects the registration request
+(4xx or 5xx response, or the response body is missing the expected IDs).
+
+```python
+from apicurio_serdes._errors import SchemaRegistrationError
+
+try:
+    payload = serializer(data, ctx)
+except SchemaRegistrationError as e:
+    print(f"Registration failed for '{e.artifact_id}': {e.cause}")
+    # e.__cause__ is also set for traceback chaining
+```
+
+**Common causes:**
+
+- `if_exists="FAIL"` and the artifact already exists in the registry
+- The registry rejected the schema content (schema validation error)
+- The registry returned an unexpected response body
+
+**Recovery:** Check `e.cause` for the registry error message. If the artifact already
+exists and `FAIL` is too strict, switch to `if_exists="FIND_OR_CREATE_VERSION"`.
+
+## Handling `ResolverError`
+
+Raised when `artifact_resolver` raises an exception or returns something other than
+a non-empty string.
+
+```python
+from apicurio_serdes._errors import ResolverError
+
+try:
+    payload = serializer(data, ctx)
+except ResolverError as e:
+    print(f"Resolver failed: {e}")
+    if e.cause:
+        print(f"Caused by: {e.cause}")
+```
+
+**Common causes:**
+
+- The resolver raised an unhandled exception
+- The resolver returned `None` or `""` instead of an artifact ID
+
+**Recovery:** Fix the resolver implementation to always return a non-empty string.
+
+## Handling `AuthenticationError`
+
+Raised by `KeycloakAuth` when the token endpoint is unreachable, returns a non-200
+response, or returns a body missing `access_token` or `expires_in`.
+
+```python
+from apicurio_serdes._errors import AuthenticationError
+
+try:
+    payload = serializer(data, ctx)
+except AuthenticationError as e:
+    print(f"Authentication failed: {e}")
+```
+
+**Common causes:**
+
+- The `token_url` is incorrect or the Keycloak realm does not exist
+- The `client_id` or `client_secret` are wrong (non-200 response from the token endpoint)
+- The token endpoint returned JSON without `access_token` or `expires_in`
+
+**Recovery:** Double-check the `token_url`, `client_id`, and `client_secret` in
+`KeycloakAuth`. See [Authentication](../how-to/authentication.md) for examples.
 
 ## Putting It All Together
 

--- a/docs/how-to/error-handling.fr.md
+++ b/docs/how-to/error-handling.fr.md
@@ -9,8 +9,11 @@ ainsi que des exceptions Python standard pour les erreurs de validation.
 |-----------|---------------------|----------------|
 | `SchemaNotFoundError` | L'artefact ou l'identifiant de schema n'existe pas dans le registry (HTTP 404) | `group_id`, `artifact_id` ou `id_type`, `id_value` |
 | `RegistryConnectionError` | Le registry est injoignable (erreur réseau) | `url` |
+| `SchemaRegistrationError` | Le registry a rejeté une demande d'enregistrement de schema (4xx/5xx ou corps de réponse invalide) | `artifact_id`, `cause` |
 | `SerializationError` | Le callable `to_dict` a levé une exception | `cause` |
+| `ResolverError` | Le callable `artifact_resolver` a levé une exception ou retourné une valeur non-string | `cause` |
 | `DeserializationError` | Wire format invalide, échec de décodage Avro, ou échec du hook `from_dict` | `cause` |
+| `AuthenticationError` | L'endpoint de token est injoignable, a retourné une réponse non-200, ou le corps de réponse est malformé | — |
 | `RuntimeError` | Le client registry a été fermé | — |
 | `ValueError` | L'identifiant de schema dépasse la limite 32 bits (CONFLUENT_PAYLOAD), ou les identifiants de la réponse registry sont hors de la plage int64 | — |
 
@@ -183,6 +186,77 @@ les données contiennent des champs supplémentaires non définis dans le schema
 **Récupération :** Assurez-vous que le dictionnaire de données possède tous les champs
 requis avec les types corrects, ou changez de wire format pour les grands identifiants
 de schema.
+
+## Gérer `SchemaRegistrationError`
+
+Levée lorsque `auto_register=True` et que le registry rejette la demande d'enregistrement
+(réponse 4xx ou 5xx, ou corps de réponse sans les identifiants attendus).
+
+```python
+from apicurio_serdes._errors import SchemaRegistrationError
+
+try:
+    payload = serializer(data, ctx)
+except SchemaRegistrationError as e:
+    print(f"Enregistrement échoué pour '{e.artifact_id}' : {e.cause}")
+    # e.__cause__ est également défini pour le chaînage de la trace
+```
+
+**Causes fréquentes :**
+
+- `if_exists="FAIL"` et l'artefact existe déjà dans le registry
+- Le registry a rejeté le contenu du schema (erreur de validation)
+- Le registry a retourné un corps de réponse inattendu
+
+**Récupération :** Consultez `e.cause` pour le message d'erreur du registry. Si l'artefact
+existe déjà et que `FAIL` est trop strict, passez à `if_exists="FIND_OR_CREATE_VERSION"`.
+
+## Gérer `ResolverError`
+
+Levée lorsque `artifact_resolver` lève une exception ou retourne autre chose qu'une
+chaîne non vide.
+
+```python
+from apicurio_serdes._errors import ResolverError
+
+try:
+    payload = serializer(data, ctx)
+except ResolverError as e:
+    print(f"Résolveur en échec : {e}")
+    if e.cause:
+        print(f"Causé par : {e.cause}")
+```
+
+**Causes fréquentes :**
+
+- Le résolveur a levé une exception non gérée
+- Le résolveur a retourné `None` ou `""` au lieu d'un identifiant d'artefact
+
+**Récupération :** Corrigez l'implémentation du résolveur pour qu'il retourne toujours
+une chaîne non vide.
+
+## Gérer `AuthenticationError`
+
+Levée par `KeycloakAuth` lorsque l'endpoint de token est injoignable, retourne une réponse
+non-200, ou retourne un corps sans `access_token` ni `expires_in`.
+
+```python
+from apicurio_serdes._errors import AuthenticationError
+
+try:
+    payload = serializer(data, ctx)
+except AuthenticationError as e:
+    print(f"Authentification échouée : {e}")
+```
+
+**Causes fréquentes :**
+
+- L'URL `token_url` est incorrecte ou le realm Keycloak n'existe pas
+- Le `client_id` ou le `client_secret` sont erronés (réponse non-200 de l'endpoint de token)
+- L'endpoint de token a retourné du JSON sans `access_token` ni `expires_in`
+
+**Récupération :** Vérifiez le `token_url`, le `client_id` et le `client_secret` dans
+`KeycloakAuth`. Voir [Authentification](../how-to/authentication.md) pour des exemples.
 
 ## Tout assembler
 

--- a/docs/user-guide/avro-deserializer.en.md
+++ b/docs/user-guide/avro-deserializer.en.md
@@ -28,6 +28,7 @@ record = deserializer(kafka_message.value(), ctx)
 | `registry_client` | `ApicurioRegistryClient` | required | The registry client used to resolve schema identifiers. |
 | `from_dict` | callable | `None` | Optional `(dict, ctx) -> Any` transformation applied after decoding. |
 | `use_id` | `"contentId"` or `"globalId"` | `"globalId"` | How to interpret the 4-byte schema identifier in the wire format header. |
+| `reader_schema` | `dict` | `None` | Optional Avro schema dict used as the reader schema. When provided, fastavro performs schema resolution between the writer schema (from the message) and this schema, enabling field additions with defaults, type promotions, and alias-based renames. Parsed once at construction time. |
 
 ### Schema identifier mode (`use_id`)
 
@@ -77,6 +78,51 @@ event = deserializer(payload, ctx)
 ```
 
 When `from_dict` is `None` (the default), the decoded dict is returned directly.
+
+## Schema evolution (`reader_schema`)
+
+By default the deserializer uses the writer schema for both reading and decoding — the
+schema embedded in the message. If your consumer is on a different schema version, pass
+`reader_schema` and fastavro handles the resolution:
+
+```python
+writer_schema = {
+    "type": "record",
+    "name": "UserEvent",
+    "namespace": "com.example",
+    "fields": [
+        {"name": "userId", "type": "string"},
+        {"name": "country", "type": "string"},
+    ],
+}
+
+reader_schema = {
+    "type": "record",
+    "name": "UserEvent",
+    "namespace": "com.example",
+    "fields": [
+        {"name": "userId", "type": "string"},
+        {"name": "country", "type": "string"},
+        # New field added in the consumer — default fills the gap
+        {"name": "region", "type": ["null", "string"], "default": None},
+    ],
+}
+
+deserializer = AvroDeserializer(client, reader_schema=reader_schema)
+# Messages written with the old writer_schema decode successfully;
+# "region" comes back as None.
+```
+
+A few things to keep in mind during resolution:
+
+- Fields the reader expects but the writer omitted are filled with their default value;
+  without a default, the decode fails.
+- Fields in the writer that the reader ignores are dropped silently.
+- Type promotions follow Avro rules: `int → long → float → double`, `string → bytes`, etc.
+- Reader field aliases resolve writer field names.
+
+If the schemas are incompatible — say, a new required field has no default — fastavro
+raises a `ValueError` wrapped in `DeserializationError`.
 
 ## Schema caching
 

--- a/docs/user-guide/avro-deserializer.en.md
+++ b/docs/user-guide/avro-deserializer.en.md
@@ -87,6 +87,8 @@ schema embedded in the message. If your consumer is on a different schema versio
 
 ```python
 writer_schema = {
+    # This is what the producer used — it is embedded in the message,
+    # not passed to the deserializer.
     "type": "record",
     "name": "UserEvent",
     "namespace": "com.example",

--- a/docs/user-guide/avro-deserializer.fr.md
+++ b/docs/user-guide/avro-deserializer.fr.md
@@ -87,6 +87,8 @@ passez `reader_schema` et fastavro gère la résolution :
 
 ```python
 writer_schema = {
+    # C'est ce que le producteur a utilisé — il est intégré dans le message,
+    # pas passé au désérialiseur.
     "type": "record",
     "name": "UserEvent",
     "namespace": "com.example",

--- a/docs/user-guide/avro-deserializer.fr.md
+++ b/docs/user-guide/avro-deserializer.fr.md
@@ -28,6 +28,7 @@ record = deserializer(kafka_message.value(), ctx)
 | `registry_client` | `ApicurioRegistryClient` | obligatoire | Le client registry utilisé pour résoudre les identifiants de schema. |
 | `from_dict` | callable | `None` | Transformation optionnelle `(dict, ctx) -> Any` appliquée après le décodage. |
 | `use_id` | `"contentId"` ou `"globalId"` | `"globalId"` | Comment interpréter l'identifiant de schema de 4 octets dans l'en-tête du wire format. |
+| `reader_schema` | `dict` | `None` | Schema Avro optionnel utilisé comme schema lecteur. Quand il est fourni, fastavro effectue une résolution de schema entre le schema d'écriture (issu du message) et ce schema, permettant les ajouts de champs avec valeurs par défaut, les promotions de type et les renommages par alias. Parsé une seule fois à la construction. |
 
 ### Mode d'identifiant de schema (`use_id`)
 
@@ -77,6 +78,51 @@ event = deserializer(payload, ctx)
 ```
 
 Quand `from_dict` est `None` (valeur par défaut), le dict décodé est retourné directement.
+
+## Évolution de schema (`reader_schema`)
+
+Par défaut, le désérialiseur utilise le schema d'écriture pour les deux rôles — le schema
+intégré dans le message. Si votre consommateur est sur une version de schema différente,
+passez `reader_schema` et fastavro gère la résolution :
+
+```python
+writer_schema = {
+    "type": "record",
+    "name": "UserEvent",
+    "namespace": "com.example",
+    "fields": [
+        {"name": "userId", "type": "string"},
+        {"name": "country", "type": "string"},
+    ],
+}
+
+reader_schema = {
+    "type": "record",
+    "name": "UserEvent",
+    "namespace": "com.example",
+    "fields": [
+        {"name": "userId", "type": "string"},
+        {"name": "country", "type": "string"},
+        # Nouveau champ ajouté côté consommateur — la valeur par défaut comble l'écart
+        {"name": "region", "type": ["null", "string"], "default": None},
+    ],
+}
+
+deserializer = AvroDeserializer(client, reader_schema=reader_schema)
+# Les messages écrits avec l'ancien writer_schema décodent correctement ;
+# "region" revient à None.
+```
+
+Quelques points à garder en tête lors de la résolution :
+
+- Les champs attendus par le lecteur mais omis par l'écrivain sont remplis avec leur valeur
+  par défaut ; sans valeur par défaut, le décodage échoue.
+- Les champs de l'écrivain ignorés par le lecteur sont abandonnés silencieusement.
+- Les promotions de type suivent les règles Avro : `int → long → float → double`, `string → bytes`, etc.
+- Les alias de champs du schema lecteur résolvent les noms de champs de l'écrivain.
+
+Si les schemas sont incompatibles — par exemple, un nouveau champ obligatoire sans valeur par
+défaut — fastavro lève une `ValueError` encapsulée dans `DeserializationError`.
 
 ## Mise en cache du schema
 

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -86,6 +86,7 @@ nav:
   - How-to Guides:
       - Custom Serialization: how-to/custom-serialization.md
       - Identifier Selection: how-to/identifier-selection.md
+      - Authentication: how-to/authentication.md
       - Error Handling: how-to/error-handling.md
   - Migration:
       - From confluent-kafka: migration/from-confluent-kafka.md


### PR DESCRIPTION
## Summary

- Add `reader_schema` parameter and schema evolution section to `avro-deserializer` user guide (EN + FR)
- Add `SchemaRegistrationError`, `ResolverError`, and `AuthenticationError` to the error-handling how-to (EN + FR)
- Add authentication how-to covering `BearerAuth`, `KeycloakAuth`, and the `http_client` escape hatch (EN + FR)
- Add `BearerAuth`, `KeycloakAuth`, all four Avro strategies, and three missing exceptions to both API reference pages
- Register the authentication how-to in mkdocs nav

Closes #72

## Test plan

- [ ] All eight changed/created doc files render correctly in MkDocs preview
- [ ] Links between error-handling and authentication pages resolve
- [ ] API reference `:::` directives point to existing module paths

🤖 Generated with [Claude Code](https://claude.com/claude-code)