### PR TITLE
release: v0.4.0

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -3,6 +3,7 @@ name: Publish
 on:
   release:
     types: [published]
+  workflow_dispatch: {}
 
 permissions: {}
 
@@ -10,6 +11,8 @@ jobs:
   build:
     runs-on: ubuntu-latest
     timeout-minutes: 10
+    outputs:
+      hashes: ${{ steps.hashes.outputs.hashes }}
     steps:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd  # v6.0.2
         with:
@@ -19,13 +22,29 @@ jobs:
           python-version: "3.13"
       - uses: astral-sh/setup-uv@37802adc94f370d6bfd71619e3f0bf239e1f3b78  # v7.6.0
       - run: uv build
+      - name: Compute artifact hashes
+        id: hashes
+        run: echo "hashes=$(sha256sum dist/* | base64 -w0)" >> "$GITHUB_OUTPUT"
       - uses: actions/upload-artifact@bbbca2ddaa5d8feaa63e36b76fdaad77386f024f  # v7.0.0
         with:
           name: dist
           path: dist/
 
+  provenance:
+    needs: build
+    if: github.event_name == 'release'
+    permissions:
+      actions: read
+      id-token: write
+      contents: write
+    uses: slsa-framework/slsa-github-generator/.github/workflows/generator_generic_slsa3.yml@v2.1.0
+    with:
+      base64-subjects: "${{ needs.build.outputs.hashes }}"
+      upload-assets: true
+
   sign-release:
     needs: build
+    if: github.event_name == 'release'
     runs-on: ubuntu-latest
     timeout-minutes: 10
     permissions:
@@ -67,7 +86,8 @@ jobs:
           skip-existing: true
 
   validate-testpypi:
-    needs: [build, publish-testpypi]
+    needs: publish-testpypi
+    if: startsWith(github.ref, 'refs/tags/')
     runs-on: ubuntu-latest
     timeout-minutes: 10
     steps:
@@ -102,7 +122,8 @@ jobs:
           python -c "import apicurio_serdes; print(apicurio_serdes.__name__)"
 
   publish-pypi:
-    needs: validate-testpypi
+    needs: [validate-testpypi, provenance]
+    if: github.event_name == 'release'
     runs-on: ubuntu-latest
     timeout-minutes: 10
     environment: pypi

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -64,10 +64,10 @@ jobs:
       - name: Upload signatures to GitHub release
         env:
           GH_TOKEN: ${{ github.token }}
-        run: gh release upload "${{ github.ref_name }}" dist/*.sigstore.json --repo "${{ github.repository }}"
+        run: gh release upload "${{ github.ref_name }}" dist/*.sigstore.json --repo "${{ github.repository }}" --clobber
 
   publish-testpypi:
-    needs: build
+    needs: [build, sign-release]
     runs-on: ubuntu-latest
     timeout-minutes: 10
     environment: testpypi

--- a/.markdownlint.json
+++ b/.markdownlint.json
@@ -1,5 +1,6 @@
 {
   "default": true,
   "MD013": { "line_length": 120, "tables": false, "code_blocks": false },
+  "MD024": { "siblings_only": true },
   "MD060": false
 }

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -7,3 +7,9 @@ repos:
         stages: [pre-commit, pre-push]
       - id: ruff-format
         stages: [pre-commit, pre-push]
+  - repo: https://github.com/PyCQA/bandit
+    rev: 1.9.4
+    hooks:
+      - id: bandit
+        args: ["-c", "pyproject.toml", "-ll"]
+        stages: [pre-commit, pre-push]

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -4,5 +4,6 @@
 
 ## Git Workflow
 
-- The default merge target for all PRs is **`main`**. Never merge into a feature branch unless explicitly instructed.
-- Before merging any PR, confirm the base branch is `main` (or whatever the user explicitly specified).
+- **Feature requests** target the current **release branch** (e.g. `release/v0.4.0`).
+- **Hotfixes** target **`main`** directly.
+- Before merging any PR, confirm the base branch matches this policy (or whatever the user explicitly specified).

--- a/README.md
+++ b/README.md
@@ -9,6 +9,8 @@
 [![Python versions](https://img.shields.io/pypi/pyversions/apicurio-serdes)](https://pypi.org/project/apicurio-serdes/)
 [![PyPI Downloads](https://img.shields.io/pypi/dm/apicurio-serdes)](https://pypi.org/project/apicurio-serdes/)
 [![License](https://img.shields.io/pypi/l/apicurio-serdes)](https://pypi.org/project/apicurio-serdes/)
+[![Ruff](https://img.shields.io/endpoint?url=https://raw.githubusercontent.com/astral-sh/ruff/main/assets/badge/v2.json)](https://github.com/astral-sh/ruff)
+[![security: bandit](https://img.shields.io/badge/security-bandit-yellow.svg)](https://github.com/PyCQA/bandit)
 
 Python serialization library for [Apicurio Registry](https://www.apicur.io/registry/).
 

--- a/docs/api-reference/index.fr.md
+++ b/docs/api-reference/index.fr.md
@@ -29,6 +29,16 @@ d'`apicurio-serdes`.
 
 ::: apicurio_serdes.serialization.WireFormat
 
+## Authentification
+
+### BearerAuth
+
+::: apicurio_serdes._auth.BearerAuth
+
+### KeycloakAuth
+
+::: apicurio_serdes._auth.KeycloakAuth
+
 ## Avro
 
 ### AvroSerializer
@@ -43,6 +53,22 @@ d'`apicurio-serdes`.
 
 ::: apicurio_serdes.avro._async_deserializer.AsyncAvroDeserializer
 
+### TopicIdStrategy
+
+::: apicurio_serdes.avro._strategies.TopicIdStrategy
+
+### SimpleTopicIdStrategy
+
+::: apicurio_serdes.avro._strategies.SimpleTopicIdStrategy
+
+### QualifiedRecordIdStrategy
+
+::: apicurio_serdes.avro._strategies.QualifiedRecordIdStrategy
+
+### TopicRecordIdStrategy
+
+::: apicurio_serdes.avro._strategies.TopicRecordIdStrategy
+
 ## Exceptions
 
 ### SchemaNotFoundError
@@ -53,10 +79,22 @@ d'`apicurio-serdes`.
 
 ::: apicurio_serdes._errors.RegistryConnectionError
 
+### SchemaRegistrationError
+
+::: apicurio_serdes._errors.SchemaRegistrationError
+
 ### SerializationError
 
 ::: apicurio_serdes._errors.SerializationError
 
+### ResolverError
+
+::: apicurio_serdes._errors.ResolverError
+
 ### DeserializationError
 
 ::: apicurio_serdes._errors.DeserializationError
+
+### AuthenticationError
+
+::: apicurio_serdes._errors.AuthenticationError

--- a/docs/api-reference/index.md
+++ b/docs/api-reference/index.md
@@ -28,6 +28,16 @@ Complete reference for all public classes, methods, and exceptions in `apicurio-
 
 ::: apicurio_serdes.serialization.WireFormat
 
+## Authentication
+
+### BearerAuth
+
+::: apicurio_serdes._auth.BearerAuth
+
+### KeycloakAuth
+
+::: apicurio_serdes._auth.KeycloakAuth
+
 ## Avro
 
 ### AvroSerializer
@@ -42,6 +52,22 @@ Complete reference for all public classes, methods, and exceptions in `apicurio-
 
 ::: apicurio_serdes.avro._async_deserializer.AsyncAvroDeserializer
 
+### TopicIdStrategy
+
+::: apicurio_serdes.avro._strategies.TopicIdStrategy
+
+### SimpleTopicIdStrategy
+
+::: apicurio_serdes.avro._strategies.SimpleTopicIdStrategy
+
+### QualifiedRecordIdStrategy
+
+::: apicurio_serdes.avro._strategies.QualifiedRecordIdStrategy
+
+### TopicRecordIdStrategy
+
+::: apicurio_serdes.avro._strategies.TopicRecordIdStrategy
+
 ## Exceptions
 
 ### SchemaNotFoundError
@@ -52,10 +78,22 @@ Complete reference for all public classes, methods, and exceptions in `apicurio-
 
 ::: apicurio_serdes._errors.RegistryConnectionError
 
+### SchemaRegistrationError
+
+::: apicurio_serdes._errors.SchemaRegistrationError
+
 ### SerializationError
 
 ::: apicurio_serdes._errors.SerializationError
 
+### ResolverError
+
+::: apicurio_serdes._errors.ResolverError
+
 ### DeserializationError
 
 ::: apicurio_serdes._errors.DeserializationError
+
+### AuthenticationError
+
+::: apicurio_serdes._errors.AuthenticationError

--- a/docs/changelog.en.md
+++ b/docs/changelog.en.md
@@ -6,6 +6,15 @@ All user-visible changes are documented here.
 
 ### Added
 
+- `ApicurioRegistryClient` and `AsyncApicurioRegistryClient` now retry automatically
+  on transient failures. Retries on `httpx.TransportError` and HTTP 429/502/503/504
+  with exponential backoff and full jitter. Three new constructor parameters control
+  the behaviour: `max_retries` (default 3), `retry_backoff_ms` (default 1 000 ms),
+  `retry_max_backoff_ms` (default 20 000 ms). Set `max_retries=0` to disable.
+- Both clients accept an optional `http_client` escape hatch (`httpx.Client` /
+  `httpx.AsyncClient`). When provided the supplied client is used as-is and is
+  **not** closed by `close()` / `aclose()`. An `auth` parameter is also available
+  for httpx-compatible authentication handlers when not using the escape hatch.
 - `AvroDeserializer` and `AsyncAvroDeserializer` accept an optional
   `reader_schema` parameter (Avro schema dict, default `None`). When provided,
   fastavro performs Avro schema resolution between the writer schema (embedded
@@ -42,18 +51,23 @@ All user-visible changes are documented here.
 
 ### Client Hardening & Deduplication
 
-This release focuses on improving robustness and maintainability through comprehensive client hardening and code deduplication.
+This release focuses on improving robustness and maintainability through comprehensive
+client hardening and code deduplication.
 
 ### Added
 
-- `ApicurioRegistryClient` — HTTP client for the Apicurio Registry v3 native API with schema caching and thread-safe access.
+- `ApicurioRegistryClient` — HTTP client for the Apicurio Registry v3 native API
+  with schema caching and thread-safe access.
 - `AsyncApicurioRegistryClient` — async counterpart using `httpx.AsyncClient`, safe for concurrent coroutine use.
-- `AvroSerializer` — serializes Python data to Confluent-framed Avro bytes. Supports custom `to_dict` hooks, `globalId`/`contentId` wire format selection, strict mode, and `KAFKA_HEADERS` wire format.
+- `AvroSerializer` — serializes Python data to Confluent-framed Avro bytes. Supports
+  custom `to_dict` hooks, `globalId`/`contentId` wire format selection, strict mode,
+  and `KAFKA_HEADERS` wire format.
 - `AvroDeserializer` — deserializes Confluent-framed Avro bytes back to Python dicts with optional `from_dict` hook.
 - `AsyncAvroDeserializer` — async counterpart to `AvroDeserializer`.
 - `SerializationContext` and `MessageField` — thin context objects compatible with confluent-kafka's interface.
 - `WireFormat` enum — `CONFLUENT_PAYLOAD` and `KAFKA_HEADERS` framing modes.
-- `SchemaNotFoundError`, `RegistryConnectionError`, `SerializationError`, `DeserializationError` — typed exception hierarchy for predictable error handling.
+- `SchemaNotFoundError`, `RegistryConnectionError`, `SerializationError`,
+  `DeserializationError` — typed exception hierarchy for predictable error handling.
 - `CachedSchema` — frozen (immutable) dataclass holding resolved schema data and registry metadata.
 - Closed-client guard (`RuntimeError`) on both sync and async clients to prevent use-after-close.
 - 32-bit schema ID validation for `CONFLUENT_PAYLOAD` wire format with actionable error message suggesting `KAFKA_HEADERS`.
@@ -62,7 +76,8 @@ This release focuses on improving robustness and maintainability through compreh
 
 ### Changed
 
-- **Breaking**: `AvroDeserializer` and `AsyncAvroDeserializer` `use_id` default changed from `"contentId"` to `"globalId"` to match `AvroSerializer` default (see ADR-006).
+- **Breaking**: `AvroDeserializer` and `AsyncAvroDeserializer` `use_id` default changed
+  from `"contentId"` to `"globalId"` to match `AvroSerializer` default (see ADR-006).
 
 ### Internal
 

--- a/docs/changelog.en.md
+++ b/docs/changelog.en.md
@@ -6,6 +6,12 @@ All user-visible changes are documented here.
 
 ### Added
 
+- `AvroDeserializer` and `AsyncAvroDeserializer` accept an optional
+  `reader_schema` parameter (Avro schema dict, default `None`). When provided,
+  fastavro performs Avro schema resolution between the writer schema (embedded
+  in the message) and the supplied reader schema, enabling schema evolution
+  patterns: field defaults fill gaps for added fields, type promotions, and
+  alias-based field renames. Parsed once at construction time.
 - `register_schema(artifact_id, schema, if_exists)` method on both
   `ApicurioRegistryClient` and `AsyncApicurioRegistryClient`. Registers a
   schema artifact via the Apicurio Registry v3 `POST /groups/{groupId}/artifacts`

--- a/docs/changelog.en.md
+++ b/docs/changelog.en.md
@@ -6,6 +6,10 @@ All user-visible changes are documented here.
 
 ### Added
 
+- `cache_max_size` (default `1000`) and `cache_ttl_seconds` (default `None`) constructor parameters on both clients.
+  `cache_max_size` caps both caches with LRU eviction. `cache_ttl_seconds` enables optional TTL expiry on
+  artifact-based lookups (`get_schema`, `register_schema`); ID-based lookups (`get_schema_by_global_id`,
+  `get_schema_by_content_id`) are content-addressed and never expire.
 - `ApicurioRegistryClient` and `AsyncApicurioRegistryClient` now retry automatically
   on transient failures. Retries on `httpx.TransportError` and HTTP 429/502/503/504
   with exponential backoff and full jitter. Three new constructor parameters control

--- a/docs/changelog.fr.md
+++ b/docs/changelog.fr.md
@@ -6,6 +6,13 @@ Toutes les modifications visibles par les utilisateurs sont documentées ici.
 
 ### Ajouts
 
+- `AvroDeserializer` et `AsyncAvroDeserializer` acceptent un paramètre optionnel
+  `reader_schema` (dict de schema Avro, défaut `None`). Quand il est fourni,
+  fastavro effectue une résolution de schema Avro entre le schema d'écriture
+  (embarqué dans le message) et le schema lecteur fourni, permettant les
+  patrons d'évolution de schema : les valeurs par défaut remplissent les
+  nouveaux champs ajoutés, les promotions de type sont supportées, ainsi que
+  les renommages de champs via alias. Parsé une seule fois à la construction.
 - Méthode `register_schema(artifact_id, schema, if_exists)` sur `ApicurioRegistryClient`
   et `AsyncApicurioRegistryClient`. Enregistre un artifact de schema via l'endpoint
   Apicurio Registry v3 `POST /groups/{groupId}/artifacts` et peuple le cache

--- a/docs/changelog.fr.md
+++ b/docs/changelog.fr.md
@@ -6,6 +6,10 @@ Toutes les modifications visibles par les utilisateurs sont documentées ici.
 
 ### Ajouts
 
+- Paramètres de constructeur `cache_max_size` (défaut `1000`) et `cache_ttl_seconds` (défaut `None`) sur les deux
+  clients. `cache_max_size` limite les deux caches avec éviction LRU. `cache_ttl_seconds` active un TTL optionnel sur
+  les lookups basés sur l'artifact (`get_schema`, `register_schema`) ; les lookups basés sur l'identifiant
+  (`get_schema_by_global_id`, `get_schema_by_content_id`) sont adressés par contenu et n'expirent jamais.
 - `ApicurioRegistryClient` et `AsyncApicurioRegistryClient` effectuent désormais
   automatiquement des nouvelles tentatives sur les défaillances transitoires. Les
   nouvelles tentatives couvrent les `httpx.TransportError` et les codes HTTP

--- a/docs/changelog.fr.md
+++ b/docs/changelog.fr.md
@@ -6,6 +6,18 @@ Toutes les modifications visibles par les utilisateurs sont documentées ici.
 
 ### Ajouts
 
+- `ApicurioRegistryClient` et `AsyncApicurioRegistryClient` effectuent désormais
+  automatiquement des nouvelles tentatives sur les défaillances transitoires. Les
+  nouvelles tentatives couvrent les `httpx.TransportError` et les codes HTTP
+  429/502/503/504, avec un délai exponentiel et full jitter. Trois nouveaux paramètres
+  de constructeur contrôlent ce comportement : `max_retries` (défaut 3),
+  `retry_backoff_ms` (défaut 1 000 ms), `retry_max_backoff_ms` (défaut 20 000 ms).
+  Définir `max_retries=0` pour désactiver.
+- Les deux clients acceptent un paramètre de fuite optionnel `http_client`
+  (`httpx.Client` / `httpx.AsyncClient`). Quand il est fourni, le client fourni est
+  utilisé tel quel et **n'est pas** fermé par `close()` / `aclose()`. Un paramètre
+  `auth` est également disponible pour les gestionnaires d'authentification
+  compatibles httpx quand le paramètre `http_client` n'est pas utilisé.
 - `AvroDeserializer` et `AsyncAvroDeserializer` acceptent un paramètre optionnel
   `reader_schema` (dict de schema Avro, défaut `None`). Quand il est fourni,
   fastavro effectue une résolution de schema Avro entre le schema d'écriture
@@ -42,27 +54,37 @@ Toutes les modifications visibles par les utilisateurs sont documentées ici.
 
 ### Durcissement des clients et déduplication
 
-Cette version se concentre sur l'amélioration de la robustesse et de la maintenabilité par le durcissement complet des clients et la déduplication du code.
+Cette version se concentre sur l'amélioration de la robustesse et de la maintenabilité
+par le durcissement complet des clients et la déduplication du code.
 
 ### Ajouts
 
-- `ApicurioRegistryClient` — client HTTP pour l'API native v3 d'Apicurio Registry avec mise en cache des schemas et accès thread-safe.
-- `AsyncApicurioRegistryClient` — équivalent asynchrone utilisant `httpx.AsyncClient`, adapté à l'utilisation concurrente de coroutines.
-- `AvroSerializer` — sérialise les données Python en octets Avro au cadrage Confluent. Prend en charge les hooks `to_dict` personnalisés, la sélection du wire format `globalId`/`contentId`, le mode strict, et le wire format `KAFKA_HEADERS`.
+- `ApicurioRegistryClient` — client HTTP pour l'API native v3 d'Apicurio Registry avec
+  mise en cache des schemas et accès thread-safe.
+- `AsyncApicurioRegistryClient` — équivalent asynchrone utilisant `httpx.AsyncClient`,
+  adapté à l'utilisation concurrente de coroutines.
+- `AvroSerializer` — sérialise les données Python en octets Avro au cadrage Confluent.
+  Prend en charge les hooks `to_dict` personnalisés, la sélection du wire format
+  `globalId`/`contentId`, le mode strict, et le wire format `KAFKA_HEADERS`.
 - `AvroDeserializer` — désérialise les octets Avro au cadrage Confluent en dicts Python avec hook `from_dict` optionnel.
 - `AsyncAvroDeserializer` — équivalent asynchrone d'`AvroDeserializer`.
 - `SerializationContext` et `MessageField` — objets de contexte légers compatibles avec l'interface de confluent-kafka.
 - Enum `WireFormat` — modes de cadrage `CONFLUENT_PAYLOAD` et `KAFKA_HEADERS`.
-- `SchemaNotFoundError`, `RegistryConnectionError`, `SerializationError`, `DeserializationError` — hiérarchie d'exceptions typées pour une gestion d'erreurs prévisible.
+- `SchemaNotFoundError`, `RegistryConnectionError`, `SerializationError`,
+  `DeserializationError` — hiérarchie d'exceptions typées pour une gestion
+  d'erreurs prévisible.
 - `CachedSchema` — dataclass gelée (immutable) contenant les données de schema résolues et les métadonnées du registry.
 - Protection contre l'utilisation d'un client fermé (`RuntimeError`) sur les clients sync et async.
-- Validation de l'identifiant de schema 32 bits pour le wire format `CONFLUENT_PAYLOAD` avec message d'erreur suggérant `KAFKA_HEADERS`.
+- Validation de l'identifiant de schema 32 bits pour le wire format `CONFLUENT_PAYLOAD`
+  avec message d'erreur suggérant `KAFKA_HEADERS`.
 - Validation de la plage int64 signé sur les `globalId`/`contentId` des en-têtes de réponse du registry.
 - 19 Architecture Decision Records dans `docs/decisions/`.
 
 ### Modifié
 
-- **Rupture** : le défaut de `use_id` d'`AvroDeserializer` et `AsyncAvroDeserializer` est passé de `"contentId"` à `"globalId"` pour correspondre au défaut d'`AvroSerializer` (voir ADR-006).
+- **Rupture** : le défaut de `use_id` d'`AvroDeserializer` et `AsyncAvroDeserializer`
+  est passé de `"contentId"` à `"globalId"` pour correspondre au défaut
+  d'`AvroSerializer` (voir ADR-006).
 
 ### Interne
 

--- a/docs/concepts/schema-caching.en.md
+++ b/docs/concepts/schema-caching.en.md
@@ -1,10 +1,13 @@
 # Schema Caching
 
-`apicurio-serdes` caches schemas after the first fetch so that subsequent serialization calls do not make HTTP requests. This page explains how schema caching works and what to expect from its behaviour.
+`apicurio-serdes` caches schemas after the first fetch so that subsequent serialization calls do not make HTTP
+requests. This page explains how schema caching works and what to expect from its behaviour.
 
 ## How the Cache Works
 
-When you call a serializer for the first time, it asks the `ApicurioRegistryClient` to fetch the schema from the registry. The client stores the result as a `CachedSchema` — a frozen (immutable) dataclass — in an in-memory cache keyed by `(group_id, artifact_id)`. Freezing the cached entry prevents accidental mutation of shared schema data.
+When you call a serializer for the first time, it asks the `ApicurioRegistryClient` to fetch the schema from the
+registry. The client stores the result as a `CachedSchema` — a frozen (immutable) dataclass — in an in-memory cache
+keyed by `(group_id, artifact_id)`. Freezing the cached entry prevents accidental mutation of shared schema data.
 
 ```text
 First call:
@@ -32,12 +35,23 @@ Subsequent calls:
 
 ## Cache Lifetime
 
-The cache lives for the lifetime of the `ApicurioRegistryClient` instance. There is no TTL (time-to-live) or expiration — once a schema is cached, it stays cached until the client is garbage-collected.
+The cache lives for the lifetime of the `ApicurioRegistryClient` instance. By default there is no TTL (time-to-live)
+or expiration — once a schema is cached, it stays cached until the client is garbage-collected or the entry is evicted
+by the LRU policy.
+
+Artifact-based lookups (`get_schema`, `register_schema`) can be given a configurable TTL via `cache_ttl_seconds`.
+After the TTL elapses, the next call re-fetches from the registry and picks up any new schema version automatically.
+
+ID-based lookups (`get_schema_by_global_id`, `get_schema_by_content_id`) are content-addressed and immutable — a
+`globalId` or `contentId` always refers to the same schema content. These entries never expire regardless of
+`cache_ttl_seconds`.
 
 This means:
 
-- **Within a long-running process** (e.g., a Kafka consumer loop), schemas are fetched once at startup and never again.
-- **If a schema changes in the registry**, the running client will not see the new version. To pick up schema changes, create a new `ApicurioRegistryClient` instance.
+- **Within a long-running process** (e.g., a Kafka consumer loop), schemas are fetched once at startup and never
+  again (unless TTL is set or they are evicted by the LRU policy).
+- **If a schema changes in the registry** and no TTL is configured, the running client will not see the new version
+  until restarted. With `cache_ttl_seconds` set, the client picks up new versions automatically after each TTL window.
 
 ```python
 # Schema cached for the lifetime of this client
@@ -55,9 +69,35 @@ for event in events:
     serializer_a(event, ctx)
 ```
 
+## Cache Eviction and Size Limits
+
+Two constructor parameters control cache behaviour:
+
+- `cache_max_size` (default `1000`): maximum number of entries in each cache. When the limit is reached, the
+  least-recently-used entry is evicted to make room for new entries (LRU policy). Applies to both the schema cache
+  and the ID cache.
+- `cache_ttl_seconds` (default `None`): optional TTL in seconds for artifact-based schema cache entries. After this
+  duration, the cached entry is treated as a miss and the registry is re-fetched. ID-based cache entries never expire.
+
+```python
+from apicurio_serdes import ApicurioRegistryClient
+
+# Limit both caches to 500 entries and re-fetch artifact schemas every 5 minutes
+client = ApicurioRegistryClient(
+    url="http://registry:8080/apis/registry/v3",
+    group_id="com.example.schemas",
+    cache_max_size=500,
+    cache_ttl_seconds=300,
+)
+```
+
+Both parameters raise `ValueError` on invalid values: `cache_max_size` must be at least `1`;
+`cache_ttl_seconds` must be `None` or strictly positive.
+
 ## Cache Sharing
 
-Multiple serializers that share the same `ApicurioRegistryClient` instance also share the cache. If two serializers use the same `artifact_id`, the schema is fetched once:
+Multiple serializers that share the same `ApicurioRegistryClient` instance also share the cache. If two serializers
+use the same `artifact_id`, the schema is fetched once:
 
 ```python
 # Same client → same cache → one HTTP request for "UserEvent"
@@ -69,18 +109,23 @@ If you create separate `ApicurioRegistryClient` instances, each has its own inde
 
 ## Thread Safety
 
-The cache is protected by a reentrant lock (`threading.RLock`). Multiple threads can safely call `get_schema` concurrently:
+The cache is protected by a reentrant lock (`threading.RLock`). Multiple threads can safely call `get_schema`
+concurrently:
 
-- If two threads request the same schema simultaneously, only one makes the HTTP request; the other waits on the lock and then reads from the cache.
+- If two threads request the same schema simultaneously, only one makes the HTTP request; the other waits on the lock
+  and then reads from the cache.
 - Read operations on an already-cached schema do not acquire the lock (fast path).
 
-This means you can safely share a single `ApicurioRegistryClient` and its serializers across threads in a multi-threaded producer.
+This means you can safely share a single `ApicurioRegistryClient` and its serializers across threads in a
+multi-threaded producer.
 
 ## When to Create a New Client
 
 Create a new `ApicurioRegistryClient` when:
 
-- **The schema has been updated in the registry** and you need the new version.
+- **The schema has been updated in the registry** and you need the new version, and no `cache_ttl_seconds` is
+  configured. With `cache_ttl_seconds` set, the running client picks up new schema versions automatically after each
+  TTL window.
 - **You are connecting to a different registry** or switching groups.
 - **You want to reset the cache** (e.g., in tests).
 

--- a/docs/concepts/schema-caching.fr.md
+++ b/docs/concepts/schema-caching.fr.md
@@ -1,10 +1,15 @@
 # Mise en cache des schemas
 
-`apicurio-serdes` met en cache les schemas après la première récupération afin que les appels de sérialisation suivants n'effectuent pas de requêtes HTTP. Cette page explique le fonctionnement de la mise en cache des schemas et ce qu'il faut en attendre.
+`apicurio-serdes` met en cache les schemas après la première récupération afin que les appels de sérialisation
+suivants n'effectuent pas de requêtes HTTP. Cette page explique le fonctionnement de la mise en cache des schemas et
+ce qu'il faut en attendre.
 
 ## Fonctionnement du cache
 
-Lorsque vous appelez un serializer pour la première fois, il demande à l'`ApicurioRegistryClient` de récupérer le schema depuis le registry. Le client stocke le résultat sous forme de `CachedSchema` — une dataclass gelée (immutable) — dans un cache en mémoire indexé par `(group_id, artifact_id)`. Le gel de l'entrée en cache empêche la mutation accidentelle des données de schema partagées.
+Lorsque vous appelez un serializer pour la première fois, il demande à l'`ApicurioRegistryClient` de récupérer le
+schema depuis le registry. Le client stocke le résultat sous forme de `CachedSchema` — une dataclass gelée (immutable)
+— dans un cache en mémoire indexé par `(group_id, artifact_id)`. Le gel de l'entrée en cache empêche la mutation
+accidentelle des données de schema partagées.
 
 ```text
 First call:
@@ -32,12 +37,26 @@ Subsequent calls:
 
 ## Durée de vie du cache
 
-Le cache persiste pendant toute la durée de vie de l'instance `ApicurioRegistryClient`. Il n'y a pas de TTL (time-to-live) ni d'expiration — une fois qu'un schema est mis en cache, il y reste jusqu'à ce que le client soit collecté par le ramasse-miettes.
+Le cache persiste pendant toute la durée de vie de l'instance `ApicurioRegistryClient`. Par défaut, il n'y a pas de
+TTL (time-to-live) ni d'expiration — une fois qu'un schema est mis en cache, il y reste jusqu'à ce que le client soit
+collecté par le ramasse-miettes ou que l'entrée soit évincée par la politique LRU.
+
+Les lookups basés sur l'artifact (`get_schema`, `register_schema`) peuvent recevoir un TTL configurable via
+`cache_ttl_seconds`. Une fois le TTL écoulé, le prochain appel récupère à nouveau depuis le registry et intègre
+automatiquement toute nouvelle version de schema.
+
+Les lookups basés sur l'identifiant (`get_schema_by_global_id`, `get_schema_by_content_id`) sont adressés par contenu
+et immuables — un `globalId` ou `contentId` fait toujours référence au même contenu de schema. Ces entrées n'expirent
+jamais, quelle que soit la valeur de `cache_ttl_seconds`.
 
 Cela signifie :
 
-- **Au sein d'un processus de longue durée** (par ex., une boucle de consommation Kafka), les schemas sont récupérés une seule fois au démarrage et jamais ensuite.
-- **Si un schema change dans le registry**, le client en cours d'exécution ne verra pas la nouvelle version. Pour prendre en compte les changements de schema, créez une nouvelle instance d'`ApicurioRegistryClient`.
+- **Au sein d'un processus de longue durée** (par ex., une boucle de consommation Kafka), les schemas sont récupérés
+  une seule fois au démarrage et jamais ensuite (sauf si un TTL est configuré ou si des entrées sont évincées par la
+  politique LRU).
+- **Si un schema change dans le registry** et qu'aucun TTL n'est configuré, le client en cours d'exécution ne verra
+  pas la nouvelle version avant un redémarrage. Avec `cache_ttl_seconds` configuré, le client intègre les nouvelles
+  versions automatiquement après chaque fenêtre TTL.
 
 ```python
 # Schema cached for the lifetime of this client
@@ -55,9 +74,36 @@ for event in events:
     serializer_a(event, ctx)
 ```
 
+## Éviction du cache et limites de taille
+
+Deux paramètres de constructeur contrôlent le comportement du cache :
+
+- `cache_max_size` (défaut `1000`) : nombre maximum d'entrées dans chaque cache. Lorsque la limite est atteinte,
+  l'entrée la moins récemment utilisée est évincée pour faire de la place aux nouvelles entrées (politique LRU).
+  S'applique au cache de schemas et au cache d'identifiants.
+- `cache_ttl_seconds` (défaut `None`) : TTL optionnel en secondes pour les entrées du cache de schemas basé sur
+  l'artifact. Après cette durée, l'entrée est traitée comme un cache miss et le registry est de nouveau interrogé.
+  Les entrées du cache d'identifiants n'expirent jamais.
+
+```python
+from apicurio_serdes import ApicurioRegistryClient
+
+# Limiter les deux caches à 500 entrées et récupérer les schemas d'artifact toutes les 5 minutes
+client = ApicurioRegistryClient(
+    url="http://registry:8080/apis/registry/v3",
+    group_id="com.example.schemas",
+    cache_max_size=500,
+    cache_ttl_seconds=300,
+)
+```
+
+Ces deux paramètres lèvent une `ValueError` en cas de valeur invalide : `cache_max_size` doit être au moins `1` ;
+`cache_ttl_seconds` doit être `None` ou strictement positif.
+
 ## Partage du cache
 
-Plusieurs serializers qui partagent la même instance d'`ApicurioRegistryClient` partagent également le cache. Si deux serializers utilisent le même `artifact_id`, le schema n'est récupéré qu'une seule fois :
+Plusieurs serializers qui partagent la même instance d'`ApicurioRegistryClient` partagent également le cache.
+Si deux serializers utilisent le même `artifact_id`, le schema n'est récupéré qu'une seule fois :
 
 ```python
 # Same client → same cache → one HTTP request for "UserEvent"
@@ -69,18 +115,23 @@ Si vous créez des instances distinctes d'`ApicurioRegistryClient`, chacune poss
 
 ## Thread Safety
 
-Le cache est protégé par un verrou réentrant (`threading.RLock`). Plusieurs threads peuvent appeler `get_schema` de manière concurrente en toute sécurité :
+Le cache est protégé par un verrou réentrant (`threading.RLock`). Plusieurs threads peuvent appeler `get_schema`
+de manière concurrente en toute sécurité :
 
-- Si deux threads demandent le même schema simultanément, un seul effectue la requête HTTP ; l'autre attend sur le verrou puis lit depuis le cache.
+- Si deux threads demandent le même schema simultanément, un seul effectue la requête HTTP ; l'autre attend sur le
+  verrou puis lit depuis le cache.
 - Les opérations de lecture sur un schema déjà en cache n'acquièrent pas le verrou (chemin rapide).
 
-Cela signifie que vous pouvez partager en toute sécurité une seule instance d'`ApicurioRegistryClient` et ses serializers entre plusieurs threads dans un producteur multi-thread.
+Cela signifie que vous pouvez partager en toute sécurité une seule instance d'`ApicurioRegistryClient` et ses
+serializers entre plusieurs threads dans un producteur multi-thread.
 
 ## Quand créer un nouveau client
 
 Créez une nouvelle instance d'`ApicurioRegistryClient` lorsque :
 
-- **Le schema a été mis à jour dans le registry** et vous avez besoin de la nouvelle version.
+- **Le schema a été mis à jour dans le registry** et vous avez besoin de la nouvelle version, et qu'aucun
+  `cache_ttl_seconds` n'est configuré. Avec `cache_ttl_seconds` configuré, le client intègre les nouvelles versions
+  de schemas automatiquement après chaque fenêtre TTL.
 - **Vous vous connectez à un registry différent** ou changez de groupe.
 - **Vous souhaitez réinitialiser le cache** (par ex., dans les tests).
 

--- a/docs/decisions/011-no-cache-eviction.md
+++ b/docs/decisions/011-no-cache-eviction.md
@@ -1,6 +1,11 @@
 # ADR-011: No cache eviction — unbounded cache growth accepted
 
-**Status:** Accepted
+> **This decision has been superseded by [ADR-021](021-lru-ttl-cache-eviction.md).**
+> ADR-021 introduces `_CacheCore` with LRU eviction and optional TTL, activated
+> by issue #39 (v0.4.0 milestone). The analysis below is preserved for historical
+> context.
+
+**Status:** Superseded by [ADR-021](021-lru-ttl-cache-eviction.md)
 **Date:** 2026-03-11
 **Context:** PR #32 review item 11 — "Unbounded cache growth — no eviction"
 

--- a/docs/decisions/014-no-timeout-retry-configuration.md
+++ b/docs/decisions/014-no-timeout-retry-configuration.md
@@ -1,6 +1,6 @@
 # ADR-014: No timeout or retry configuration on HTTP clients
 
-**Status:** Accepted
+**Status:** Superseded by ADR-020
 **Date:** 2026-03-11
 **Context:** PR #32 review item 15 — "No timeout/retry configuration on HTTP clients"
 

--- a/docs/decisions/020-retry-with-exponential-backoff.md
+++ b/docs/decisions/020-retry-with-exponential-backoff.md
@@ -1,0 +1,67 @@
+# ADR-020: Retry with Exponential Backoff and httpx Escape Hatch
+
+**Status:** Accepted
+**Date:** 2026-03-18
+**Supersedes:** ADR-014 (No timeout or retry configuration on HTTP clients)
+
+## Context
+
+ADR-014 rejected built-in retry logic on the grounds that retry policy is
+application-specific and baking it in forces opinions on callers. However, both
+reference implementations disagree:
+
+- **Confluent Python** (`SchemaRegistryClient`): built-in retry with
+  `max.retries=3`, `retries.wait.ms=1000`, `retries.max.wait.ms=20000`,
+  exponential backoff with full jitter, retrying on 408/429/5xx.
+- **Apicurio Java** (`SchemaResolverConfig`): built-in retry with
+  `apicurio.registry.retry-count=3`, `apicurio.registry.retry-backoff-ms=300`.
+
+Additionally, the "delegate to the user" escape hatch proposed in ADR-014
+(pass a pre-configured `httpx.Client`) does not actually cover the transient
+HTTP status code case: `httpx.HTTPTransport(retries=N)` only retries on
+connection errors, not on 429/5xx responses. Users who need full retry
+coverage would have to implement the retry loop themselves — a significant
+burden for a trivially common operational concern.
+
+The set of retryable events (transport errors, 429, 502, 503, 504) is
+uncontroversial, well-established, and safe regardless of caller SLA. A user
+who wants no retries can set `max_retries=0`.
+
+## Decision
+
+1. Add `max_retries`, `retry_backoff_ms`, and `retry_max_backoff_ms`
+   keyword-only parameters to both `ApicurioRegistryClient` and
+   `AsyncApicurioRegistryClient`, with defaults matching Confluent Python
+   (`max_retries=3`, `retry_backoff_ms=1000`, `retry_max_backoff_ms=20000`).
+
+2. Implement exponential backoff with full jitter:
+   `delay = random.uniform(0, min(retry_backoff_ms * 2^attempt, retry_max_backoff_ms)) / 1000`.
+
+3. Retry on: `httpx.TransportError` (any), HTTP 429, 502, 503, 504.
+   Do **not** retry on: 4xx other than 429, 500 (ambiguous for mutations).
+
+4. Also accept an `http_client` keyword-only parameter (`httpx.Client` for
+   sync, `httpx.AsyncClient` for async) as a power-user escape hatch for
+   custom transports, connection pools, auth, and mTLS. When a user-provided
+   client is given, the library does not close it on `close()` / `aclose()`.
+
+## Rationale
+
+- Aligns with both reference implementations.
+- Retryable events are infrastructure noise, not business logic — the
+  right policy is uncontroversial for this class of errors.
+- `httpx.HTTPTransport(retries=N)` is insufficient for production use
+  (covers only connection errors, not 5xx/429).
+- `max_retries=0` fully disables retry for callers who prefer to manage
+  it themselves.
+- The `http_client` escape hatch preserves the power-user path from ADR-014's
+  revisit trigger.
+
+## Consequences
+
+- Existing clients get 3 retries by default where they previously had none.
+  On persistent registry outages, failure takes up to ~3× longer to surface.
+  This is acceptable and matches the behaviour users expect from the reference
+  implementations.
+- The `http_client` parameter enables advanced scenarios (mTLS, custom proxies,
+  service-mesh-aware auth) without the library needing to expose every knob.

--- a/docs/decisions/021-lru-ttl-cache-eviction.md
+++ b/docs/decisions/021-lru-ttl-cache-eviction.md
@@ -1,0 +1,111 @@
+# ADR-021: LRU + optional TTL cache eviction via `_CacheCore`
+
+**Status:** Accepted
+**Date:** 2026-03-19
+**Supersedes:** [ADR-011](011-no-cache-eviction.md)
+**Context:** Issue #39 (v0.4.0 milestone) — configurable LRU size cap and optional TTL expiry
+
+## Context
+
+ADR-011 accepted unbounded caches with a revisit trigger: *"if real-world users
+report memory pressure, add optional `max_cache_size` with LRU eviction."*
+Issue #39, added to the v0.4.0 milestone, activates that trigger.
+
+Additionally, ADR-011's rationale that *"schemas are immutable"* is only
+partially correct. ID-based lookups (`globalId`, `contentId`) are
+content-addressed and truly immutable. But artifact-based lookups (`get_schema`
+by `artifact_id`) return the **latest version**, which changes every time a new
+schema version is registered. TTL is therefore justified for `_schema_cache` but
+not for `_id_cache`.
+
+## Decision
+
+Introduce `_CacheCore` — a lock-free `OrderedDict`-backed cache class — in
+`_base.py`. Replace both plain `dict` caches in `_RegistryClientBase` with
+`_CacheCore` instances. Add two new keyword-only constructor parameters to both
+`ApicurioRegistryClient` and `AsyncApicurioRegistryClient`:
+
+| Parameter | Type | Default | Applied to |
+| --------- | ---- | ------- | ---------- |
+| `cache_max_size` | `int` | `1000` | Both `_schema_cache` and `_id_cache` |
+| `cache_ttl_seconds` | `float \| None` | `None` | `_schema_cache` only |
+
+`_id_cache` is always constructed with `ttl=None` regardless of
+`cache_ttl_seconds`. `cache_max_size` applies to both caches as a memory bound.
+
+## Rationale
+
+### Split-cache TTL policy
+
+Artifact-based lookups return the *latest version* (mutable). A new schema
+version registered after a cache entry is written makes that entry stale. TTL
+is the correct mechanism to surface new versions automatically.
+
+ID-based lookups are content-addressed and immutable — `globalId` and
+`contentId` are permanent identifiers for specific schema content. There is no
+correctness reason to expire them; doing so only wastes HTTP round-trips to
+re-fetch identical content.
+
+### Intentional divergence from Apicurio Java
+
+The Apicurio Java client (`ERCache.java`) applies the **same TTL** to all five
+lookup indexes, including ID-based ones, and has **no LRU size cap**. We diverge
+on both points as a deliberate semantic choice:
+
+- **No TTL on ID cache**: ID lookups are immutable; expiring them is semantically
+  wrong, not merely pragmatic.
+- **LRU cap on both caches**: `ConcurrentHashMap` with no size limit is a memory
+  safety hazard in long-running services. We cap both caches as a defensive bound.
+
+### Alignment with Confluent Python
+
+The Confluent Python client (`confluent-kafka-python`) independently arrived at
+the same split: a permanent `_SchemaCache` for ID-based lookups and a
+`TTLCache`/`LRUCache` for latest-version lookups. Our design aligns with
+Confluent on semantics:
+
+| Decision | Confluent Python | Apicurio Java | This library |
+| -------- | ---------------- | ------------- | ------------ |
+| TTL on artifact (mutable) cache | Yes (optional) | Yes (30 s default) | Yes (`None` default) |
+| TTL on ID (immutable) cache | No — permanent | Yes (same TTL) | **No — permanent** |
+| LRU cap on artifact cache | Yes (1000) | No | Yes (1000) |
+| LRU cap on ID cache | No cap | No | Yes (1000, shared param) |
+
+### Stdlib-only constraint
+
+`_CacheCore` uses `collections.OrderedDict` and `time.monotonic` only — no new
+dependencies. `move_to_end` and `popitem(last=False)` are both O(1) on CPython's
+`OrderedDict`.
+
+### Lock-free design
+
+`_CacheCore` is intentionally lock-free. The existing client locks
+(`threading.RLock` for sync, `asyncio.Lock` for async) already serialise the
+check-fetch-set sequence required by the double-checked locking pattern
+(ADR-004). Adding a second internal lock inside `_CacheCore` would introduce
+re-entrancy concerns with `asyncio.Lock` (which is not re-entrant) and
+unnecessary overhead.
+
+`peek()` is used in the unlocked fast path: it checks TTL but does **not** call
+`move_to_end` or `del` (both are mutating operations unsafe without a lock). The
+actual LRU update and deletion happen inside the lock via `get()`.
+
+### Default alignment
+
+Defaults match Confluent Python exactly:
+
+- `cache_max_size=1000` matches `cache.capacity` default.
+- `cache_ttl_seconds=None` matches `cache.latest.ttl.sec` default (opt-in TTL).
+
+## Consequences
+
+- Both clients gain two new optional constructor parameters. The change is
+  fully backward-compatible — existing code with no new kwargs gets
+  `cache_max_size=1000` and `cache_ttl_seconds=None` (no TTL, same behaviour as
+  before except with a 1000-entry LRU cap instead of unbounded growth).
+- Memory growth is now bounded by `cache_max_size` entries in each cache.
+- Users can opt into TTL by setting `cache_ttl_seconds`. After TTL elapses,
+  the next `get_schema` call re-fetches from the registry and surfaces any
+  new schema version automatically.
+- `ValueError` is raised for `cache_max_size < 1` or `cache_ttl_seconds <= 0`
+  (zero TTL is rejected; use `cache_ttl_seconds=None` to disable TTL).

--- a/docs/how-to/authentication.en.md
+++ b/docs/how-to/authentication.en.md
@@ -1,0 +1,127 @@
+# Authentication
+
+Pass an `auth` argument to either client to connect to a protected registry.
+Two handlers are built in: `BearerAuth` for static or provider-supplied tokens,
+and `KeycloakAuth` for OAuth2 client credentials against a Keycloak endpoint.
+
+The `auth` parameter is mutually exclusive with `http_client` — if you supply
+your own httpx client, configure auth on it directly.
+
+## `BearerAuth` — static or dynamic token
+
+### Static token
+
+```python
+from apicurio_serdes import ApicurioRegistryClient, BearerAuth
+
+auth = BearerAuth(token="my-static-token")
+
+client = ApicurioRegistryClient(
+    url="http://registry:8080/apis/registry/v3",
+    group_id="com.example.schemas",
+    auth=auth,
+)
+```
+
+### Dynamic token (refreshed per request)
+
+Pass a zero-argument callable via `token_provider` instead. It is called on every
+request, so it can return a fresh token each time — useful for short-lived credentials
+like GCP OIDC identity tokens or Vault leases:
+
+```python
+from apicurio_serdes import BearerAuth
+
+def get_token() -> str:
+    # replace with your actual token-fetching logic
+    return fetch_oidc_token()
+
+auth = BearerAuth(token_provider=get_token)
+```
+
+`token` and `token_provider` are mutually exclusive; exactly one must be supplied.
+
+## `KeycloakAuth` — OAuth2 client credentials
+
+For Keycloak-protected registries, `KeycloakAuth` handles the client credentials
+flow including token refresh. Give it a token URL, a client ID, and a secret:
+
+```python
+from apicurio_serdes import ApicurioRegistryClient, KeycloakAuth
+
+auth = KeycloakAuth(
+    token_url="https://keycloak.example.com/realms/myrealm/protocol/openid-connect/token",
+    client_id="my-client",
+    client_secret="secret",
+    scope="openid",          # optional
+)
+
+client = ApicurioRegistryClient(
+    url="http://registry:8080/apis/registry/v3",
+    group_id="com.example.schemas",
+    auth=auth,
+)
+```
+
+The token is fetched on the first request. After that, `KeycloakAuth` refreshes it
+automatically when less than 20% of its TTL remains. The async client gets its own
+non-blocking refresh path so it never blocks the event loop.
+
+## Using with `AsyncApicurioRegistryClient`
+
+Both `BearerAuth` and `KeycloakAuth` work unchanged with the async client:
+
+```python
+from apicurio_serdes import AsyncApicurioRegistryClient, KeycloakAuth
+
+auth = KeycloakAuth(
+    token_url="https://keycloak.example.com/realms/myrealm/protocol/openid-connect/token",
+    client_id="my-client",
+    client_secret="secret",
+)
+
+async with AsyncApicurioRegistryClient(
+    url="http://registry:8080/apis/registry/v3",
+    group_id="com.example.schemas",
+    auth=auth,
+) as client:
+    ...
+```
+
+## Using a custom `httpx` client (escape hatch)
+
+Neither handler fits? Supply a pre-configured `httpx.Client` via `http_client` instead.
+The client is used as-is — `close()` **won't** close it. You are responsible for
+closing it yourself.
+
+```python
+import httpx
+from apicurio_serdes import ApicurioRegistryClient
+
+http_client = httpx.Client(
+    headers={"X-Api-Key": "my-api-key"},
+    verify="/path/to/custom-ca.pem",
+)
+
+client = ApicurioRegistryClient(
+    url="http://registry:8080/apis/registry/v3",
+    group_id="com.example.schemas",
+    http_client=http_client,
+)
+```
+
+## Error handling
+
+Authentication failures raise `AuthenticationError`:
+
+```python
+from apicurio_serdes._errors import AuthenticationError
+
+try:
+    payload = serializer(data, ctx)
+except AuthenticationError as e:
+    print(f"Authentication failed: {e}")
+```
+
+See [Error Handling](./error-handling.md#handling-authenticationerror) for
+common causes and recovery steps.

--- a/docs/how-to/authentication.fr.md
+++ b/docs/how-to/authentication.fr.md
@@ -1,0 +1,131 @@
+# Authentification
+
+Passez un argument `auth` à l'un ou l'autre client pour vous connecter à un registry
+protégé. Deux gestionnaires sont intégrés : `BearerAuth` pour les tokens statiques ou
+fournis par un provider, et `KeycloakAuth` pour les identifiants clients OAuth2 contre
+un endpoint Keycloak.
+
+Le paramètre `auth` est mutuellement exclusif avec `http_client` — si vous fournissez
+votre propre client httpx, configurez l'authentification directement dessus.
+
+## `BearerAuth` — token statique ou dynamique
+
+### Token statique
+
+```python
+from apicurio_serdes import ApicurioRegistryClient, BearerAuth
+
+auth = BearerAuth(token="my-static-token")
+
+client = ApicurioRegistryClient(
+    url="http://registry:8080/apis/registry/v3",
+    group_id="com.example.schemas",
+    auth=auth,
+)
+```
+
+### Token dynamique (rafraîchi à chaque requête)
+
+Passez un callable sans argument via `token_provider` à la place. Il est appelé à chaque
+requête et peut retourner un token frais à chaque fois — utile pour les identifiants
+de courte durée comme les tokens OIDC GCP ou les baux Vault :
+
+```python
+from apicurio_serdes import BearerAuth
+
+def get_token() -> str:
+    # remplacez par votre logique réelle de récupération de token
+    return fetch_oidc_token()
+
+auth = BearerAuth(token_provider=get_token)
+```
+
+`token` et `token_provider` sont mutuellement exclusifs ; exactement l'un des deux doit
+être fourni.
+
+## `KeycloakAuth` — identifiants clients OAuth2
+
+Pour les registries protégés par Keycloak, `KeycloakAuth` gère le flux des identifiants
+clients, y compris le rafraîchissement du token. Fournissez-lui une URL de token, un
+identifiant client et un secret :
+
+```python
+from apicurio_serdes import ApicurioRegistryClient, KeycloakAuth
+
+auth = KeycloakAuth(
+    token_url="https://keycloak.example.com/realms/myrealm/protocol/openid-connect/token",
+    client_id="my-client",
+    client_secret="secret",
+    scope="openid",          # optionnel
+)
+
+client = ApicurioRegistryClient(
+    url="http://registry:8080/apis/registry/v3",
+    group_id="com.example.schemas",
+    auth=auth,
+)
+```
+
+Le token est récupéré lors de la première requête. Ensuite, `KeycloakAuth` le rafraîchit
+automatiquement lorsqu'il reste moins de 20% de son TTL. Le client asynchrone dispose de
+son propre chemin de rafraîchissement non bloquant pour ne jamais bloquer la boucle
+d'événements.
+
+## Utilisation avec `AsyncApicurioRegistryClient`
+
+`BearerAuth` et `KeycloakAuth` fonctionnent sans modification avec le client asynchrone :
+
+```python
+from apicurio_serdes import AsyncApicurioRegistryClient, KeycloakAuth
+
+auth = KeycloakAuth(
+    token_url="https://keycloak.example.com/realms/myrealm/protocol/openid-connect/token",
+    client_id="my-client",
+    client_secret="secret",
+)
+
+async with AsyncApicurioRegistryClient(
+    url="http://registry:8080/apis/registry/v3",
+    group_id="com.example.schemas",
+    auth=auth,
+) as client:
+    ...
+```
+
+## Utilisation d'un client `httpx` personnalisé (trappe de sortie)
+
+Aucun des gestionnaires ne convient ? Fournissez directement un `httpx.Client`
+préconfiguré via `http_client`. Le client est utilisé tel quel — `close()` **ne le
+fermera pas**. C'est à vous de le fermer.
+
+```python
+import httpx
+from apicurio_serdes import ApicurioRegistryClient
+
+http_client = httpx.Client(
+    headers={"X-Api-Key": "my-api-key"},
+    verify="/chemin/vers/ca-personnalise.pem",
+)
+
+client = ApicurioRegistryClient(
+    url="http://registry:8080/apis/registry/v3",
+    group_id="com.example.schemas",
+    http_client=http_client,
+)
+```
+
+## Gestion des erreurs
+
+Les échecs d'authentification lèvent `AuthenticationError` :
+
+```python
+from apicurio_serdes._errors import AuthenticationError
+
+try:
+    payload = serializer(data, ctx)
+except AuthenticationError as e:
+    print(f"Authentification échouée : {e}")
+```
+
+Voir [Gestion des erreurs](./error-handling.md#gerer-authenticationerror) pour les
+causes fréquentes et les étapes de récupération.

--- a/docs/how-to/error-handling.en.md
+++ b/docs/how-to/error-handling.en.md
@@ -9,8 +9,11 @@ Python exceptions for validation errors.
 |-----------|-------------------|----------------|
 | `SchemaNotFoundError` | The artifact or schema ID does not exist in the registry (HTTP 404) | `group_id`, `artifact_id` or `id_type`, `id_value` |
 | `RegistryConnectionError` | The registry is unreachable (network error) | `url` |
+| `SchemaRegistrationError` | The registry rejected a schema registration request (4xx/5xx or bad response body) | `artifact_id`, `cause` |
 | `SerializationError` | The `to_dict` callable raised an exception | `cause` |
+| `ResolverError` | The `artifact_resolver` callable raised an exception or returned a non-string | `cause` |
 | `DeserializationError` | Wire format invalid, Avro decode failure, or `from_dict` hook failure | `cause` |
+| `AuthenticationError` | The token endpoint is unreachable, returned a non-200 response, or the response body is malformed | — |
 | `RuntimeError` | The registry client has been closed | — |
 | `ValueError` | Schema ID exceeds 32-bit limit (CONFLUENT_PAYLOAD), or registry response IDs outside int64 range | — |
 
@@ -171,6 +174,76 @@ contains extra fields not defined in the schema.
 
 **Recovery:** Ensure the data dictionary has all required fields with the correct types,
 or switch wire format for large schema IDs.
+
+## Handling `SchemaRegistrationError`
+
+Raised when `auto_register=True` and the registry rejects the registration request
+(4xx or 5xx response, or the response body is missing the expected IDs).
+
+```python
+from apicurio_serdes._errors import SchemaRegistrationError
+
+try:
+    payload = serializer(data, ctx)
+except SchemaRegistrationError as e:
+    print(f"Registration failed for '{e.artifact_id}': {e.cause}")
+    # e.__cause__ is also set for traceback chaining
+```
+
+**Common causes:**
+
+- `if_exists="FAIL"` and the artifact already exists in the registry
+- The registry rejected the schema content (schema validation error)
+- The registry returned an unexpected response body
+
+**Recovery:** Check `e.cause` for the registry error message. If the artifact already
+exists and `FAIL` is too strict, switch to `if_exists="FIND_OR_CREATE_VERSION"`.
+
+## Handling `ResolverError`
+
+Raised when `artifact_resolver` raises an exception or returns something other than
+a non-empty string.
+
+```python
+from apicurio_serdes._errors import ResolverError
+
+try:
+    payload = serializer(data, ctx)
+except ResolverError as e:
+    print(f"Resolver failed: {e}")
+    if e.cause:
+        print(f"Caused by: {e.cause}")
+```
+
+**Common causes:**
+
+- The resolver raised an unhandled exception
+- The resolver returned `None` or `""` instead of an artifact ID
+
+**Recovery:** Fix the resolver implementation to always return a non-empty string.
+
+## Handling `AuthenticationError`
+
+Raised by `KeycloakAuth` when the token endpoint is unreachable, returns a non-200
+response, or returns a body missing `access_token` or `expires_in`.
+
+```python
+from apicurio_serdes._errors import AuthenticationError
+
+try:
+    payload = serializer(data, ctx)
+except AuthenticationError as e:
+    print(f"Authentication failed: {e}")
+```
+
+**Common causes:**
+
+- The `token_url` is incorrect or the Keycloak realm does not exist
+- The `client_id` or `client_secret` are wrong (non-200 response from the token endpoint)
+- The token endpoint returned JSON without `access_token` or `expires_in`
+
+**Recovery:** Double-check the `token_url`, `client_id`, and `client_secret` in
+`KeycloakAuth`. See [Authentication](../how-to/authentication.md) for examples.
 
 ## Putting It All Together
 

--- a/docs/how-to/error-handling.en.md
+++ b/docs/how-to/error-handling.en.md
@@ -1,6 +1,7 @@
 # Error Handling
 
-`apicurio-serdes` raises specific exception types for each failure mode, plus standard Python exceptions for validation errors.
+`apicurio-serdes` raises specific exception types for each failure mode, plus standard
+Python exceptions for validation errors.
 
 ## Exception Overview
 
@@ -60,24 +61,31 @@ except RegistryConnectionError as e:
 - The URL is wrong (missing `/apis/registry/v3` path)
 - A firewall or network issue is blocking the connection
 
-**Recovery pattern — retry with backoff:**
+**Built-in retry:** Both clients retry automatically on transient failures — no
+manual retry loop is needed. Configure the retry behaviour at construction time:
 
 ```python
-import time
-from apicurio_serdes._errors import RegistryConnectionError
+from apicurio_serdes import ApicurioRegistryClient
 
-max_retries = 3
-for attempt in range(max_retries):
-    try:
-        payload = serializer(data, ctx)
-        break
-    except RegistryConnectionError:
-        if attempt == max_retries - 1:
-            raise
-        time.sleep(2 ** attempt)
+client = ApicurioRegistryClient(
+    url="http://registry:8080/apis/registry/v3",
+    group_id="my-group",
+    max_retries=3,               # default — set to 0 to disable
+    retry_backoff_ms=1000,       # base delay for the first retry (ms)
+    retry_max_backoff_ms=20000,  # maximum backoff cap (ms)
+)
 ```
 
-Note: this exception is only raised on the **first** serialization call (when the schema is fetched). Once the schema is cached, no further HTTP requests are made, so network errors cannot occur during serialization.
+Retry covers `httpx.TransportError` (network-level failure) and HTTP responses
+with status 429, 502, 503, and 504 (transient server errors). After all retries
+are exhausted, `RegistryConnectionError` is raised.
+
+**Do not** wrap calls in an additional retry loop — that would multiply the
+effective retry count and interfere with the built-in backoff.
+
+Note: this exception is only raised on the **first** serialization call (when the schema
+is fetched). Once the schema is cached, no further HTTP requests are made, so network
+errors cannot occur during serialization.
 
 ## Handling `SerializationError`
 
@@ -104,7 +112,8 @@ except SerializationError as e:
 
 ## Handling `ValueError`
 
-Raised by the underlying Avro encoder (fastavro) when the data does not match the schema. This is **not** an `apicurio-serdes` exception — it comes from fastavro directly.
+Raised by the underlying Avro encoder (fastavro) when the data does not match the schema.
+This is **not** an `apicurio-serdes` exception — it comes from fastavro directly.
 
 ```python
 try:
@@ -113,7 +122,8 @@ except ValueError as e:
     print(f"Data does not match schema: {e}")
 ```
 
-If `strict=True` is enabled on the serializer, `ValueError` is also raised when the data contains extra fields not defined in the schema.
+If `strict=True` is enabled on the serializer, `ValueError` is also raised when the data
+contains extra fields not defined in the schema.
 
 **Recovery:** Ensure the data dictionary has all required fields with the correct types.
 
@@ -140,8 +150,11 @@ except RuntimeError as e:
 
 In addition to Avro schema validation errors from fastavro, `ValueError` is raised in two new situations:
 
-- **32-bit schema ID overflow**: When using `CONFLUENT_PAYLOAD` wire format, the schema ID must fit in an unsigned 32-bit integer. If the registry-assigned ID exceeds this limit, use `WireFormat.KAFKA_HEADERS` instead.
-- **int64 range validation**: When registry response headers contain a `globalId` or `contentId` outside the signed 64-bit integer range.
+- **32-bit schema ID overflow**: When using `CONFLUENT_PAYLOAD` wire format, the schema
+  ID must fit in an unsigned 32-bit integer. If the registry-assigned ID exceeds this
+  limit, use `WireFormat.KAFKA_HEADERS` instead.
+- **int64 range validation**: When registry response headers contain a `globalId` or
+  `contentId` outside the signed 64-bit integer range.
 
 ```python
 try:
@@ -153,9 +166,11 @@ except ValueError as e:
         print(f"Data does not match schema: {e}")
 ```
 
-If `strict=True` is enabled on the serializer, `ValueError` is also raised when the data contains extra fields not defined in the schema.
+If `strict=True` is enabled on the serializer, `ValueError` is also raised when the data
+contains extra fields not defined in the schema.
 
-**Recovery:** Ensure the data dictionary has all required fields with the correct types, or switch wire format for large schema IDs.
+**Recovery:** Ensure the data dictionary has all required fields with the correct types,
+or switch wire format for large schema IDs.
 
 ## Putting It All Together
 

--- a/docs/how-to/error-handling.fr.md
+++ b/docs/how-to/error-handling.fr.md
@@ -1,6 +1,7 @@
 # Gestion des erreurs
 
-`apicurio-serdes` lève des types d'exceptions spécifiques pour chaque mode de défaillance, ainsi que des exceptions Python standard pour les erreurs de validation.
+`apicurio-serdes` lève des types d'exceptions spécifiques pour chaque mode de défaillance,
+ainsi que des exceptions Python standard pour les erreurs de validation.
 
 ## Vue d'ensemble des exceptions
 
@@ -60,24 +61,34 @@ except RegistryConnectionError as e:
 - L'URL est incorrecte (chemin `/apis/registry/v3` manquant)
 - Un pare-feu ou un problème réseau bloque la connexion
 
-**Stratégie de récupération — nouvelle tentative avec délai exponentiel :**
+**Nouvelle tentative intégrée :** Les deux clients effectuent automatiquement des
+nouvelles tentatives sur les défaillances transitoires — aucune boucle de nouvelle
+tentative manuelle n'est nécessaire. Configurez ce comportement à la construction :
 
 ```python
-import time
-from apicurio_serdes._errors import RegistryConnectionError
+from apicurio_serdes import ApicurioRegistryClient
 
-max_retries = 3
-for attempt in range(max_retries):
-    try:
-        payload = serializer(data, ctx)
-        break
-    except RegistryConnectionError:
-        if attempt == max_retries - 1:
-            raise
-        time.sleep(2 ** attempt)
+client = ApicurioRegistryClient(
+    url="http://registry:8080/apis/registry/v3",
+    group_id="my-group",
+    max_retries=3,               # défaut — mettre à 0 pour désactiver
+    retry_backoff_ms=1000,       # délai de base pour la première tentative (ms)
+    retry_max_backoff_ms=20000,  # délai maximum (ms)
+)
 ```
 
-Remarque : cette exception n'est levée que lors du **premier** appel de sérialisation (lorsque le schema est récupéré). Une fois le schema mis en cache, aucune requête HTTP supplémentaire n'est effectuée, les erreurs réseau ne peuvent donc pas survenir pendant la sérialisation.
+Les nouvelles tentatives couvrent les `httpx.TransportError` (échec au niveau réseau)
+et les réponses HTTP avec les codes 429, 502, 503 et 504 (erreurs serveur transitoires).
+Une fois toutes les tentatives épuisées, `RegistryConnectionError` est levée.
+
+**N'encapsulez pas** les appels dans une boucle de nouvelle tentative supplémentaire —
+cela multiplierait le nombre effectif de tentatives et interférerait avec le délai
+exponentiel intégré.
+
+Remarque : cette exception n'est levée que lors du **premier** appel de sérialisation
+(lorsque le schema est récupéré). Une fois le schema mis en cache, aucune requête HTTP
+supplémentaire n'est effectuée, les erreurs réseau ne peuvent donc pas survenir pendant
+la sérialisation.
 
 ## Gérer `SerializationError`
 
@@ -100,11 +111,14 @@ except SerializationError as e:
 - Le callable a tenté d'accéder à un attribut inexistant sur l'objet en entrée
 - Une erreur de validation Pydantic s'est produite dans `model_dump()`
 
-**Récupération :** Corrigez l'implémentation de `to_dict` ou validez les données en entrée avant la sérialisation.
+**Récupération :** Corrigez l'implémentation de `to_dict` ou validez les données en
+entrée avant la sérialisation.
 
 ## Gérer `ValueError`
 
-Levée par l'encodeur Avro sous-jacent (fastavro) lorsque les données ne correspondent pas au schema. Ce n'est **pas** une exception `apicurio-serdes` — elle provient directement de fastavro.
+Levée par l'encodeur Avro sous-jacent (fastavro) lorsque les données ne correspondent
+pas au schema. Ce n'est **pas** une exception `apicurio-serdes` — elle provient
+directement de fastavro.
 
 ```python
 try:
@@ -113,9 +127,11 @@ except ValueError as e:
     print(f"Data does not match schema: {e}")
 ```
 
-Si `strict=True` est activé sur le serializer, `ValueError` est également levée lorsque les données contiennent des champs supplémentaires non définis dans le schema.
+Si `strict=True` est activé sur le serializer, `ValueError` est également levée lorsque
+les données contiennent des champs supplémentaires non définis dans le schema.
 
-**Récupération :** Assurez-vous que le dictionnaire de données possède tous les champs requis avec les types corrects.
+**Récupération :** Assurez-vous que le dictionnaire de données possède tous les champs
+requis avec les types corrects.
 
 ## Gérer `RuntimeError` (client fermé)
 
@@ -131,17 +147,25 @@ except RuntimeError as e:
 
 **Causes fréquentes :**
 
-- Appeler `close()` ou sortir d'un gestionnaire de contexte, puis réutiliser le même client
+- Appeler `close()` ou sortir d'un gestionnaire de contexte, puis réutiliser le même
+  client
 - Partager un client entre threads/coroutines où un chemin le ferme prématurément
 
-**Récupération :** Créez une nouvelle instance d'`ApicurioRegistryClient` ou d'`AsyncApicurioRegistryClient`.
+**Récupération :** Créez une nouvelle instance d'`ApicurioRegistryClient` ou
+d'`AsyncApicurioRegistryClient`.
 
 ## Gérer `ValueError` (validation)
 
-En plus des erreurs de validation de schema Avro provenant de fastavro, `ValueError` est levée dans deux nouvelles situations :
+En plus des erreurs de validation de schema Avro provenant de fastavro, `ValueError` est
+levée dans deux nouvelles situations :
 
-- **Dépassement de l'identifiant de schema 32 bits** : avec le wire format `CONFLUENT_PAYLOAD`, l'identifiant de schema doit tenir dans un entier non signé de 32 bits. Si l'identifiant attribué par le registry dépasse cette limite, utilisez `WireFormat.KAFKA_HEADERS` à la place.
-- **Validation de la plage int64** : lorsque les en-têtes de réponse du registry contiennent un `globalId` ou `contentId` en dehors de la plage d'entiers signés de 64 bits.
+- **Dépassement de l'identifiant de schema 32 bits** : avec le wire format
+  `CONFLUENT_PAYLOAD`, l'identifiant de schema doit tenir dans un entier non signé de
+  32 bits. Si l'identifiant attribué par le registry dépasse cette limite, utilisez
+  `WireFormat.KAFKA_HEADERS` à la place.
+- **Validation de la plage int64** : lorsque les en-têtes de réponse du registry
+  contiennent un `globalId` ou `contentId` en dehors de la plage d'entiers signés de
+  64 bits.
 
 ```python
 try:
@@ -153,9 +177,12 @@ except ValueError as e:
         print(f"Les données ne correspondent pas au schema : {e}")
 ```
 
-Si `strict=True` est activé sur le serializer, `ValueError` est également levée lorsque les données contiennent des champs supplémentaires non définis dans le schema.
+Si `strict=True` est activé sur le serializer, `ValueError` est également levée lorsque
+les données contiennent des champs supplémentaires non définis dans le schema.
 
-**Récupération :** Assurez-vous que le dictionnaire de données possède tous les champs requis avec les types corrects, ou changez de wire format pour les grands identifiants de schema.
+**Récupération :** Assurez-vous que le dictionnaire de données possède tous les champs
+requis avec les types corrects, ou changez de wire format pour les grands identifiants
+de schema.
 
 ## Tout assembler
 

--- a/docs/how-to/error-handling.fr.md
+++ b/docs/how-to/error-handling.fr.md
@@ -9,8 +9,11 @@ ainsi que des exceptions Python standard pour les erreurs de validation.
 |-----------|---------------------|----------------|
 | `SchemaNotFoundError` | L'artefact ou l'identifiant de schema n'existe pas dans le registry (HTTP 404) | `group_id`, `artifact_id` ou `id_type`, `id_value` |
 | `RegistryConnectionError` | Le registry est injoignable (erreur réseau) | `url` |
+| `SchemaRegistrationError` | Le registry a rejeté une demande d'enregistrement de schema (4xx/5xx ou corps de réponse invalide) | `artifact_id`, `cause` |
 | `SerializationError` | Le callable `to_dict` a levé une exception | `cause` |
+| `ResolverError` | Le callable `artifact_resolver` a levé une exception ou retourné une valeur non-string | `cause` |
 | `DeserializationError` | Wire format invalide, échec de décodage Avro, ou échec du hook `from_dict` | `cause` |
+| `AuthenticationError` | L'endpoint de token est injoignable, a retourné une réponse non-200, ou le corps de réponse est malformé | — |
 | `RuntimeError` | Le client registry a été fermé | — |
 | `ValueError` | L'identifiant de schema dépasse la limite 32 bits (CONFLUENT_PAYLOAD), ou les identifiants de la réponse registry sont hors de la plage int64 | — |
 
@@ -183,6 +186,77 @@ les données contiennent des champs supplémentaires non définis dans le schema
 **Récupération :** Assurez-vous que le dictionnaire de données possède tous les champs
 requis avec les types corrects, ou changez de wire format pour les grands identifiants
 de schema.
+
+## Gérer `SchemaRegistrationError`
+
+Levée lorsque `auto_register=True` et que le registry rejette la demande d'enregistrement
+(réponse 4xx ou 5xx, ou corps de réponse sans les identifiants attendus).
+
+```python
+from apicurio_serdes._errors import SchemaRegistrationError
+
+try:
+    payload = serializer(data, ctx)
+except SchemaRegistrationError as e:
+    print(f"Enregistrement échoué pour '{e.artifact_id}' : {e.cause}")
+    # e.__cause__ est également défini pour le chaînage de la trace
+```
+
+**Causes fréquentes :**
+
+- `if_exists="FAIL"` et l'artefact existe déjà dans le registry
+- Le registry a rejeté le contenu du schema (erreur de validation)
+- Le registry a retourné un corps de réponse inattendu
+
+**Récupération :** Consultez `e.cause` pour le message d'erreur du registry. Si l'artefact
+existe déjà et que `FAIL` est trop strict, passez à `if_exists="FIND_OR_CREATE_VERSION"`.
+
+## Gérer `ResolverError`
+
+Levée lorsque `artifact_resolver` lève une exception ou retourne autre chose qu'une
+chaîne non vide.
+
+```python
+from apicurio_serdes._errors import ResolverError
+
+try:
+    payload = serializer(data, ctx)
+except ResolverError as e:
+    print(f"Résolveur en échec : {e}")
+    if e.cause:
+        print(f"Causé par : {e.cause}")
+```
+
+**Causes fréquentes :**
+
+- Le résolveur a levé une exception non gérée
+- Le résolveur a retourné `None` ou `""` au lieu d'un identifiant d'artefact
+
+**Récupération :** Corrigez l'implémentation du résolveur pour qu'il retourne toujours
+une chaîne non vide.
+
+## Gérer `AuthenticationError`
+
+Levée par `KeycloakAuth` lorsque l'endpoint de token est injoignable, retourne une réponse
+non-200, ou retourne un corps sans `access_token` ni `expires_in`.
+
+```python
+from apicurio_serdes._errors import AuthenticationError
+
+try:
+    payload = serializer(data, ctx)
+except AuthenticationError as e:
+    print(f"Authentification échouée : {e}")
+```
+
+**Causes fréquentes :**
+
+- L'URL `token_url` est incorrecte ou le realm Keycloak n'existe pas
+- Le `client_id` ou le `client_secret` sont erronés (réponse non-200 de l'endpoint de token)
+- L'endpoint de token a retourné du JSON sans `access_token` ni `expires_in`
+
+**Récupération :** Vérifiez le `token_url`, le `client_id` et le `client_secret` dans
+`KeycloakAuth`. Voir [Authentification](../how-to/authentication.md) pour des exemples.
 
 ## Tout assembler
 

--- a/docs/plans/2026-03-13-auth-plan.md
+++ b/docs/plans/2026-03-13-auth-plan.md
@@ -1,0 +1,266 @@
+# Plan: Client Authentication — BearerAuth and KeycloakAuth (2026-03-13)
+
+## Summary
+
+Add authentication support to `ApicurioRegistryClient` and
+`AsyncApicurioRegistryClient` via a new `_auth.py` module. Two `httpx.Auth`
+subclasses are introduced: `BearerAuth` (static token or callable provider,
+covers GCP OIDC) and `KeycloakAuth` (client credentials flow with
+threshold-based auto-refresh). Both clients gain an `auth=` constructor kwarg.
+Both classes are exported from the top-level package. No new dependencies.
+
+## Stakes Classification
+
+**Level**: Medium
+
+**Rationale**: New module + changes to two existing clients + new public API
+surface. Well-contained (no architectural changes, no schema logic touched).
+Requires 100% coverage including async refresh paths.
+
+## Context
+
+**Research**: [docs/plans/2026-03-13-auth-research.md](2026-03-13-auth-research.md)
+
+**Worktree**: `.worktrees/feat-auth-38/`
+
+**Affected files**:
+
+- `src/apicurio_serdes/_auth.py` (new)
+- `src/apicurio_serdes/_client.py` (minor: `auth=` kwarg)
+- `src/apicurio_serdes/_async_client.py` (minor: `auth=` kwarg)
+- `src/apicurio_serdes/__init__.py` (add exports)
+- `tests/test_auth.py` (new)
+- `tests/test_client.py` (add constructor + header tests)
+- `tests/test_async_client.py` (add parity test)
+
+## Success Criteria
+
+- [ ] `BearerAuth(token="...")` injects `Authorization: Bearer <token>` header
+- [ ] `BearerAuth(token_provider=fn)` calls `fn()` on every request
+- [ ] `KeycloakAuth` fetches token via client credentials on first use
+- [ ] `KeycloakAuth` auto-refreshes when <20% TTL remains
+- [ ] `KeycloakAuth` works with both sync and async clients without blocking
+- [ ] `auth=None` (default) leaves existing behaviour unchanged
+- [ ] `BearerAuth` and `KeycloakAuth` exported from `apicurio_serdes`
+- [ ] 100% coverage on all new and modified code
+- [ ] mypy strict passes with no new errors
+
+## Implementation Steps
+
+### Phase 1: BearerAuth
+
+#### Step 1.1: Write BearerAuth tests (RED)
+
+- **Files**: `tests/test_auth.py` (new)
+- **Action**: Create test file with `TestBearerAuth` class. Use `respx` to
+  mock a registry endpoint and assert the `Authorization` header.
+- **Test cases**:
+  - Static token: `BearerAuth(token="tok")` — request carries
+    `Authorization: Bearer tok`
+  - Dynamic token: `BearerAuth(token_provider=lambda: "dyn")` — request carries
+    `Authorization: Bearer dyn`
+  - Provider called on each request: two requests → provider called twice
+    (assert call count)
+  - Missing both args: `BearerAuth()` → raises `ValueError`
+  - Both args provided: `BearerAuth(token="t", token_provider=fn)` → raises
+    `ValueError`
+  - Works via sync `httpx.Client` (direct httpx test, no registry)
+  - Works via async `httpx.AsyncClient` (direct httpx test, no registry)
+- **Verify**: Tests collected and all fail (no `_auth.py` yet)
+- **Complexity**: Small
+
+#### Step 1.2: Implement BearerAuth (GREEN)
+
+- **Files**: `src/apicurio_serdes/_auth.py` (new)
+- **Action**: Create module with `BearerAuth(httpx.Auth)`.
+  - `__init__`: validate exactly one of `token` or `token_provider` is given
+  - `_get_token() -> str`: returns `self._token` or calls `self._token_provider()`
+  - `auth_flow`: injects `Authorization: Bearer {self._get_token()}`, yields request
+  - Single `auth_flow` serves both sync and async (no I/O in the method)
+- **Verify**: All Step 1.1 tests pass; `uv run pytest tests/test_auth.py -x`
+- **Complexity**: Small
+
+### Phase 2: KeycloakAuth — sync path
+
+#### Step 2.1: Write KeycloakAuth sync tests (RED)
+
+- **Files**: `tests/test_auth.py`
+- **Action**: Add `TestKeycloakAuthSync` class. Mock the Keycloak token
+  endpoint with `respx` and a mock registry route.
+- **Test cases**:
+  - Happy path: first request triggers token POST; registry GET receives
+    `Authorization: Bearer <access_token>`
+  - Token reuse: two requests → token endpoint called only once
+  - Auto-refresh: manipulate `_expires_at` to be in the past; second request
+    triggers a second token POST
+  - Threshold refresh: set `_expires_at` to now + 0.1 × `_expires_in`
+    (within 20% window) → triggers refresh before the request
+  - Token endpoint returns 401 → raises `AuthenticationError`
+  - Token endpoint unreachable (transport error) → raises `AuthenticationError`
+  - `scope` param: `KeycloakAuth(..., scope="openid")` — POST body includes
+    `scope=openid`
+  - No `scope`: POST body omits `scope` field
+- **Verify**: Tests collected and all fail
+- **Complexity**: Small
+
+#### Step 2.2: Implement KeycloakAuth sync path (GREEN)
+
+- **Files**: `src/apicurio_serdes/_auth.py`, `src/apicurio_serdes/_errors.py`
+- **Action**:
+  - Add `AuthenticationError(Exception)` to `_errors.py`
+  - Add `KeycloakAuth(httpx.Auth)` to `_auth.py`:
+    - `__init__`: store `token_url`, `client_id`, `client_secret`, `scope`;
+      init `_token = ""`, `_expires_at = 0.0`, `_expires_in = 0.0`,
+      `_sync_lock = threading.Lock()`
+    - `_is_expired() -> bool`: `True` if no token or
+      `_expires_at < monotonic() + _expires_in * 0.2`
+    - `_sync_fetch_token()`: POST `token_url` with `httpx.Client()` (short-lived);
+      parse `access_token` + `expires_in`; update state;
+      raise `AuthenticationError` on non-200 or transport error
+    - `_sync_ensure_token()`: double-checked lock pattern calling
+      `_sync_fetch_token` if expired
+    - `sync_auth_flow`: call `_sync_ensure_token()`, inject header, yield request
+- **Verify**: All Step 2.1 tests pass; `uv run pytest tests/test_auth.py -x`
+- **Complexity**: Medium
+
+### Phase 3: KeycloakAuth — async path
+
+#### Step 3.1: Write KeycloakAuth async tests (RED)
+
+- **Files**: `tests/test_auth.py`
+- **Action**: Add `TestKeycloakAuthAsync` class. Mirror the sync test cases
+  using `pytest.mark.asyncio` and `respx` async context.
+- **Test cases** (async equivalents of Step 2.1):
+  - Happy path via `httpx.AsyncClient`
+  - Token reuse (single POST)
+  - Auto-refresh (manipulate `_expires_at`)
+  - Threshold refresh
+  - Token endpoint 401 → `AuthenticationError`
+  - Token endpoint unreachable → `AuthenticationError`
+  - Lazy lock: `KeycloakAuth` created outside event loop → still works when
+    used inside `async with`
+- **Verify**: Tests collected and all fail
+- **Complexity**: Small
+
+#### Step 3.2: Implement KeycloakAuth async path (GREEN)
+
+- **Files**: `src/apicurio_serdes/_auth.py`
+- **Action**: Extend `KeycloakAuth`:
+  - Add `_async_lock: asyncio.Lock | None = None` (init as `None`)
+  - `_get_async_lock()`: creates lock lazily on first call
+  - `_async_fetch_token()`: `async with httpx.AsyncClient() as c: await c.post(...)`;
+    same parse + error handling as sync
+  - `_async_ensure_token()`: async double-checked lock using `_get_async_lock()`
+  - `async_auth_flow`: `await _async_ensure_token()`, inject header, yield request
+- **Verify**: All Step 3.1 tests pass; full `uv run pytest tests/test_auth.py`
+- **Complexity**: Medium
+
+### Phase 4: Wire auth into registry clients
+
+#### Step 4.1: Write client auth wiring tests (RED)
+
+- **Files**: `tests/test_client.py`, `tests/test_async_client.py`
+- **Action**: Add auth-related tests to existing test classes.
+- **Test cases for `test_client.py`**:
+  - Constructor accepts `auth=None` (default, existing tests still pass)
+  - Constructor accepts `auth=BearerAuth(token="tok")`
+  - Registry request carries `Authorization: Bearer tok` header (via respx
+    `route.calls[0].request.headers`)
+- **Test cases for `test_async_client.py`**:
+  - Same three cases, async variants
+  - `TestInterfaceParity`: assert `AsyncApicurioRegistryClient.__init__` has
+    `auth` parameter matching sync client signature
+- **Verify**: New tests collected and fail; existing tests still pass
+- **Complexity**: Small
+
+#### Step 4.2: Update `_client.py` and `_async_client.py` (GREEN)
+
+- **Files**: `src/apicurio_serdes/_client.py:44-46`,
+  `src/apicurio_serdes/_async_client.py:31-34`
+- **Action**:
+  - `_client.py`: add `auth: httpx.Auth | None = None` to `__init__` signature;
+    pass `auth=auth` to `httpx.Client(base_url=url, auth=auth)`
+  - `_async_client.py`: same change for `httpx.AsyncClient`
+  - Update docstrings for both to document the `auth` parameter
+- **Verify**: All Step 4.1 tests pass; `uv run pytest -x`
+- **Complexity**: Small
+
+### Phase 5: Public API and coverage gate
+
+#### Step 5.1: Export BearerAuth and KeycloakAuth
+
+- **Files**: `src/apicurio_serdes/__init__.py:17-26`
+- **Action**: Import `BearerAuth`, `KeycloakAuth` from `._auth`; add both to
+  `__all__`; import `AuthenticationError` from `._errors` and add to `__all__`
+- **Verify**: `python -c "from apicurio_serdes import BearerAuth, KeycloakAuth,
+  AuthenticationError"` succeeds
+- **Complexity**: Small
+
+#### Step 5.2: Full test suite and coverage gate
+
+- **Files**: all test files
+- **Action**: Run full suite with coverage
+- **Verify**:
+  - `uv run pytest --tb=short` — 0 failures
+  - Coverage report shows 100% on `_auth.py`, `_errors.py`, `_client.py`,
+    `_async_client.py`, `__init__.py`
+  - `uv run mypy src/` — 0 errors
+- **Complexity**: Small
+
+## Test Strategy
+
+### Automated Tests
+
+| Test case | Type | Input | Expected output |
+| --------- | ---- | ----- | --------------- |
+| Static Bearer injects header | Unit | `BearerAuth(token="tok")` | `Authorization: Bearer tok` |
+| Dynamic Bearer calls provider | Unit | `BearerAuth(token_provider=fn)` | fn called; header set |
+| Provider called per request | Unit | Two requests | fn called twice |
+| BearerAuth no args | Unit | `BearerAuth()` | `ValueError` |
+| BearerAuth both args | Unit | `BearerAuth(token=..., token_provider=...)` | `ValueError` |
+| BearerAuth sync client | Integration | `httpx.Client(auth=BearerAuth(...))` | header on request |
+| BearerAuth async client | Integration | `httpx.AsyncClient(auth=BearerAuth(...))` | header on request |
+| Keycloak happy path (sync) | Integration | First request | token POST made; header set |
+| Keycloak token reuse (sync) | Integration | Two requests | one POST only |
+| Keycloak auto-refresh (sync) | Integration | Expired `_expires_at` | second POST made |
+| Keycloak threshold (sync) | Integration | Near-expiry `_expires_at` | refresh before request |
+| Keycloak 401 token endpoint (sync) | Integration | Mock 401 on token URL | `AuthenticationError` |
+| Keycloak transport error (sync) | Integration | Mock connection refused | `AuthenticationError` |
+| Keycloak scope param (sync) | Unit | `scope="openid"` | body includes `scope=openid` |
+| Keycloak no scope (sync) | Unit | no scope | body omits `scope` |
+| Keycloak happy path (async) | Integration | First async request | token POST made; header set |
+| Keycloak token reuse (async) | Integration | Two async requests | one POST only |
+| Keycloak auto-refresh (async) | Integration | Expired `_expires_at` | second POST made |
+| Keycloak lazy lock | Unit | Created outside loop | no error on first async use |
+| Client auth=None default | Unit | `ApicurioRegistryClient(url, group_id)` | no auth header |
+| Client auth kwarg (sync) | Integration | `auth=BearerAuth(token="t")` | header on registry call |
+| Client auth kwarg (async) | Integration | `auth=BearerAuth(token="t")` | header on registry call |
+| Interface parity | Unit | Inspect signatures | sync and async match |
+
+### Manual Verification
+
+- [ ] `python -c "from apicurio_serdes import BearerAuth, KeycloakAuth,
+  AuthenticationError; print('OK')"` — all three importable
+- [ ] `uv run mypy src/` — zero errors after implementation
+
+## Risks and Mitigations
+
+| Risk | Impact | Mitigation |
+| ---- | ------ | ---------- |
+| Lazy `asyncio.Lock` race on first async call | Two concurrent calls both fetch tokens | Lock creation is idempotent; worst case is two fetches on first use, then one lock in use — acceptable |
+| Short-lived `httpx.Client` in `_sync_fetch_token` adds overhead | Minor latency on refresh | Only on token refresh (rare); acceptable trade-off for simplicity |
+| `_expires_at` clock drift | Premature refresh | Using `time.monotonic()` (not wall clock); 20% threshold provides margin |
+| mypy strict rejects `Callable[[], str]` annotation | Build failure | Type imported from `collections.abc`; tested locally before PR |
+| Test isolation: `_expires_at` mutation bleeds across tests | Flaky tests | Each test instantiates a fresh `KeycloakAuth`; no shared state |
+
+## Rollback Strategy
+
+All changes are additive — no existing signatures are broken (new `auth=None`
+default is backwards-compatible). Rollback is `git revert` of the feature
+branch. No database migrations. No config changes in production.
+
+## Status
+
+- [x] Plan approved
+- [x] Implementation started
+- [x] Implementation complete

--- a/docs/plans/2026-03-13-auth-research.md
+++ b/docs/plans/2026-03-13-auth-research.md
@@ -1,0 +1,265 @@
+# Research: Client Authentication (2026-03-13)
+
+## Problem Statement
+
+The registry clients (`ApicurioRegistryClient` and `AsyncApicurioRegistryClient`)
+make unauthenticated HTTP calls. The first production deployment requires writing
+to a Kafka topic on a GCP staging cluster from Airflow DAGs. The Apicurio registry
+may be secured behind Keycloak OIDC. Two auth patterns are needed:
+
+- **Bearer token** — static string or dynamic callable (GCP OIDC identity token)
+- **Keycloak OAuth2** — client credentials flow with automatic token refresh
+
+## Requirements
+
+| ID   | Requirement |
+|------|-------------|
+| R-1  | `auth=` kwarg on both `ApicurioRegistryClient` and `AsyncApicurioRegistryClient` |
+| R-2  | `BearerAuth(token="...")` for static tokens |
+| R-3  | `BearerAuth(token_provider=callable)` for dynamic tokens (e.g., GCP OIDC) |
+| R-4  | `KeycloakAuth(token_url, client_id, client_secret)` for client credentials flow |
+| R-5  | `KeycloakAuth` auto-refreshes when token nears expiry (threshold-based) |
+| R-6  | Both auth classes work with sync and async clients |
+| R-7  | No new runtime dependencies |
+| R-8  | 100% test coverage maintained |
+| R-9  | Exported from top-level `apicurio_serdes` package |
+
+## Findings
+
+### Relevant Files
+
+| File | Purpose | Key Lines |
+|------|---------|-----------|
+| `src/apicurio_serdes/_base.py` | Base class: `url`, `group_id`, caches, response parsing | 40–49 |
+| `src/apicurio_serdes/_client.py` | Sync client; constructs `httpx.Client(base_url=url)` | 44–46 |
+| `src/apicurio_serdes/_async_client.py` | Async client; constructs `httpx.AsyncClient(base_url=url)` | 31–34 |
+| `src/apicurio_serdes/__init__.py` | Public exports — needs `BearerAuth`, `KeycloakAuth` added | 17–26 |
+| `tests/conftest.py` | `mock_registry` fixture via `respx`; route helpers | 135–139 |
+| `tests/test_client.py` | Sync client tests; constructor validation pattern | 264+ |
+| `tests/test_async_client.py` | Async client tests; `TestInterfaceParity` at line 196 | 196+ |
+
+### Client Construction Extension Points
+
+Both clients are minimal wrappers: `__init__` calls `super().__init__(url, group_id)`
+then constructs the httpx client. Auth needs to be threaded through here:
+
+```python
+# _client.py — current
+self._http_client = httpx.Client(base_url=url)
+
+# _client.py — after change
+self._http_client = httpx.Client(base_url=url, auth=auth)
+```
+
+The base class (`_RegistryClientBase`) does **not** need to change. It holds no
+HTTP client; auth is purely a transport-layer concern of the subclasses.
+
+### httpx Auth Protocol
+
+httpx provides a generator-based `httpx.Auth` protocol with three methods:
+
+```python
+class httpx.Auth:
+    def auth_flow(self, request) -> Generator[Request, Response, None]: ...
+    def sync_auth_flow(self, request) -> Generator[Request, Response, None]: ...
+    async def async_auth_flow(self, request) -> AsyncGenerator[Request, Response]: ...
+```
+
+- `sync_auth_flow` is called by `httpx.Client`
+- `async_auth_flow` is called by `httpx.AsyncClient`
+- By default, both delegate to `auth_flow` if only `auth_flow` is overridden
+- **Key**: when `auth_flow` does no I/O (just injects a header), one class serves both clients
+
+**Simple Bearer injection (no I/O, single class works for sync + async):**
+
+```python
+class BearerAuth(httpx.Auth):
+    def auth_flow(self, request):
+        request.headers["Authorization"] = f"Bearer {self._get_token()}"
+        yield request
+```
+
+### Keycloak Token Flow
+
+Endpoint: `POST {token_url}` where `token_url` is the full URL, e.g.
+`https://keycloak.example.com/realms/myrealm/protocol/openid-connect/token`.
+
+Request body (`application/x-www-form-urlencoded`):
+
+```text
+grant_type=client_credentials&client_id=<id>&client_secret=<secret>
+```
+
+Response JSON:
+
+```json
+{
+  "access_token": "eyJhbGci...",
+  "expires_in": 300,
+  "token_type": "Bearer"
+}
+```
+
+No refresh token is issued for client credentials grants — a new token must be
+fetched on expiry.
+
+### Token Refresh Pattern
+
+Confluent's production implementation uses a **threshold-based expiry window**:
+refresh when less than 20% of the TTL remains (`expires_at - now < 0.2 * expires_in`).
+This avoids clock-skew races where a token expires mid-request.
+
+Pattern with double-checked locking:
+
+```python
+def _is_expired(self) -> bool:
+    if not self._token:
+        return True
+    return self._expires_at < time.monotonic() + (self._expires_in * 0.2)
+
+def _ensure_token(self) -> None:
+    if self._is_expired():
+        with self._lock:
+            if self._is_expired():   # second check inside lock
+                self._fetch_token()
+```
+
+### Sync vs Async Duality for KeycloakAuth
+
+`BearerAuth` has no I/O in `auth_flow` → single class with `auth_flow` works.
+
+`KeycloakAuth` must perform an HTTP POST to fetch a token. This creates a duality:
+
+- **Sync client path**: `sync_auth_flow` must use `threading.Lock` and `httpx.Client`
+- **Async client path**: `async_auth_flow` must use `asyncio.Lock` and avoid blocking
+
+**Recommended approach — separate `sync_auth_flow` and `async_auth_flow`**:
+
+```python
+class KeycloakAuth(httpx.Auth):
+    def __init__(self, token_url, client_id, client_secret, scope=None):
+        ...
+        self._sync_lock = threading.Lock()
+        self._async_lock: asyncio.Lock | None = None  # lazily created
+
+    def sync_auth_flow(self, request):
+        self._sync_ensure_token()
+        request.headers["Authorization"] = f"Bearer {self._token}"
+        yield request
+
+    async def async_auth_flow(self, request):
+        await self._async_ensure_token()
+        request.headers["Authorization"] = f"Bearer {self._token}"
+        yield request
+```
+
+`_sync_ensure_token` uses `threading.Lock` + opens a short-lived `httpx.Client`
+for the token POST.
+
+`_async_ensure_token` uses `asyncio.Lock` (created lazily on first call to stay
+event-loop-safe) + opens a short-lived `httpx.AsyncClient` for the token POST.
+
+**Why lazy async lock?** Although Python ≥ 3.10 allows creating `asyncio.Lock()`
+without a running loop, creating it lazily inside `_async_ensure_token` is
+the safest pattern and avoids any edge cases when the object is used across
+different event loops in tests.
+
+**Alternative — `asyncio.to_thread`**: Run `_sync_fetch_token` in a thread pool
+from `_async_ensure_token`. Simpler, but introduces thread-pool overhead on every
+token refresh and still requires careful lock handling.
+
+### Test Patterns
+
+The project uses `respx` for HTTP mocking. Auth tests need to:
+
+1. Verify `Authorization: Bearer` header is sent on registry requests
+2. For `KeycloakAuth`: mock the token endpoint POST + the registry GET
+3. Verify auto-refresh: set `expires_at` in the past, confirm a new token fetch
+
+`respx` can assert on request headers:
+
+```python
+route = router.get(url).mock(...)
+assert route.calls[0].request.headers["authorization"] == "Bearer test-token"
+```
+
+For `KeycloakAuth`, mock the token endpoint separately:
+
+```python
+router.post("https://keycloak/token").mock(
+    return_value=Response(200, json={"access_token": "tok", "expires_in": 300})
+)
+```
+
+### External Research Summary
+
+| Topic | Finding | Source |
+|-------|---------|--------|
+| httpx `auth_flow` | Generator protocol; `sync_auth_flow`/`async_auth_flow` wrap it | httpx docs + source |
+| Single class for sync+async | Works when `auth_flow` has no I/O | httpx source `_auth.py` |
+| Keycloak endpoint | `POST /realms/{realm}/protocol/openid-connect/token` | Keycloak official docs |
+| Token response | `access_token` + `expires_in` (no refresh token) | RFC 6749 §4.4 |
+| Threshold refresh | 20% TTL remaining; double-checked lock | Confluent source |
+| CUSTOM bearer source | User-supplied callable; Confluent `_CustomOAuthClient` | Confluent source |
+
+### Technical Constraints
+
+- **No new dependencies** — httpx is already a dependency; token fetch uses httpx directly
+- **Python ≥ 3.10** — `asyncio.Lock()` safe without running loop; `asyncio.to_thread` available
+- **100% coverage** — every branch in both `sync_auth_flow` and `async_auth_flow` must be tested,
+  including the token-expired refresh path
+- **mypy strict** — `httpx.Auth` subclasses must be properly typed; `token_provider` typed as
+  `Callable[[], str]`; async lock typed as `asyncio.Lock | None`
+- **Thread-safe sync, coroutine-safe async** — double-checked locking pattern required
+
+## Open Questions
+
+1. Does the staging Apicurio registry actually require auth, or only Kafka does?
+   (If registry is open, Bearer/Keycloak support is still correct to ship but not blocking.)
+2. What realm name does the backend team use in Keycloak? (Needed for `token_url` in docs/examples.)
+3. Should `KeycloakAuth` accept an optional `scope` parameter? (Default: no scope sent.)
+4. Should auth errors (e.g., 401 from token endpoint) raise a new `AuthenticationError`,
+   or wrap into `RegistryConnectionError`?
+
+## Recommendations
+
+### New module: `src/apicurio_serdes/_auth.py`
+
+```python
+class BearerAuth(httpx.Auth):
+    def __init__(
+        self,
+        token: str | None = None,
+        token_provider: Callable[[], str] | None = None,
+    ) -> None: ...
+
+    def auth_flow(self, request: httpx.Request) -> Generator[...]: ...
+
+
+class KeycloakAuth(httpx.Auth):
+    def __init__(
+        self,
+        token_url: str,
+        client_id: str,
+        client_secret: str,
+        scope: str | None = None,
+    ) -> None: ...
+
+    def sync_auth_flow(self, request: httpx.Request) -> Generator[...]: ...
+    async def async_auth_flow(self, request: httpx.Request) -> AsyncGenerator[...]: ...
+```
+
+### Changes to `_client.py` and `_async_client.py`
+
+Add `auth: httpx.Auth | None = None` parameter; pass to `httpx.Client`/`httpx.AsyncClient`.
+
+### Changes to `__init__.py`
+
+Export `BearerAuth` and `KeycloakAuth` from top-level package.
+
+### Test files
+
+- `tests/test_auth.py` — unit tests for `BearerAuth` and `KeycloakAuth` in isolation
+  (no real HTTP, mock token endpoint with respx)
+- `tests/test_client.py` — add constructor test for `auth=BearerAuth(...)` passed through
+- `tests/test_async_client.py` — same parity test

--- a/docs/plans/2026-03-19-cache-ttl-plan.md
+++ b/docs/plans/2026-03-19-cache-ttl-plan.md
@@ -1,0 +1,421 @@
+# Plan: Cache TTL and Eviction Policy (#39) (2026-03-19)
+
+## Summary
+
+Replace the unbounded `dict` caches in `_RegistryClientBase` with a new
+`_CacheCore` class backed by `collections.OrderedDict`. `_CacheCore` provides
+LRU eviction (size cap) and optional TTL expiry using only stdlib. Two new
+constructor parameters — `cache_max_size` (default `1000`) and
+`cache_ttl_seconds` (default `None`) — are added to both clients. TTL applies
+only to `_schema_cache` (mutable, latest-version lookups); `_id_cache` is
+content-addressed and never expires. LRU cap applies to both caches. ADR-011
+is superseded by ADR-021.
+
+## Stakes Classification
+
+**Level**: High
+
+**Rationale**: Changes touch the cache abstraction shared by both sync and
+async clients, the constructor signatures of both public client classes, and
+the double-checked locking pattern (ADR-004). Incorrect mutation of
+`OrderedDict` outside a lock would corrupt the LRU order. A regression here
+silently degrades reliability under concurrent load.
+
+## Context
+
+**Research**: [docs/plans/2026-03-19-cache-ttl-research.md](2026-03-19-cache-ttl-research.md)
+
+**Affected Areas**:
+
+- `src/apicurio_serdes/_base.py` — `_CacheCore`, `_RegistryClientBase.__init__`
+- `src/apicurio_serdes/_client.py` — `ApicurioRegistryClient.__init__`,
+  cache access in `get_schema`, `register_schema`, `_get_schema_by_id`
+- `src/apicurio_serdes/_async_client.py` — same methods, async versions
+- `docs/decisions/021-lru-ttl-cache-eviction.md` — new ADR
+- `docs/decisions/011-no-cache-eviction.md` — status updated to Superseded
+- `docs/concepts/schema-caching.en.md` — updated cache lifetime and new eviction section
+- `docs/concepts/schema-caching.fr.md` — French translation of same
+- `docs/changelog.en.md` / `docs/changelog.fr.md` — `### Added` entries
+
+## Success Criteria
+
+- [ ] `_CacheCore` implements LRU eviction (O(1) via `OrderedDict`)
+- [ ] `_CacheCore` implements optional per-entry TTL (eager check on every `get`/`peek`)
+- [ ] `peek()` is safe to call outside a lock (no mutation)
+- [ ] `get()` and `set()` are only called inside the existing client lock
+- [ ] `cache_ttl_seconds` applies to `_schema_cache` only; `_id_cache` never expires
+- [ ] `cache_max_size` applies to both caches
+- [ ] Defaults match Confluent: `cache_max_size=1000`, `cache_ttl_seconds=None`
+- [ ] `ValueError` raised for `cache_max_size < 1` or `cache_ttl_seconds <= 0`
+- [ ] Double-checked locking pattern (ADR-004) preserved in both clients
+- [ ] 100% test coverage; all existing tests pass
+- [ ] ADR-021 created, ADR-011 updated to Superseded
+- [ ] ADR-021 documents the intentional divergence from Apicurio Java
+- [ ] `docs/concepts/schema-caching` updated (en + fr)
+- [ ] Changelogs updated (en + fr)
+
+## Implementation Steps
+
+### Phase 1: ADR
+
+#### Step 1.1: Create ADR-021
+
+- **Files**: `docs/decisions/021-lru-ttl-cache-eviction.md`
+- **Action**: Create a new ADR superseding ADR-011. Must cover:
+  - The decision: `_CacheCore` with LRU cap on both caches, optional TTL on
+    `_schema_cache` only
+  - The revisit trigger from ADR-011 being met (issue #39, v0.4.0 milestone)
+  - Stdlib-only constraint (`OrderedDict` + `time.monotonic`, no new deps)
+  - The split-cache rationale: artifact-based lookups return the *latest
+    version* (mutable); ID-based lookups are content-addressed (immutable)
+  - **Intentional divergence from Apicurio Java**: The Java client applies the
+    same TTL to all lookup indexes including ID-based ones, and has no LRU cap.
+    We diverge on both points, aligning instead with Confluent Python: no TTL
+    on ID-based lookups (re-fetching identical content is wasteful), and an LRU
+    cap on both caches as a memory safety net. Document this as a deliberate
+    semantic choice rather than a pragmatic simplification.
+  - Default alignment with Confluent (`cache_max_size=1000`,
+    `cache_ttl_seconds=None`)
+- **Verify**: File exists, `markdownlint` passes
+- **Complexity**: Small
+
+#### Step 1.2: Update ADR-011 status
+
+- **Files**: `docs/decisions/011-no-cache-eviction.md`
+- **Action**: Change `**Status:** Accepted` to
+  `**Status:** Superseded by [ADR-021](021-lru-ttl-cache-eviction.md)` and
+  add a note at the top referencing the superseding decision.
+- **Verify**: File opens, status line reads Superseded, `markdownlint` passes
+- **Complexity**: Small
+
+### Phase 2: `_CacheCore` — TDD
+
+#### Step 2.1: Write `_CacheCore` unit tests (RED)
+
+- **Files**: `tests/test_cache_core.py` (new file)
+- **Action**: Write failing unit tests for `_CacheCore`. Tests must cover every
+  behaviour path before any implementation exists.
+- **Test cases**:
+
+  *Basic get/set:*
+
+  - `set("k", "v")` then `get("k")` → returns `"v"`
+  - `get("missing")` on empty cache → returns `_CacheCore._MISSING`
+
+  *TTL = None (no expiry):*
+
+  - Entry set with `ttl=None` is never expired, even after simulated time
+    advance (monkeypatch `time.monotonic`)
+  - `peek("k")` with no TTL → returns value without modifying order
+
+  *TTL > 0 (expiry):*
+
+  - Entry still valid before TTL elapses → `get` and `peek` return value
+  - Entry expired after TTL elapses (monkeypatch `time.monotonic`) →
+    `get` returns `_MISSING` and deletes the entry from internal store
+  - Entry expired → `peek` returns `_MISSING` but does NOT delete entry
+    (store still contains the key after `peek`)
+  - Entry overwritten via `set` resets the expiry timestamp
+
+  *LRU eviction:*
+
+  - `max_size=2`: insert `"a"`, `"b"`, `"c"` → `"a"` is evicted
+  - `max_size=2`: insert `"a"`, `"b"`, access `"a"` (via `get`), insert
+    `"c"` → `"b"` is evicted (LRU is `"b"` after `"a"` was accessed)
+  - `max_size=2`: insert `"a"`, `"b"`, `peek("a")`, insert `"c"` →
+    `"a"` is evicted (`peek` must NOT update LRU order)
+  - Overwriting existing key does NOT evict (no size increase): insert
+    `"a"`, `"b"`, `set("a", "new")` → both still present
+
+  *Validation:*
+
+  - `_CacheCore(max_size=0, ttl=None)` → `ValueError`
+  - `_CacheCore(max_size=-1, ttl=None)` → `ValueError`
+  - `_CacheCore(max_size=1, ttl=0)` → `ValueError`
+  - `_CacheCore(max_size=1, ttl=-1.0)` → `ValueError`
+  - `_CacheCore(max_size=1, ttl=None)` → valid (no TTL)
+  - `_CacheCore(max_size=1, ttl=30.0)` → valid
+
+- **Verify**: Tests exist and all fail (no implementation)
+- **Complexity**: Medium
+
+#### Step 2.2: Implement `_CacheCore` in `_base.py` (GREEN)
+
+- **Files**: `src/apicurio_serdes/_base.py`
+- **Action**: Add `_CacheCore` class before `_RegistryClientBase`. Add
+  `from collections import OrderedDict` and `import time` to imports.
+  Implement `__init__`, `get`, `peek`, `set` as specified in the research.
+  `_MISSING = object()` at class level. Validate `max_size >= 1` and
+  `ttl > 0 if ttl is not None` in `__init__`.
+- **Verify**: All tests from Step 2.1 pass; `uv run pytest tests/test_cache_core.py`
+  green; `uv run ruff check src/` clean
+- **Complexity**: Small
+
+### Phase 3: Wire `_CacheCore` into `_RegistryClientBase` and sync client — TDD
+
+#### Step 3.1: Write constructor and validation tests (RED)
+
+- **Files**: `tests/test_client.py`
+- **Action**: Add BDD scenarios (or plain unit tests if simpler) for new
+  constructor parameters and the updated cache behaviour in the sync client.
+- **Test cases**:
+
+  *Constructor validation:*
+
+  - `ApicurioRegistryClient(..., cache_max_size=0)` → `ValueError`
+  - `ApicurioRegistryClient(..., cache_max_size=-1)` → `ValueError`
+  - `ApicurioRegistryClient(..., cache_ttl_seconds=0)` → `ValueError`
+  - `ApicurioRegistryClient(..., cache_ttl_seconds=-1.0)` → `ValueError`
+  - `ApicurioRegistryClient(..., cache_max_size=1, cache_ttl_seconds=30.0)`
+    → constructs without error
+
+  *LRU eviction (schema cache):*
+
+  - Client with `cache_max_size=2`, three distinct artifact schemas →
+    after fetching all three, first artifact requires a second HTTP call
+    (was evicted); second and third are still cached
+
+  *TTL expiry (schema cache only):*
+
+  - Client with `cache_ttl_seconds=60` (monkeypatched clock) → `get_schema`
+    after TTL elapsed triggers a new HTTP request
+  - Client with `cache_ttl_seconds=60` → `get_schema` before TTL elapsed
+    returns cached result without HTTP call
+
+  *ID cache never expires (TTL does not apply):*
+
+  - Client with `cache_ttl_seconds=60` (monkeypatched clock) →
+    `get_schema_by_global_id` after TTL elapsed still returns cached
+    result (no HTTP call); verifies split-cache TTL policy
+
+  *Defaults:*
+
+  - Default `cache_max_size` is `1000`
+  - Default `cache_ttl_seconds` is `None`
+
+- **Verify**: Tests exist and fail (no implementation change yet)
+- **Complexity**: Medium
+
+#### Step 3.2: Update `_RegistryClientBase.__init__` (GREEN partial)
+
+- **Files**: `src/apicurio_serdes/_base.py:49–71`
+- **Action**: Add `cache_max_size: int = 1000` and
+  `cache_ttl_seconds: float | None = None` keyword-only params to
+  `_RegistryClientBase.__init__`. Add validation (delegate to `_CacheCore`
+  constructor). Replace:
+
+  ```python
+  self._schema_cache: dict[...] = {}
+  self._id_cache: dict[...] = {}
+  ```
+
+  with:
+
+  ```python
+  self._schema_cache: _CacheCore = _CacheCore(
+      max_size=cache_max_size, ttl=cache_ttl_seconds
+  )
+  self._id_cache: _CacheCore = _CacheCore(
+      max_size=cache_max_size, ttl=None  # ID entries never expire
+  )
+  ```
+
+- **Verify**: `uv run pytest` with no client method changes yet — tests that
+  call `_schema_cache` / `_id_cache` directly will fail (expected); no
+  import errors or syntax errors
+- **Complexity**: Small
+
+#### Step 3.3: Update `_client.py` cache access patterns (GREEN)
+
+- **Files**: `src/apicurio_serdes/_client.py:65–90, 115–248`
+- **Action**: Pass `cache_max_size` and `cache_ttl_seconds` through
+  `ApicurioRegistryClient.__init__` to `super().__init__`. Replace all
+  cache access patterns:
+
+  Fast-path (outside lock), e.g. `_client.py:135`:
+
+  ```python
+  # Before:
+  if cache_key in self._schema_cache:
+      return self._schema_cache[cache_key]
+  # After:
+  cached = self._schema_cache.peek(cache_key)
+  if cached is not _CacheCore._MISSING:
+      return cached
+  ```
+
+  Inside-lock double-check (e.g. `_client.py:140–141`):
+
+  ```python
+  # Before:
+  if cache_key in self._schema_cache:
+      return self._schema_cache[cache_key]
+  # After:
+  cached = self._schema_cache.get(cache_key)
+  if cached is not _CacheCore._MISSING:
+      return cached
+  ```
+
+  Cache write (e.g. `_client.py:145`):
+
+  ```python
+  # Before:
+  self._schema_cache[cache_key] = cached
+  # After:
+  self._schema_cache.set(cache_key, cached)
+  ```
+
+  Apply the same transformation to `register_schema` (`_client.py:219–231`)
+  and `_get_schema_by_id` (`_client.py:234–248`, using `_id_cache`).
+
+- **Verify**: `uv run pytest tests/test_client.py` — all existing cache tests
+  plus new tests from Step 3.1 pass; `uv run ruff check src/` clean
+- **Complexity**: Medium
+
+### Phase 4: Wire `_CacheCore` into async client — TDD
+
+#### Step 4.1: Write async constructor and cache behaviour tests (RED)
+
+- **Files**: `tests/test_async_client.py`
+- **Action**: Mirror the test cases from Step 3.1 for
+  `AsyncApicurioRegistryClient`. All cases identical except async invocation
+  with `await` and `pytest.mark.anyio`.
+- **Test cases**: Same as Step 3.1 (constructor validation, LRU eviction,
+  TTL expiry on schema cache, no TTL on ID cache, defaults)
+- **Verify**: New async tests exist and fail
+- **Complexity**: Medium
+
+#### Step 4.2: Update `_async_client.py` cache access patterns (GREEN)
+
+- **Files**: `src/apicurio_serdes/_async_client.py:50–74, 102–238`
+- **Action**: Pass `cache_max_size` and `cache_ttl_seconds` through
+  `AsyncApicurioRegistryClient.__init__` to `super().__init__`. Apply the
+  same `peek()` / `get()` / `set()` transformation as Step 3.3 to:
+  - `get_schema` (`_async_client.py:122–136`)
+  - `register_schema` (`_async_client.py:205–220`)
+  - `_get_schema_by_id` (`_async_client.py:222–238`)
+- **Verify**: `uv run pytest tests/test_async_client.py` — all tests pass;
+  `uv run ruff check src/` clean
+- **Complexity**: Medium
+
+### Phase 5: Full suite verification
+
+#### Step 5.1: Run complete test suite
+
+- **Files**: All test files
+- **Action**: `uv run pytest` — must pass with 100% coverage; no regressions
+- **Verify**: Zero failures, coverage 100%
+- **Complexity**: Small
+
+### Phase 6: Documentation
+
+#### Step 6.1: Update English schema-caching concepts guide
+
+- **Files**: `docs/concepts/schema-caching.en.md`
+- **Action**: Make the following targeted changes:
+  - **"Cache Lifetime" section**: Remove the sentence "There is no TTL
+    (time-to-live) or expiration — once a schema is cached, it stays cached
+    until the client is garbage-collected." Replace with an explanation that
+    the lifetime is configurable: by default no expiry (same behaviour), but
+    `cache_ttl_seconds` enables TTL on artifact-based lookups. Note that
+    ID-based lookups never expire (content-addressed, immutable).
+  - **"When to Create a New Client" section**: The bullet "If a schema changes
+    in the registry and you need the new version" should be updated — with
+    `cache_ttl_seconds` set, the running client will pick up new versions
+    automatically after the TTL elapses; creating a new client is only needed
+    when no TTL is configured.
+  - **New section "Cache Eviction and Size Limits"**: Add after "Cache
+    Lifetime". Explain `cache_max_size` (LRU eviction, applies to both caches,
+    default 1000) and `cache_ttl_seconds` (TTL for artifact lookups only,
+    default `None`). Include a short code example showing both params at
+    construction time.
+- **Verify**: `markdownlint docs/concepts/schema-caching.en.md` passes
+- **Complexity**: Small
+
+#### Step 6.2: Update French schema-caching concepts guide
+
+- **Files**: `docs/concepts/schema-caching.fr.md`
+- **Action**: Apply the same changes as Step 6.1 in French.
+- **Verify**: `markdownlint docs/concepts/schema-caching.fr.md` passes
+- **Complexity**: Small
+
+#### Step 6.3: Update English changelog
+
+- **Files**: `docs/changelog.en.md`
+- **Action**: Add under `## Unreleased → ### Added`:
+
+  ```markdown
+  - `cache_max_size` (default `1000`) and `cache_ttl_seconds` (default `None`)
+    constructor parameters on both clients. `cache_max_size` caps both caches
+    with LRU eviction. `cache_ttl_seconds` enables optional TTL expiry on
+    artifact-based lookups (`get_schema`, `register_schema`); ID-based lookups
+    (`get_schema_by_global_id`, `get_schema_by_content_id`) are content-addressed
+    and never expire.
+  ```
+
+- **Verify**: `markdownlint docs/changelog.en.md` passes
+- **Complexity**: Small
+
+#### Step 6.4: Update French changelog
+
+- **Files**: `docs/changelog.fr.md`
+- **Action**: Add the French translation of the entry from Step 6.3 under the
+  corresponding `## Non publié → ### Ajouté` section.
+- **Verify**: `markdownlint docs/changelog.fr.md` passes
+- **Complexity**: Small
+
+## Test Strategy
+
+### Automated Tests
+
+| Test Case | Type | Input | Expected Output |
+| --------- | ---- | ----- | --------------- |
+| `_CacheCore` get on empty cache | Unit | `get("k")` | `_MISSING` |
+| `_CacheCore` set then get | Unit | `set("k","v")`, `get("k")` | `"v"` |
+| `_CacheCore` TTL expired on `get` | Unit | set, advance clock past TTL, `get` | `_MISSING`, entry deleted |
+| `_CacheCore` TTL expired on `peek` | Unit | set, advance clock past TTL, `peek` | `_MISSING`, entry NOT deleted |
+| `_CacheCore` TTL valid on `peek` | Unit | set, clock before TTL, `peek` | value returned |
+| `_CacheCore` `peek` does not update LRU | Unit | set a, b; `peek(a)`; set c | a evicted (LRU unchanged) |
+| `_CacheCore` LRU eviction oldest | Unit | `max_size=2`; set a, b, c | a evicted |
+| `_CacheCore` LRU eviction after `get` | Unit | `max_size=2`; set a, b; `get(a)`; set c | b evicted |
+| `_CacheCore` no eviction on overwrite | Unit | `max_size=2`; set a, b; `set(a,"v2")` | both a, b present |
+| `_CacheCore` `max_size=0` | Unit | `_CacheCore(max_size=0, ttl=None)` | `ValueError` |
+| `_CacheCore` `ttl=0` | Unit | `_CacheCore(max_size=1, ttl=0)` | `ValueError` |
+| `_CacheCore` `ttl=None` no expiry | Unit | set, advance clock by 1 hour, `get` | value returned |
+| Sync client `cache_max_size=0` | Integration | constructor | `ValueError` |
+| Sync client `cache_ttl_seconds=0` | Integration | constructor | `ValueError` |
+| Sync client LRU eviction | Integration | `cache_max_size=2`, 3 schemas | 3rd fetch re-hits HTTP |
+| Sync client TTL schema cache | Integration | `cache_ttl_seconds=60`, advance clock | re-hits HTTP after expiry |
+| Sync client TTL id cache (no expiry) | Integration | `cache_ttl_seconds=60`, advance clock | ID lookup still cached |
+| Async client constructor validation | Integration | same as sync | same errors |
+| Async client LRU + TTL behaviour | Integration | same scenarios async | same expectations |
+
+### Manual Verification
+
+- [ ] Confirm `help(ApicurioRegistryClient)` shows `cache_max_size` and
+  `cache_ttl_seconds` in the constructor docstring
+- [ ] Confirm `help(AsyncApicurioRegistryClient)` shows the same params
+
+## Risks and Mitigations
+
+| Risk | Impact | Mitigation |
+| ---- | ------ | ---------- |
+| `OrderedDict.move_to_end` called outside lock corrupts LRU order | Data corruption under concurrent load | `peek()` explicitly excludes `move_to_end`; only `get()` calls it, and `get()` is always inside lock |
+| `asyncio.Lock` is not re-entrant; nested lock acquire deadlocks | Hang under async concurrent load | `_CacheCore` is lock-free; no internal locking; existing single-level lock pattern preserved |
+| TTL on `_id_cache` would re-fetch identical content | Wasted HTTP round-trips | `_id_cache` constructed with `ttl=None`; enforced in `_RegistryClientBase.__init__` |
+| Monkeypatching `time.monotonic` in tests affects global state | Flaky tests from shared state | Use `unittest.mock.patch("apicurio_serdes._base.time.monotonic")` scoped to each test |
+| `_CacheCore._MISSING` is module-level; comparison relies on identity | Accidental equality match | Sentinel is `object()`; identity check `is not _MISSING` is unambiguous |
+
+## Rollback Strategy
+
+All changes are additive at the API boundary (new optional kwargs with
+defaults). Rolling back requires reverting `_base.py`, `_client.py`, and
+`_async_client.py` to the prior dict-based implementation. No schema,
+database, or wire-format changes are made. A `git revert` of the feature
+commits is sufficient.
+
+## Status
+
+- [x] Plan approved
+- [x] Implementation started
+- [x] Implementation complete

--- a/docs/plans/2026-03-19-cache-ttl-research.md
+++ b/docs/plans/2026-03-19-cache-ttl-research.md
@@ -1,0 +1,322 @@
+# Research: Cache TTL and Eviction Policy (#39) (2026-03-19)
+
+## Problem Statement
+
+Both `_schema_cache` and `_id_cache` in `_RegistryClientBase` grow
+unbounded for the lifetime of the client. Issue #39 asks for configurable
+LRU size limits and optional TTL expiry, matching parity with Confluent
+Python and Apicurio Java reference implementations.
+
+## Requirements
+
+Gathered through clarification dialogue:
+
+- **Both** LRU size cap and TTL expiry, on both caches.
+- **stdlib only** — no new dependencies (`collections.OrderedDict`,
+  `time.monotonic`).
+- **Eager TTL check** — expired entry treated as a miss on every `get`;
+  no stale reads.
+- Thread-safe under the existing double-checked locking pattern.
+
+## Findings
+
+### Relevant Files
+
+| File | Purpose | Key Lines |
+|------|---------|-----------|
+| `src/apicurio_serdes/_base.py` | Cache declarations, `_RegistryClientBase` | 48–49, 67–96 |
+| `src/apicurio_serdes/_client.py` | Sync cache access (get/write), `threading.RLock` | 71–85, 159–174, 181–194 |
+| `src/apicurio_serdes/_async_client.py` | Async cache access, `asyncio.Lock` | 61–76, 148–163, 170–185 |
+| `docs/decisions/011-no-cache-eviction.md` | ADR-011 — unbounded cache accepted | full |
+| `docs/decisions/004-double-checked-locking-for-cache-dedup.md` | ADR-004 — stampede prevention | full |
+| `tests/test_client.py` | TS-010/011/012 cache tests, double-check locking tests | 47–263, 399–434 |
+| `tests/test_async_client.py` | Async cache + stampede tests | 142–195, 529–586 |
+
+### Current Cache Structure
+
+Both caches live in `_RegistryClientBase.__init__` (`_base.py:48–49`):
+
+```python
+self._schema_cache: dict[tuple[str, str], CachedSchema] = {}
+self._id_cache: dict[tuple[str, int], dict[str, Any]] = {}
+```
+
+Key/value types:
+
+| Cache | Key type | Value type | Mutability |
+|-------|----------|------------|------------|
+| `_schema_cache` | `(group_id, artifact_id)` | `CachedSchema` (frozen dataclass) | **Mutable** — latest version can change |
+| `_id_cache` | `(id_type, id_value)` | `dict[str, Any]` | **Immutable** — globalId/contentId are permanent |
+
+This distinction is load-bearing: `_schema_cache` entries can become stale
+(a new schema version may be registered), whereas `_id_cache` entries are
+content-addressed and never stale. Only `_schema_cache` truly needs TTL.
+
+### Access Pattern (both clients)
+
+Every lookup follows the same double-checked locking pattern (ADR-004):
+
+```text
+1. Fast-path check — outside lock, return immediately on hit
+2. Acquire self._lock (RLock or asyncio.Lock)
+3. Re-check inside lock — handle concurrent first-fetch
+4. HTTP fetch
+5. Write cache inside lock
+```
+
+All three methods (`get_schema`, `register_schema`, `_get_schema_by_id`)
+use this pattern identically in both the sync and async clients.
+
+### Existing Lock Types
+
+| Client | Lock | Re-entrant? |
+|--------|------|------------|
+| `ApicurioRegistryClient` | `threading.RLock` | Yes |
+| `AsyncApicurioRegistryClient` | `asyncio.Lock` | No |
+
+The existing locks already guard the "check + fetch + set" sequence.
+They are the correct place to also guard LRU bookkeeping, avoiding the
+need for a second internal lock inside the cache object.
+
+### ADR-011 (Must be Superseded)
+
+ADR-011 (`docs/decisions/011-no-cache-eviction.md`) accepted unbounded
+caches with the revisit trigger: *"if real-world users report memory
+pressure, add optional `max_cache_size` with LRU eviction — do not add
+TTL (schemas are immutable)."*
+
+Issue #39, added to the v0.4.0 milestone, overrides this decision. A new
+ADR-021 must supersede ADR-011.
+
+Notably, ADR-011's rationale that *"schemas are immutable"* is only correct
+for ID-based lookups. Artifact-based lookups (`get_schema` by artifact_id)
+return the **latest version**, which can change when a new schema version is
+registered. TTL is therefore justified for `_schema_cache` specifically.
+
+### External Research — Sibling Repo Analysis
+
+Source-verified against current HEAD of each repository.
+
+**Confluent Python (`confluent-kafka-python`, `_sync/schema_registry_client.py`):**
+
+Confluent uses a **split-cache architecture** — the most important finding
+for our design:
+
+| Lookup type | Cache class | TTL? | LRU cap? |
+|-------------|-------------|------|---------|
+| By schema ID / guid / subject+version | `_SchemaCache` (plain `defaultdict`) | **No** | **No** |
+| Latest version by subject | `_latest_version_cache` (`cachetools.TTLCache` or `LRUCache`) | **Optional** | **Yes (1000)** |
+
+Parameters (passed as config dict keys, not keyword args):
+
+| Key | Default | Applied to |
+|-----|---------|-----------|
+| `"cache.capacity"` | `1000` | `_latest_version_cache` only |
+| `"cache.latest.ttl.sec"` | `None` (no TTL) | `_latest_version_cache` only |
+
+When `cache.latest.ttl.sec` is set, Confluent uses `cachetools.TTLCache`
+(which is TTL + LRU combined). When it is `None`, it uses `cachetools.LRUCache`.
+The immutable ID-based `_SchemaCache` has **no cap and no TTL** — it is permanent.
+TTL checks are **eager** (`cachetools` behaviour).
+
+**Apicurio Java (`schema-resolver/cache/ERCache.java`):**
+
+Apicurio uses a **single unified `ERCache`** covering all five lookup indexes
+(globalId, contentId, content hash, GAV, latest):
+
+| Property | Default | Notes |
+|----------|---------|-------|
+| `apicurio.registry.check-period-ms` | `30000` (30 s) | Single TTL for all indexes |
+| `apicurio.registry.cache-latest` | `true` | Disable caching of latest lookups only |
+| `apicurio.registry.background-refresh-enabled` | `false` | Stale-while-revalidate; out of scope |
+
+`ERCache` stores entries in plain `ConcurrentHashMap` instances — **no LRU
+eviction and no size cap**. Expired entries remain in memory until accessed
+and replaced. The Java client applies the same TTL to both mutable (latest)
+and immutable (by ID) lookups — a pragmatic choice rather than a semantic one.
+TTL checks are **eager** (`isExpired()` called on every `get()`).
+
+**Alignment summary:**
+
+| Decision | Confluent | Apicurio Java | Our proposal |
+|----------|-----------|---------------|--------------|
+| TTL on `_schema_cache` (mutable, latest) | Yes (optional) | Yes (30 s default) | Yes (`None` default) |
+| TTL on `_id_cache` (immutable, by ID) | **No — permanent** | Yes (same TTL) | **Revised: No** |
+| LRU cap on mutable cache | Yes (1000) | No | Yes (1000) |
+| LRU cap on ID cache | **No cap** | No | Yes (1000, shared param) |
+| Default TTL | `None` | 30 s | `None` |
+| Default max_size | 1000 | ∞ | 1000 |
+| Eager TTL check | Yes | Yes | Yes |
+
+**Revised recommendation from sibling repo alignment:**
+Confluent's split is semantically sounder and better justified: ID-based
+lookups are content-addressed and immutable — there is no correctness
+reason to ever expire them. Apply `cache_ttl_seconds` **only to
+`_schema_cache`**. Apply `cache_max_size` to both (as a memory bound).
+
+**Recommended defaults (revised):**
+
+| Parameter | Default | Rationale |
+|-----------|---------|-----------|
+| `cache_max_size` | `1000` | Matches Confluent `cache.capacity` exactly |
+| `cache_ttl_seconds` | `None` | Matches Confluent `cache.latest.ttl.sec`; opt-in |
+
+**Python stdlib pattern (LRU + TTL with `OrderedDict`):**
+
+```python
+from collections import OrderedDict
+import time
+
+class _CacheCore:
+    """Lock-free core — callers must serialise access."""
+
+    _MISSING = object()
+
+    def __init__(self, max_size: int, ttl: float | None) -> None:
+        self._max_size = max_size
+        self._ttl = ttl
+        # Oldest (LRU) at front, most-recently-used at back.
+        # Values: (stored_value, expiry) or (stored_value, None) when no TTL.
+        self._store: OrderedDict = OrderedDict()
+
+    def get(self, key):
+        entry = self._store.get(key, self._MISSING)
+        if entry is self._MISSING:
+            return self._MISSING
+        value, expiry = entry
+        if expiry is not None and time.monotonic() >= expiry:
+            del self._store[key]
+            return self._MISSING
+        self._store.move_to_end(key)  # bump to MRU
+        return value
+
+    def peek(self, key):
+        """TTL check without LRU update — safe for unlocked fast-path."""
+        entry = self._store.get(key, self._MISSING)
+        if entry is self._MISSING:
+            return self._MISSING
+        value, expiry = entry
+        if expiry is not None and time.monotonic() >= expiry:
+            return self._MISSING  # expired; do NOT delete outside lock
+        return value
+
+    def set(self, key, value) -> None:
+        expiry = time.monotonic() + self._ttl if self._ttl is not None else None
+        if key in self._store:
+            self._store[key] = (value, expiry)
+            self._store.move_to_end(key)
+        else:
+            self._store[key] = (value, expiry)
+            while len(self._store) > self._max_size:
+                self._store.popitem(last=False)  # evict LRU
+```
+
+Key points:
+
+- `peek()` is for the **unlocked fast-path** — it checks TTL but does NOT
+  call `move_to_end` or `del` (which are mutating operations unsafe without
+  a lock). It returns `_MISSING` for expired entries; the actual deletion
+  happens inside the lock on the next `get()` call.
+- `get()` is for **inside the lock** — full LRU update and TTL eviction.
+- `set()` is always called inside the lock.
+- `time.monotonic()` (not `time.time()`) ensures TTL intervals are
+  immune to NTP adjustments and clock jumps (PEP 418).
+- `move_to_end` and `popitem(last=False)` are both O(1) on `OrderedDict`.
+
+**Sync/async duality:**
+
+`asyncio.Lock` cannot protect shared state from OS threads; conversely,
+holding a `threading.RLock` across an `await` is safe but blocks the event
+loop thread for the lock's hold time. Since cache operations are
+pure-memory (microseconds), this is acceptable. The two clients already use
+different lock types — `_CacheCore` (lock-free) integrates naturally into
+both without an additional lock layer.
+
+### Technical Constraints
+
+1. **Double-checked locking must be preserved** — the fast-path `peek()` +
+   locked `get()` sequence replaces the current `if key in cache:` checks.
+2. **TTL for `_schema_cache` only** — `_id_cache` entries are immutable;
+   applying TTL to them would re-fetch identical content needlessly.
+   Confluent's reference implementation confirms this split: ID-based
+   lookups are permanent, only mutable latest-version lookups get TTL.
+   `cache_max_size` still applies to both caches as a memory bound.
+3. **`asyncio.Lock` is not re-entrant** — `_CacheCore.get()` must not call
+   `_CacheCore.set()` internally (no re-entrant paths) in the async client.
+4. **100% test coverage required** — the `peek()` / expired-but-not-deleted
+   path and the LRU eviction path both need explicit tests.
+5. **ADR-011 superseded** — new ADR-021 required before implementation.
+6. **Validation**: `cache_max_size >= 1`, `cache_ttl_seconds > 0` if not None.
+
+## Open Questions
+
+1. ~~**Single TTL for both caches or separate?**~~ **Resolved by sibling
+   repo research.** Confluent explicitly applies TTL only to mutable
+   latest-version lookups; ID-based lookups use a permanent cache.
+   Our `cache_ttl_seconds` applies to `_schema_cache` only.
+   `cache_max_size` applies to both as a memory bound.
+
+2. **TTL = 0 semantics?**
+   Should `cache_ttl_seconds=0` mean "no caching" or be rejected as
+   invalid? Recommendation: raise `ValueError` (caching is a core feature;
+   disabling it entirely is not the intended use).
+
+3. **`max_size=0`?**
+   Similarly, should `cache_max_size=0` be valid (disable LRU cap) or
+   invalid? Recommendation: `ValueError` — the distinction between
+   "bounded" and "unbounded" should be controlled by not passing the
+   parameter rather than passing zero.
+
+## Recommendations
+
+### Architecture
+
+Introduce `_CacheCore` in `_base.py`. Replace both plain `dict` caches in
+`_RegistryClientBase` with `_CacheCore` instances. No change to the client
+lock types; the existing locks already provide the necessary serialisation.
+
+### New Constructor Parameters
+
+Both `ApicurioRegistryClient` and `AsyncApicurioRegistryClient` gain:
+
+| Parameter | Type | Default | Description |
+|-----------|------|---------|-------------|
+| `cache_max_size` | `int` | `1000` | LRU cap applied to both caches |
+| `cache_ttl_seconds` | `float \| None` | `None` | Per-entry TTL for `_schema_cache` only; `_id_cache` entries never expire |
+
+### Fast-path Change
+
+```python
+# Before:
+if cache_key in self._schema_cache:
+    return self._schema_cache[cache_key]
+
+# After:
+cached = self._schema_cache.peek(cache_key)
+if cached is not _MISSING:
+    return cached
+```
+
+### Inside-lock Change
+
+```python
+# Before:
+if cache_key in self._schema_cache:   # double-check
+    return self._schema_cache[cache_key]
+
+# After:
+cached = self._schema_cache.get(cache_key)   # TTL-aware double-check
+if cached is not _MISSING:
+    return cached
+```
+
+### ADR Updates
+
+- Create **ADR-021** superseding ADR-011; document the reversal rationale
+  (issue #39 milestone v0.4.0, real user concern validated).
+- Update **ADR-011** status to Superseded.
+
+### Suggested `_CacheCore` location
+
+Keep `_CacheCore` private in `_base.py` alongside `_RegistryClientBase`.
+It is an implementation detail; no public export needed.

--- a/docs/user-guide/async-client.fr.md
+++ b/docs/user-guide/async-client.fr.md
@@ -85,7 +85,7 @@ async def produce(request):
 | Récupération de schema | `client.get_schema(id)` | `await client.get_schema(id)` |
 | Enregistrement de schema | `client.register_schema(id, schema)` | `await client.register_schema(id, schema)` |
 | Type de retour | `CachedSchema` | `CachedSchema` (même classe) |
-| Paramètres du constructeur | `url`, `group_id` | `url`, `group_id` (identiques) |
+| Paramètres du constructeur | `url`, `group_id`, `max_retries`, `retry_backoff_ms`, `retry_max_backoff_ms`, `http_client`, `auth` | identiques |
 | Sécurité du cache | `threading.RLock` | `asyncio.Lock` |
 | Nettoyage | (GC automatique) | `async with` ou `await client.aclose()` |
 | Erreurs | `SchemaNotFoundError`, `RegistryConnectionError` | Mêmes types d'erreurs |

--- a/docs/user-guide/async-client.md
+++ b/docs/user-guide/async-client.md
@@ -85,7 +85,7 @@ async def produce(request):
 | Schema fetch | `client.get_schema(id)` | `await client.get_schema(id)` |
 | Schema registration | `client.register_schema(id, schema)` | `await client.register_schema(id, schema)` |
 | Return type | `CachedSchema` | `CachedSchema` (same class) |
-| Constructor params | `url`, `group_id` | `url`, `group_id` (identical) |
+| Constructor params | `url`, `group_id`, `max_retries`, `retry_backoff_ms`, `retry_max_backoff_ms`, `http_client`, `auth` | identical |
 | Cache safety | `threading.RLock` | `asyncio.Lock` |
 | Cleanup | (automatic GC) | `async with` or `await client.aclose()` |
 | Errors | `SchemaNotFoundError`, `RegistryConnectionError` | Same error types |

--- a/docs/user-guide/avro-deserializer.en.md
+++ b/docs/user-guide/avro-deserializer.en.md
@@ -28,6 +28,7 @@ record = deserializer(kafka_message.value(), ctx)
 | `registry_client` | `ApicurioRegistryClient` | required | The registry client used to resolve schema identifiers. |
 | `from_dict` | callable | `None` | Optional `(dict, ctx) -> Any` transformation applied after decoding. |
 | `use_id` | `"contentId"` or `"globalId"` | `"globalId"` | How to interpret the 4-byte schema identifier in the wire format header. |
+| `reader_schema` | `dict` | `None` | Optional Avro schema dict used as the reader schema. When provided, fastavro performs schema resolution between the writer schema (from the message) and this schema, enabling field additions with defaults, type promotions, and alias-based renames. Parsed once at construction time. |
 
 ### Schema identifier mode (`use_id`)
 
@@ -77,6 +78,53 @@ event = deserializer(payload, ctx)
 ```
 
 When `from_dict` is `None` (the default), the decoded dict is returned directly.
+
+## Schema evolution (`reader_schema`)
+
+By default the deserializer uses the writer schema for both reading and decoding — the
+schema embedded in the message. If your consumer is on a different schema version, pass
+`reader_schema` and fastavro handles the resolution:
+
+```python
+writer_schema = {
+    # This is what the producer used — it is embedded in the message,
+    # not passed to the deserializer.
+    "type": "record",
+    "name": "UserEvent",
+    "namespace": "com.example",
+    "fields": [
+        {"name": "userId", "type": "string"},
+        {"name": "country", "type": "string"},
+    ],
+}
+
+reader_schema = {
+    "type": "record",
+    "name": "UserEvent",
+    "namespace": "com.example",
+    "fields": [
+        {"name": "userId", "type": "string"},
+        {"name": "country", "type": "string"},
+        # New field added in the consumer — default fills the gap
+        {"name": "region", "type": ["null", "string"], "default": None},
+    ],
+}
+
+deserializer = AvroDeserializer(client, reader_schema=reader_schema)
+# Messages written with the old writer_schema decode successfully;
+# "region" comes back as None.
+```
+
+A few things to keep in mind during resolution:
+
+- Fields the reader expects but the writer omitted are filled with their default value;
+  without a default, the decode fails.
+- Fields in the writer that the reader ignores are dropped silently.
+- Type promotions follow Avro rules: `int → long → float → double`, `string → bytes`, etc.
+- Reader field aliases resolve writer field names.
+
+If the schemas are incompatible — say, a new required field has no default — fastavro
+raises a `ValueError` wrapped in `DeserializationError`.
 
 ## Schema caching
 

--- a/docs/user-guide/avro-deserializer.fr.md
+++ b/docs/user-guide/avro-deserializer.fr.md
@@ -28,6 +28,7 @@ record = deserializer(kafka_message.value(), ctx)
 | `registry_client` | `ApicurioRegistryClient` | obligatoire | Le client registry utilisé pour résoudre les identifiants de schema. |
 | `from_dict` | callable | `None` | Transformation optionnelle `(dict, ctx) -> Any` appliquée après le décodage. |
 | `use_id` | `"contentId"` ou `"globalId"` | `"globalId"` | Comment interpréter l'identifiant de schema de 4 octets dans l'en-tête du wire format. |
+| `reader_schema` | `dict` | `None` | Schema Avro optionnel utilisé comme schema lecteur. Quand il est fourni, fastavro effectue une résolution de schema entre le schema d'écriture (issu du message) et ce schema, permettant les ajouts de champs avec valeurs par défaut, les promotions de type et les renommages par alias. Parsé une seule fois à la construction. |
 
 ### Mode d'identifiant de schema (`use_id`)
 
@@ -77,6 +78,53 @@ event = deserializer(payload, ctx)
 ```
 
 Quand `from_dict` est `None` (valeur par défaut), le dict décodé est retourné directement.
+
+## Évolution de schema (`reader_schema`)
+
+Par défaut, le désérialiseur utilise le schema d'écriture pour les deux rôles — le schema
+intégré dans le message. Si votre consommateur est sur une version de schema différente,
+passez `reader_schema` et fastavro gère la résolution :
+
+```python
+writer_schema = {
+    # C'est ce que le producteur a utilisé — il est intégré dans le message,
+    # pas passé au désérialiseur.
+    "type": "record",
+    "name": "UserEvent",
+    "namespace": "com.example",
+    "fields": [
+        {"name": "userId", "type": "string"},
+        {"name": "country", "type": "string"},
+    ],
+}
+
+reader_schema = {
+    "type": "record",
+    "name": "UserEvent",
+    "namespace": "com.example",
+    "fields": [
+        {"name": "userId", "type": "string"},
+        {"name": "country", "type": "string"},
+        # Nouveau champ ajouté côté consommateur — la valeur par défaut comble l'écart
+        {"name": "region", "type": ["null", "string"], "default": None},
+    ],
+}
+
+deserializer = AvroDeserializer(client, reader_schema=reader_schema)
+# Les messages écrits avec l'ancien writer_schema décodent correctement ;
+# "region" revient à None.
+```
+
+Quelques points à garder en tête lors de la résolution :
+
+- Les champs attendus par le lecteur mais omis par l'écrivain sont remplis avec leur valeur
+  par défaut ; sans valeur par défaut, le décodage échoue.
+- Les champs de l'écrivain ignorés par le lecteur sont abandonnés silencieusement.
+- Les promotions de type suivent les règles Avro : `int → long → float → double`, `string → bytes`, etc.
+- Les alias de champs du schema lecteur résolvent les noms de champs de l'écrivain.
+
+Si les schemas sont incompatibles — par exemple, un nouveau champ obligatoire sans valeur par
+défaut — fastavro lève une `ValueError` encapsulée dans `DeserializationError`.
 
 ## Mise en cache du schema
 

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -86,6 +86,7 @@ nav:
   - How-to Guides:
       - Custom Serialization: how-to/custom-serialization.md
       - Identifier Selection: how-to/identifier-selection.md
+      - Authentication: how-to/authentication.md
       - Error Handling: how-to/error-handling.md
   - Migration:
       - From confluent-kafka: migration/from-confluent-kafka.md

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -52,6 +52,7 @@ dev = [
     "ruff>=0.5.0",
     "pip-audit>=2.7.0",
     "pyyaml>=6.0",
+    "bandit>=1.7.0",
 ]
 
 [tool.pytest.ini_options]
@@ -70,7 +71,10 @@ target-version = "py310"
 line-length = 88
 
 [tool.ruff.lint]
-select = ["E", "F", "I", "N", "W", "UP", "B", "SIM", "TCH"]
+select = ["E", "F", "I", "N", "W", "UP", "B", "SIM", "TCH", "C"]
+
+[tool.ruff.lint.mccabe]
+max-complexity = 10
 
 [tool.ruff.lint.per-file-ignores]
 "tests/**" = ["E501", "N815", "TCH"]
@@ -82,6 +86,10 @@ branch = true
 [tool.coverage.report]
 fail_under = 100
 show_missing = true
+
+[tool.bandit]
+targets = ["src"]
+skips = ["B311"]  # random.uniform for retry jitter does not require cryptographic quality
 
 [tool.hatch.version]
 source = "vcs"

--- a/sonar-project.properties
+++ b/sonar-project.properties
@@ -7,3 +7,9 @@ sonar.tests=tests/
 sonar.python.coverage.reportPaths=coverage.xml
 
 sonar.python.version=3.10,3.11,3.12,3.13
+
+# The sync (AvroDeserializer) and async (AsyncAvroDeserializer) deserializers
+# are intentional mirror implementations. Raising the CPD minimum avoids false
+# positives on the shared __init__ body (~99 tokens) and shared decode logic
+# (~117 tokens) that are identical by design in both files.
+sonar.cpd.py.minimumtokens=150

--- a/src/apicurio_serdes/__init__.py
+++ b/src/apicurio_serdes/__init__.py
@@ -3,8 +3,10 @@
 from importlib.metadata import version
 
 from apicurio_serdes._async_client import AsyncApicurioRegistryClient
+from apicurio_serdes._auth import BearerAuth, KeycloakAuth
 from apicurio_serdes._client import ApicurioRegistryClient
 from apicurio_serdes._errors import (
+    AuthenticationError,
     DeserializationError,
     RegistryConnectionError,
     ResolverError,
@@ -19,7 +21,10 @@ __version__ = version("apicurio-serdes")
 __all__ = [
     "ApicurioRegistryClient",
     "AsyncApicurioRegistryClient",
+    "AuthenticationError",
+    "BearerAuth",
     "DeserializationError",
+    "KeycloakAuth",
     "RegistryConnectionError",
     "ResolverError",
     "SchemaNotFoundError",

--- a/src/apicurio_serdes/_async_client.py
+++ b/src/apicurio_serdes/_async_client.py
@@ -7,7 +7,12 @@ from typing import TYPE_CHECKING, Any
 
 import httpx
 
-from apicurio_serdes._base import _RETRYABLE_STATUSES, CachedSchema, _RegistryClientBase
+from apicurio_serdes._base import (
+    _RETRYABLE_STATUSES,
+    CachedSchema,
+    _CacheCore,
+    _RegistryClientBase,
+)
 from apicurio_serdes._errors import RegistryConnectionError
 
 if TYPE_CHECKING:
@@ -42,9 +47,18 @@ class AsyncApicurioRegistryClient(_RegistryClientBase):
                      created and managed internally.
         auth: Optional httpx-compatible authentication handler. Ignored
               when ``http_client`` is provided.
+        cache_max_size: Maximum number of entries in each cache (LRU eviction).
+                        Applies to both the schema cache and the ID cache.
+                        Defaults to 1000.
+        cache_ttl_seconds: Optional TTL in seconds for artifact-based schema
+                           cache entries (``get_schema``, ``register_schema``).
+                           ID-based lookups (``get_schema_by_global_id``,
+                           ``get_schema_by_content_id``) are content-addressed
+                           and never expire. Defaults to ``None`` (no expiry).
 
     Raises:
-        ValueError: If url or group_id is empty, or max_retries < 0.
+        ValueError: If url or group_id is empty, max_retries < 0,
+                    cache_max_size < 1, or cache_ttl_seconds <= 0.
     """
 
     def __init__(
@@ -57,6 +71,8 @@ class AsyncApicurioRegistryClient(_RegistryClientBase):
         retry_max_backoff_ms: int = 20000,
         http_client: httpx.AsyncClient | None = None,
         auth: Any = None,
+        cache_max_size: int = 1000,
+        cache_ttl_seconds: float | None = None,
     ) -> None:
         super().__init__(
             url,
@@ -64,6 +80,8 @@ class AsyncApicurioRegistryClient(_RegistryClientBase):
             max_retries=max_retries,
             retry_backoff_ms=retry_backoff_ms,
             retry_max_backoff_ms=retry_max_backoff_ms,
+            cache_max_size=cache_max_size,
+            cache_ttl_seconds=cache_ttl_seconds,
         )
         self._owns_http_client = http_client is None
         self._http_client = (
@@ -121,18 +139,20 @@ class AsyncApicurioRegistryClient(_RegistryClientBase):
         """
         self._check_closed()
         cache_key = (self.group_id, artifact_id)
-        if cache_key in self._schema_cache:
-            return self._schema_cache[cache_key]
+        cached = self._schema_cache.peek(cache_key)
+        if cached is not _CacheCore._MISSING:
+            return cached  # type: ignore[return-value]
 
         async with self._lock:
-            if cache_key in self._schema_cache:
-                return self._schema_cache[cache_key]
+            cached = self._schema_cache.get(cache_key)
+            if cached is not _CacheCore._MISSING:
+                return cached  # type: ignore[return-value]
 
             response = await self._http_request(
                 "GET", self._schema_endpoint(artifact_id)
             )
             cached = self._process_schema_response(response, artifact_id)
-            self._schema_cache[cache_key] = cached
+            self._schema_cache.set(cache_key, cached)
             return cached
 
     async def get_schema_by_global_id(self, global_id: int) -> dict[str, Any]:
@@ -204,11 +224,13 @@ class AsyncApicurioRegistryClient(_RegistryClientBase):
         """
         self._check_closed()
         cache_key = (self.group_id, artifact_id)
-        if cache_key in self._schema_cache:
-            return self._schema_cache[cache_key]
+        cached = self._schema_cache.peek(cache_key)
+        if cached is not _CacheCore._MISSING:
+            return cached  # type: ignore[return-value]
         async with self._lock:
-            if cache_key in self._schema_cache:
-                return self._schema_cache[cache_key]
+            cached = self._schema_cache.get(cache_key)
+            if cached is not _CacheCore._MISSING:
+                return cached  # type: ignore[return-value]
             response = await self._http_request(
                 "POST",
                 self._register_endpoint(),
@@ -216,25 +238,27 @@ class AsyncApicurioRegistryClient(_RegistryClientBase):
                 params={"ifExists": if_exists},
             )
             cached = self._process_registration_response(response, artifact_id, schema)
-            self._schema_cache[cache_key] = cached
+            self._schema_cache.set(cache_key, cached)
             return cached
 
     async def _get_schema_by_id(self, id_type: str, id_value: int) -> dict[str, Any]:
         """Shared implementation for async ID-based schema lookups."""
         self._check_closed()
         cache_key = (id_type, id_value)
-        if cache_key in self._id_cache:
-            return self._id_cache[cache_key]
+        cached = self._id_cache.peek(cache_key)
+        if cached is not _CacheCore._MISSING:
+            return cached  # type: ignore[return-value]
 
         async with self._lock:
-            if cache_key in self._id_cache:
-                return self._id_cache[cache_key]
+            cached = self._id_cache.get(cache_key)
+            if cached is not _CacheCore._MISSING:
+                return cached  # type: ignore[return-value]
 
             response = await self._http_request(
                 "GET", self._id_endpoint(id_type, id_value)
             )
             schema = self._process_id_response(response, id_type, id_value)
-            self._id_cache[cache_key] = schema
+            self._id_cache.set(cache_key, schema)
             return schema
 
     async def aclose(self) -> None:

--- a/src/apicurio_serdes/_async_client.py
+++ b/src/apicurio_serdes/_async_client.py
@@ -7,7 +7,7 @@ from typing import TYPE_CHECKING, Any
 
 import httpx
 
-from apicurio_serdes._base import CachedSchema, _RegistryClientBase
+from apicurio_serdes._base import _RETRYABLE_STATUSES, CachedSchema, _RegistryClientBase
 from apicurio_serdes._errors import RegistryConnectionError
 
 if TYPE_CHECKING:
@@ -19,26 +19,85 @@ class AsyncApicurioRegistryClient(_RegistryClientBase):
 
     Non-blocking counterpart to ApicurioRegistryClient. Uses
     httpx.AsyncClient for async I/O. Safe for concurrent use
-    from multiple coroutines within the same event loop.
+    from multiple coroutines within the same event loop. Includes
+    automatic retry on transient failures.
 
     Args:
         url: Base URL of the Apicurio Registry v3 API.
              Example: "http://registry:8080/apis/registry/v3"
         group_id: Schema group identifier. Applied to every
                   schema lookup made by this client instance.
-        auth: Optional httpx authentication handler. Pass a
-              :class:`~apicurio_serdes.BearerAuth` or
-              :class:`~apicurio_serdes.KeycloakAuth` instance for
-              authenticated registries. Defaults to ``None`` (no auth).
+        max_retries: Maximum number of retry attempts on transient
+                     failures (transport errors and HTTP 429/502/503/504).
+                     Defaults to 3. Set to 0 to disable retries.
+        retry_backoff_ms: Base backoff delay in milliseconds for the first
+                          retry. Subsequent retries use exponential backoff
+                          with full jitter. Defaults to 1000.
+        retry_max_backoff_ms: Maximum backoff delay cap in milliseconds.
+                              Defaults to 20000.
+        http_client: Optional pre-configured ``httpx.AsyncClient`` to use
+                     for all HTTP requests. When provided, the client is
+                     used as-is and will **not** be closed by :meth:`aclose`.
+                     When ``None`` (default), a new ``httpx.AsyncClient`` is
+                     created and managed internally.
+        auth: Optional httpx-compatible authentication handler. Ignored
+              when ``http_client`` is provided.
 
     Raises:
-        ValueError: If url or group_id is empty.
+        ValueError: If url or group_id is empty, or max_retries < 0.
     """
 
-    def __init__(self, url: str, group_id: str, auth: httpx.Auth | None = None) -> None:
-        super().__init__(url, group_id)
-        self._http_client = httpx.AsyncClient(base_url=url, auth=auth)
+    def __init__(
+        self,
+        url: str,
+        group_id: str,
+        *,
+        max_retries: int = 3,
+        retry_backoff_ms: int = 1000,
+        retry_max_backoff_ms: int = 20000,
+        http_client: httpx.AsyncClient | None = None,
+        auth: Any = None,
+    ) -> None:
+        super().__init__(
+            url,
+            group_id,
+            max_retries=max_retries,
+            retry_backoff_ms=retry_backoff_ms,
+            retry_max_backoff_ms=retry_max_backoff_ms,
+        )
+        self._owns_http_client = http_client is None
+        self._http_client = (
+            http_client
+            if http_client is not None
+            else httpx.AsyncClient(base_url=url, auth=auth)
+        )
         self._lock = asyncio.Lock()
+
+    async def _http_request(
+        self, method: str, url: str, **kwargs: Any
+    ) -> httpx.Response:
+        """Execute an HTTP request with retry on transient failures (async).
+
+        Retries on ``httpx.TransportError`` and on responses with status
+        codes in ``_RETRYABLE_STATUSES`` (429, 502, 503, 504).
+        Uses exponential backoff with full jitter between attempts.
+        """
+        delays = self._retry_delays()
+        while True:
+            try:
+                response = await self._http_client.request(method, url, **kwargs)
+            except httpx.TransportError as exc:
+                delay = next(delays, None)
+                if delay is None:
+                    raise RegistryConnectionError(self.url, exc) from exc
+                await asyncio.sleep(delay)
+                continue
+            if response.status_code in _RETRYABLE_STATUSES:
+                delay = next(delays, None)
+                if delay is not None:
+                    await asyncio.sleep(delay)
+                    continue
+            return response
 
     async def get_schema(self, artifact_id: str) -> CachedSchema:
         """Retrieve an Avro schema by artifact ID (async).
@@ -57,7 +116,7 @@ class AsyncApicurioRegistryClient(_RegistryClientBase):
         Raises:
             SchemaNotFoundError: If the artifact does not exist (HTTP 404).
             RegistryConnectionError: If the registry is unreachable or returns
-                an unexpected HTTP status code.
+                a persistent error after all retries are exhausted.
             RuntimeError: If the client has been closed.
         """
         self._check_closed()
@@ -69,13 +128,9 @@ class AsyncApicurioRegistryClient(_RegistryClientBase):
             if cache_key in self._schema_cache:
                 return self._schema_cache[cache_key]
 
-            try:
-                response = await self._http_client.get(
-                    self._schema_endpoint(artifact_id)
-                )
-            except httpx.TransportError as exc:
-                raise RegistryConnectionError(self.url, exc) from exc
-
+            response = await self._http_request(
+                "GET", self._schema_endpoint(artifact_id)
+            )
             cached = self._process_schema_response(response, artifact_id)
             self._schema_cache[cache_key] = cached
             return cached
@@ -154,15 +209,12 @@ class AsyncApicurioRegistryClient(_RegistryClientBase):
         async with self._lock:
             if cache_key in self._schema_cache:
                 return self._schema_cache[cache_key]
-            try:
-                response = await self._http_client.post(
-                    self._register_endpoint(),
-                    json=self._register_body(artifact_id, schema),
-                    params={"ifExists": if_exists},
-                )
-            except httpx.TransportError as exc:
-                raise RegistryConnectionError(self.url, exc) from exc
-
+            response = await self._http_request(
+                "POST",
+                self._register_endpoint(),
+                json=self._register_body(artifact_id, schema),
+                params={"ifExists": if_exists},
+            )
             cached = self._process_registration_response(response, artifact_id, schema)
             self._schema_cache[cache_key] = cached
             return cached
@@ -178,13 +230,9 @@ class AsyncApicurioRegistryClient(_RegistryClientBase):
             if cache_key in self._id_cache:
                 return self._id_cache[cache_key]
 
-            try:
-                response = await self._http_client.get(
-                    self._id_endpoint(id_type, id_value)
-                )
-            except httpx.TransportError as exc:
-                raise RegistryConnectionError(self.url, exc) from exc
-
+            response = await self._http_request(
+                "GET", self._id_endpoint(id_type, id_value)
+            )
             schema = self._process_id_response(response, id_type, id_value)
             self._id_cache[cache_key] = schema
             return schema
@@ -194,9 +242,12 @@ class AsyncApicurioRegistryClient(_RegistryClientBase):
 
         Call this when the client is no longer needed and you are not
         using it as an async context manager. Safe to call multiple times.
+        When a custom ``http_client`` was provided at construction, it
+        is **not** closed — the caller retains ownership.
         """
         self._closed = True
-        await self._http_client.aclose()
+        if self._owns_http_client:
+            await self._http_client.aclose()
 
     async def __aenter__(self) -> AsyncApicurioRegistryClient:
         """Enter the async context manager. Returns self."""

--- a/src/apicurio_serdes/_async_client.py
+++ b/src/apicurio_serdes/_async_client.py
@@ -26,14 +26,18 @@ class AsyncApicurioRegistryClient(_RegistryClientBase):
              Example: "http://registry:8080/apis/registry/v3"
         group_id: Schema group identifier. Applied to every
                   schema lookup made by this client instance.
+        auth: Optional httpx authentication handler. Pass a
+              :class:`~apicurio_serdes.BearerAuth` or
+              :class:`~apicurio_serdes.KeycloakAuth` instance for
+              authenticated registries. Defaults to ``None`` (no auth).
 
     Raises:
         ValueError: If url or group_id is empty.
     """
 
-    def __init__(self, url: str, group_id: str) -> None:
+    def __init__(self, url: str, group_id: str, auth: httpx.Auth | None = None) -> None:
         super().__init__(url, group_id)
-        self._http_client = httpx.AsyncClient(base_url=url)
+        self._http_client = httpx.AsyncClient(base_url=url, auth=auth)
         self._lock = asyncio.Lock()
 
     async def get_schema(self, artifact_id: str) -> CachedSchema:

--- a/src/apicurio_serdes/_auth.py
+++ b/src/apicurio_serdes/_auth.py
@@ -1,0 +1,254 @@
+"""Authentication classes for Apicurio registry clients."""
+
+from __future__ import annotations
+
+import asyncio
+import threading
+import time
+from typing import TYPE_CHECKING
+from urllib.parse import urlparse, urlunparse
+
+import httpx
+
+from apicurio_serdes._errors import AuthenticationError
+
+if TYPE_CHECKING:
+    from collections.abc import AsyncGenerator, Callable, Generator
+
+__all__ = ["BearerAuth", "KeycloakAuth"]
+
+_REFRESH_THRESHOLD = 0.2  # refresh when < 20% of TTL remains
+
+
+class BearerAuth(httpx.Auth):
+    """Bearer token authentication for Apicurio registry clients.
+
+    Exactly one of *token* or *token_provider* must be supplied.
+
+    Args:
+        token: Static Bearer token string.
+        token_provider: Zero-argument callable that returns a token string.
+            Called on every request, so it can return fresh tokens (e.g.
+            GCP OIDC identity tokens retrieved via ``google-auth``).
+
+    Raises:
+        ValueError: If neither or both of *token* and *token_provider* are given.
+
+    Example:
+        ```python
+        # Static token
+        auth = BearerAuth(token="my-static-token")
+
+        # Dynamic token (GCP OIDC)
+        auth = BearerAuth(token_provider=lambda: get_google_id_token())
+
+        client = ApicurioRegistryClient(url="...", group_id="...", auth=auth)
+        ```
+    """
+
+    def __init__(
+        self,
+        token: str | None = None,
+        token_provider: Callable[[], str] | None = None,
+    ) -> None:
+        if (token is None) == (token_provider is None):
+            raise ValueError(
+                "BearerAuth requires exactly one of 'token' or 'token_provider'."
+            )
+        self._token = token
+        self._token_provider = token_provider
+
+    def _get_token(self) -> str:
+        if self._token_provider is not None:
+            return self._token_provider()
+        return self._token  # type: ignore[return-value]
+
+    def auth_flow(
+        self, request: httpx.Request
+    ) -> Generator[httpx.Request, httpx.Response, None]:
+        """Inject Authorization header; works for both sync and async clients."""
+        request.headers["Authorization"] = f"Bearer {self._get_token()}"
+        yield request
+
+
+class KeycloakAuth(httpx.Auth):
+    """OAuth2 client credentials auth against a Keycloak token endpoint.
+
+    Fetches a token on first use and automatically refreshes it when
+    less than 20% of its TTL remains (threshold-based refresh).
+
+    Implements separate ``sync_auth_flow`` / ``async_auth_flow`` so that
+    async callers never block the event loop.
+
+    Args:
+        token_url: Full URL of the Keycloak token endpoint, e.g.
+            ``"https://keycloak.example.com/realms/myrealm/protocol/openid-connect/token"``.
+        client_id: OAuth2 client ID.
+        client_secret: OAuth2 client secret.
+        scope: Optional OAuth2 scope string (e.g. ``"openid"``).
+
+    Raises:
+        AuthenticationError: If the token endpoint is unreachable, returns a
+            non-200 response, or returns a 200 response with a malformed body
+            (missing or empty ``access_token``, missing or non-positive
+            ``expires_in``, or non-JSON).
+
+    Example:
+        ```python
+        auth = KeycloakAuth(
+            token_url="https://keycloak.example.com/realms/myrealm/protocol/openid-connect/token",
+            client_id="my-client",
+            client_secret="secret",
+        )
+        client = ApicurioRegistryClient(url="...", group_id="...", auth=auth)
+        ```
+    """
+
+    def __init__(
+        self,
+        token_url: str,
+        client_id: str,
+        client_secret: str,
+        scope: str | None = None,
+    ) -> None:
+        self._token_url = token_url
+        self._client_id = client_id
+        self._client_secret = client_secret
+        self._scope = scope
+
+        self._token: str = ""
+        self._expires_at: float = 0.0
+        self._expires_in: float = 0.0
+
+        self._sync_lock = threading.Lock()
+        self._async_lock: asyncio.Lock | None = None
+
+    def __repr__(self) -> str:
+        return (
+            f"KeycloakAuth(token_url={self._token_url!r}, "
+            f"client_id={self._client_id!r}, client_secret=***)"
+        )
+
+    # ── Shared helpers ──
+
+    def _is_expired(self) -> bool:
+        if not self._token:
+            return True
+        return (
+            self._expires_at < time.monotonic() + self._expires_in * _REFRESH_THRESHOLD
+        )
+
+    def _build_token_data(self) -> dict[str, str]:
+        data: dict[str, str] = {
+            "grant_type": "client_credentials",
+            "client_id": self._client_id,
+            "client_secret": self._client_secret,
+        }
+        if self._scope is not None:
+            data["scope"] = self._scope
+        return data
+
+    @staticmethod
+    def _safe_url(url: str) -> str:
+        """Strip userinfo from a URL to avoid leaking embedded credentials."""
+        parsed = urlparse(url)
+        netloc = parsed.hostname or ""
+        if parsed.port:
+            netloc = f"{netloc}:{parsed.port}"
+        return urlunparse(parsed._replace(netloc=netloc))
+
+    def _parse_token_response(self, response: httpx.Response) -> None:
+        try:
+            response.raise_for_status()
+        except httpx.HTTPStatusError as exc:
+            # Limit error text to avoid leaking secrets from non-standard IdP responses
+            try:
+                error_detail = response.json().get("error", response.status_code)
+            except Exception:
+                error_detail = response.status_code
+            raise AuthenticationError(
+                f"Token endpoint returned {response.status_code}: {error_detail}"
+            ) from exc
+        try:
+            payload = response.json()
+            token = payload["access_token"]
+            expires_in = float(payload["expires_in"])
+        except (KeyError, TypeError, ValueError) as exc:
+            raise AuthenticationError(
+                "Unexpected token endpoint response"
+                f" (missing access_token or expires_in): {exc}"
+            ) from exc
+        if not isinstance(token, str) or not token:
+            raise AuthenticationError(
+                "Unexpected token endpoint response"
+                f" (access_token is empty or not a string): {token!r}"
+            )
+        if expires_in <= 0:
+            raise AuthenticationError(
+                "Unexpected token endpoint response"
+                f" (expires_in must be positive): {expires_in}"
+            )
+        self._token = token
+        self._expires_in = expires_in
+        self._expires_at = time.monotonic() + expires_in
+
+    # ── Sync path ──
+
+    def _sync_fetch_token(self) -> None:
+        try:
+            with httpx.Client() as client:
+                response = client.post(self._token_url, data=self._build_token_data())
+        except httpx.TransportError as exc:
+            raise AuthenticationError(
+                f"Could not reach token endpoint"
+                f" {self._safe_url(self._token_url)}: {exc}"
+            ) from exc
+        self._parse_token_response(response)
+
+    def _sync_ensure_token(self) -> None:
+        if self._is_expired():
+            with self._sync_lock:
+                if self._is_expired():
+                    self._sync_fetch_token()
+
+    def sync_auth_flow(
+        self, request: httpx.Request
+    ) -> Generator[httpx.Request, httpx.Response, None]:
+        """Sync auth flow: ensure token, inject header."""
+        self._sync_ensure_token()
+        request.headers["Authorization"] = f"Bearer {self._token}"
+        yield request
+
+    # ── Async path ──
+
+    def _get_async_lock(self) -> asyncio.Lock:
+        if self._async_lock is None:
+            self._async_lock = asyncio.Lock()
+        return self._async_lock
+
+    async def _async_fetch_token(self) -> None:
+        try:
+            async with httpx.AsyncClient() as client:
+                response = await client.post(
+                    self._token_url, data=self._build_token_data()
+                )
+        except httpx.TransportError as exc:
+            raise AuthenticationError(
+                f"Could not reach token endpoint"
+                f" {self._safe_url(self._token_url)}: {exc}"
+            ) from exc
+        self._parse_token_response(response)
+
+    async def _async_ensure_token(self) -> None:
+        if self._is_expired():
+            async with self._get_async_lock():
+                if self._is_expired():
+                    await self._async_fetch_token()
+
+    async def async_auth_flow(
+        self, request: httpx.Request
+    ) -> AsyncGenerator[httpx.Request, httpx.Response]:
+        """Async auth flow: ensure token without blocking, inject header."""
+        await self._async_ensure_token()
+        request.headers["Authorization"] = f"Bearer {self._token}"
+        yield request

--- a/src/apicurio_serdes/_base.py
+++ b/src/apicurio_serdes/_base.py
@@ -4,6 +4,8 @@ from __future__ import annotations
 
 import json
 import random
+import time
+from collections import OrderedDict
 from dataclasses import dataclass
 from typing import TYPE_CHECKING, Any
 
@@ -21,6 +23,67 @@ from apicurio_serdes._errors import (
 # HTTP status codes that indicate a transient server-side condition safe to retry.
 # 500 is excluded: ambiguous for mutations (server may have processed the request).
 _RETRYABLE_STATUSES: frozenset[int] = frozenset({429, 502, 503, 504})
+
+
+class _CacheCore:
+    """Lock-free LRU+TTL cache core. Callers must serialise all mutating calls.
+
+    ``OrderedDict`` keeps insertion order: oldest (LRU) at the front, most-recently
+    used (MRU) at the back.  Values are stored as ``(value, expiry)`` tuples where
+    ``expiry`` is a monotonic timestamp (``time.monotonic() + ttl``) or ``None``
+    when no TTL is configured.
+
+    ``peek()`` is safe to call outside a lock — it checks TTL but never mutates
+    ``_store``.  ``get()`` and ``set()`` **must** be called inside the caller's
+    lock because they mutate ``_store`` (LRU update and eviction).
+    """
+
+    _MISSING: object = object()
+
+    def __init__(self, max_size: int, ttl: float | None) -> None:
+        if max_size < 1:
+            raise ValueError(f"cache_max_size must be >= 1, got {max_size}")
+        if ttl is not None and ttl <= 0:
+            raise ValueError(f"cache_ttl_seconds must be > 0, got {ttl}")
+        self._max_size = max_size
+        self._ttl = ttl
+        self._store: OrderedDict[Any, tuple[Any, float | None]] = OrderedDict()
+
+    def peek(self, key: object) -> object:
+        """TTL check without LRU update — safe to call outside a lock (no mutation)."""
+        raw: tuple[Any, float | None] | None = self._store.get(key)
+        if raw is None:
+            return self._MISSING
+        value, expiry = raw
+        if expiry is not None and time.monotonic() >= expiry:
+            return self._MISSING  # expired; do NOT delete — deletion requires lock
+        return value
+
+    def get(self, key: object) -> object:
+        """Full LRU update + TTL eviction. Must be called inside caller's lock."""
+        raw: tuple[Any, float | None] | None = self._store.get(key)
+        if raw is None:
+            return self._MISSING
+        value, expiry = raw
+        if expiry is not None and time.monotonic() >= expiry:
+            del self._store[key]
+            return self._MISSING
+        self._store.move_to_end(key)  # bump to MRU position
+        return value
+
+    def set(self, key: object, value: object) -> None:
+        """Insert/update with LRU eviction if over cap.
+
+        Must be called inside caller's lock.
+        """
+        expiry = time.monotonic() + self._ttl if self._ttl is not None else None
+        if key in self._store:
+            self._store[key] = (value, expiry)
+            self._store.move_to_end(key)
+        else:
+            self._store[key] = (value, expiry)
+            while len(self._store) > self._max_size:
+                self._store.popitem(last=False)  # evict LRU (front)
 
 
 @dataclass(frozen=True)
@@ -54,6 +117,8 @@ class _RegistryClientBase:
         max_retries: int = 3,
         retry_backoff_ms: int = 1000,
         retry_max_backoff_ms: int = 20000,
+        cache_max_size: int = 1000,
+        cache_ttl_seconds: float | None = None,
     ) -> None:
         if not url:
             raise ValueError("url must not be empty")
@@ -66,8 +131,14 @@ class _RegistryClientBase:
         self.max_retries = max_retries
         self.retry_backoff_ms = retry_backoff_ms
         self.retry_max_backoff_ms = retry_max_backoff_ms
-        self._schema_cache: dict[tuple[str, str], CachedSchema] = {}
-        self._id_cache: dict[tuple[str, int], dict[str, Any]] = {}
+        # Validation is delegated to _CacheCore constructor.
+        self._schema_cache: _CacheCore = _CacheCore(
+            max_size=cache_max_size, ttl=cache_ttl_seconds
+        )
+        self._id_cache: _CacheCore = _CacheCore(
+            max_size=cache_max_size,
+            ttl=None,  # ID entries never expire (immutable)
+        )
         self._closed = False
 
     def _check_closed(self) -> None:

--- a/src/apicurio_serdes/_base.py
+++ b/src/apicurio_serdes/_base.py
@@ -3,8 +3,12 @@
 from __future__ import annotations
 
 import json
+import random
 from dataclasses import dataclass
-from typing import Any
+from typing import TYPE_CHECKING, Any
+
+if TYPE_CHECKING:
+    from collections.abc import Iterator
 
 import httpx
 
@@ -13,6 +17,10 @@ from apicurio_serdes._errors import (
     SchemaNotFoundError,
     SchemaRegistrationError,
 )
+
+# HTTP status codes that indicate a transient server-side condition safe to retry.
+# 500 is excluded: ambiguous for mutations (server may have processed the request).
+_RETRYABLE_STATUSES: frozenset[int] = frozenset({429, 502, 503, 504})
 
 
 @dataclass(frozen=True)
@@ -38,13 +46,26 @@ class _RegistryClientBase:
     ``self._closed = True`` inside their own ``close()`` / ``aclose()``.
     """
 
-    def __init__(self, url: str, group_id: str) -> None:
+    def __init__(
+        self,
+        url: str,
+        group_id: str,
+        *,
+        max_retries: int = 3,
+        retry_backoff_ms: int = 1000,
+        retry_max_backoff_ms: int = 20000,
+    ) -> None:
         if not url:
             raise ValueError("url must not be empty")
         if not group_id:
             raise ValueError("group_id must not be empty")
+        if max_retries < 0:
+            raise ValueError(f"max_retries must be >= 0, got {max_retries}")
         self.url = url
         self.group_id = group_id
+        self.max_retries = max_retries
+        self.retry_backoff_ms = retry_backoff_ms
+        self.retry_max_backoff_ms = retry_max_backoff_ms
         self._schema_cache: dict[tuple[str, str], CachedSchema] = {}
         self._id_cache: dict[tuple[str, int], dict[str, Any]] = {}
         self._closed = False
@@ -61,6 +82,20 @@ class _RegistryClientBase:
     @staticmethod
     def _id_endpoint(id_type: str, id_value: int) -> str:
         return f"/ids/{id_type}s/{id_value}"
+
+    def _compute_delay(self, attempt: int) -> float:
+        """Full-jitter exponential backoff in seconds.
+
+        delay = random(0, min(retry_backoff_ms * 2^attempt, retry_max_backoff_ms))
+                / 1000
+        """
+        cap = min(self.retry_backoff_ms * (2**attempt), self.retry_max_backoff_ms)
+        return random.uniform(0, cap) / 1000.0
+
+    def _retry_delays(self) -> Iterator[float]:
+        """Yield one delay (seconds) per retry attempt, up to max_retries values."""
+        for attempt in range(self.max_retries):
+            yield self._compute_delay(attempt)
 
     def _process_schema_response(
         self, response: httpx.Response, artifact_id: str

--- a/src/apicurio_serdes/_client.py
+++ b/src/apicurio_serdes/_client.py
@@ -3,11 +3,12 @@
 from __future__ import annotations
 
 import threading
+import time
 from typing import TYPE_CHECKING, Any
 
 import httpx
 
-from apicurio_serdes._base import CachedSchema, _RegistryClientBase
+from apicurio_serdes._base import _RETRYABLE_STATUSES, CachedSchema, _RegistryClientBase
 from apicurio_serdes._errors import RegistryConnectionError
 
 if TYPE_CHECKING:
@@ -21,20 +22,33 @@ class ApicurioRegistryClient(_RegistryClientBase):
     """HTTP client for the Apicurio Registry v3 native API.
 
     Handles schema retrieval by group_id / artifact_id with
-    built-in caching. Thread-safe for read operations.
+    built-in caching and automatic retry on transient failures.
+    Thread-safe for read operations.
 
     Args:
         url: Base URL of the Apicurio Registry v3 API.
              Example: ``"http://registry:8080/apis/registry/v3"``.
         group_id: Schema group identifier. Applied to every
                   schema lookup made by this client instance.
-        auth: Optional httpx authentication handler. Pass a
-              :class:`~apicurio_serdes.BearerAuth` or
-              :class:`~apicurio_serdes.KeycloakAuth` instance for
-              authenticated registries. Defaults to ``None`` (no auth).
+        max_retries: Maximum number of retry attempts on transient
+                     failures (transport errors and HTTP 429/502/503/504).
+                     Defaults to 3. Set to 0 to disable retries.
+        retry_backoff_ms: Base backoff delay in milliseconds for the first
+                          retry. Subsequent retries use exponential backoff
+                          with full jitter. Defaults to 1000.
+        retry_max_backoff_ms: Maximum backoff delay cap in milliseconds.
+                              Defaults to 20000.
+        http_client: Optional pre-configured ``httpx.Client`` to use for
+                     all HTTP requests. When provided, the client is used
+                     as-is and will **not** be closed by :meth:`close`.
+                     Use this to configure custom timeouts, proxies, mTLS,
+                     or transport-level retry. When ``None`` (default), a
+                     new ``httpx.Client`` is created and managed internally.
+        auth: Optional httpx-compatible authentication handler (e.g.
+              ``BearerAuth``). Ignored when ``http_client`` is provided.
 
     Raises:
-        ValueError: If *url* or *group_id* is empty.
+        ValueError: If *url* or *group_id* is empty, or *max_retries* < 0.
 
     Example:
         ```python
@@ -48,10 +62,55 @@ class ApicurioRegistryClient(_RegistryClientBase):
         ```
     """
 
-    def __init__(self, url: str, group_id: str, auth: httpx.Auth | None = None) -> None:
-        super().__init__(url, group_id)
-        self._http_client = httpx.Client(base_url=url, auth=auth)
+    def __init__(
+        self,
+        url: str,
+        group_id: str,
+        *,
+        max_retries: int = 3,
+        retry_backoff_ms: int = 1000,
+        retry_max_backoff_ms: int = 20000,
+        http_client: httpx.Client | None = None,
+        auth: Any = None,
+    ) -> None:
+        super().__init__(
+            url,
+            group_id,
+            max_retries=max_retries,
+            retry_backoff_ms=retry_backoff_ms,
+            retry_max_backoff_ms=retry_max_backoff_ms,
+        )
+        self._owns_http_client = http_client is None
+        self._http_client = (
+            http_client
+            if http_client is not None
+            else httpx.Client(base_url=url, auth=auth)
+        )
         self._lock = threading.RLock()
+
+    def _http_request(self, method: str, url: str, **kwargs: Any) -> httpx.Response:
+        """Execute an HTTP request with retry on transient failures.
+
+        Retries on ``httpx.TransportError`` and on responses with status
+        codes in ``_RETRYABLE_STATUSES`` (429, 502, 503, 504).
+        Uses exponential backoff with full jitter between attempts.
+        """
+        delays = self._retry_delays()
+        while True:
+            try:
+                response = self._http_client.request(method, url, **kwargs)
+            except httpx.TransportError as exc:
+                delay = next(delays, None)
+                if delay is None:
+                    raise RegistryConnectionError(self.url, exc) from exc
+                time.sleep(delay)
+                continue
+            if response.status_code in _RETRYABLE_STATUSES:
+                delay = next(delays, None)
+                if delay is not None:
+                    time.sleep(delay)
+                    continue
+            return response
 
     def get_schema(self, artifact_id: str) -> CachedSchema:
         """Retrieve an Avro schema by artifact ID.
@@ -67,7 +126,8 @@ class ApicurioRegistryClient(_RegistryClientBase):
 
         Raises:
             SchemaNotFoundError: If the artifact does not exist (HTTP 404).
-            RegistryConnectionError: If the registry is unreachable.
+            RegistryConnectionError: If the registry is unreachable or returns
+                a persistent error after all retries are exhausted.
             RuntimeError: If the client has been closed.
         """
         self._check_closed()
@@ -80,11 +140,7 @@ class ApicurioRegistryClient(_RegistryClientBase):
             if cache_key in self._schema_cache:
                 return self._schema_cache[cache_key]
 
-            try:
-                response = self._http_client.get(self._schema_endpoint(artifact_id))
-            except httpx.TransportError as exc:
-                raise RegistryConnectionError(self.url, exc) from exc
-
+            response = self._http_request("GET", self._schema_endpoint(artifact_id))
             cached = self._process_schema_response(response, artifact_id)
             self._schema_cache[cache_key] = cached
             return cached
@@ -165,15 +221,12 @@ class ApicurioRegistryClient(_RegistryClientBase):
         with self._lock:
             if cache_key in self._schema_cache:
                 return self._schema_cache[cache_key]
-            try:
-                response = self._http_client.post(
-                    self._register_endpoint(),
-                    json=self._register_body(artifact_id, schema),
-                    params={"ifExists": if_exists},
-                )
-            except httpx.TransportError as exc:
-                raise RegistryConnectionError(self.url, exc) from exc
-
+            response = self._http_request(
+                "POST",
+                self._register_endpoint(),
+                json=self._register_body(artifact_id, schema),
+                params={"ifExists": if_exists},
+            )
             cached = self._process_registration_response(response, artifact_id, schema)
             self._schema_cache[cache_key] = cached
             return cached
@@ -189,11 +242,7 @@ class ApicurioRegistryClient(_RegistryClientBase):
             if cache_key in self._id_cache:
                 return self._id_cache[cache_key]
 
-            try:
-                response = self._http_client.get(self._id_endpoint(id_type, id_value))
-            except httpx.TransportError as exc:
-                raise RegistryConnectionError(self.url, exc) from exc
-
+            response = self._http_request("GET", self._id_endpoint(id_type, id_value))
             schema = self._process_id_response(response, id_type, id_value)
             self._id_cache[cache_key] = schema
             return schema
@@ -203,9 +252,12 @@ class ApicurioRegistryClient(_RegistryClientBase):
 
         Call this when the client is no longer needed and you are not
         using it as a context manager. Safe to call multiple times.
+        When a custom ``http_client`` was provided at construction, it
+        is **not** closed — the caller retains ownership.
         """
         self._closed = True
-        self._http_client.close()
+        if self._owns_http_client:
+            self._http_client.close()
 
     def __enter__(self) -> ApicurioRegistryClient:
         """Enter the context manager. Returns self."""

--- a/src/apicurio_serdes/_client.py
+++ b/src/apicurio_serdes/_client.py
@@ -8,7 +8,12 @@ from typing import TYPE_CHECKING, Any
 
 import httpx
 
-from apicurio_serdes._base import _RETRYABLE_STATUSES, CachedSchema, _RegistryClientBase
+from apicurio_serdes._base import (
+    _RETRYABLE_STATUSES,
+    CachedSchema,
+    _CacheCore,
+    _RegistryClientBase,
+)
 from apicurio_serdes._errors import RegistryConnectionError
 
 if TYPE_CHECKING:
@@ -46,9 +51,18 @@ class ApicurioRegistryClient(_RegistryClientBase):
                      new ``httpx.Client`` is created and managed internally.
         auth: Optional httpx-compatible authentication handler (e.g.
               ``BearerAuth``). Ignored when ``http_client`` is provided.
+        cache_max_size: Maximum number of entries in each cache (LRU eviction).
+                        Applies to both the schema cache and the ID cache.
+                        Defaults to 1000.
+        cache_ttl_seconds: Optional TTL in seconds for artifact-based schema
+                           cache entries (``get_schema``, ``register_schema``).
+                           ID-based lookups (``get_schema_by_global_id``,
+                           ``get_schema_by_content_id``) are content-addressed
+                           and never expire. Defaults to ``None`` (no expiry).
 
     Raises:
-        ValueError: If *url* or *group_id* is empty, or *max_retries* < 0.
+        ValueError: If *url* or *group_id* is empty, *max_retries* < 0,
+                    *cache_max_size* < 1, or *cache_ttl_seconds* <= 0.
 
     Example:
         ```python
@@ -72,6 +86,8 @@ class ApicurioRegistryClient(_RegistryClientBase):
         retry_max_backoff_ms: int = 20000,
         http_client: httpx.Client | None = None,
         auth: Any = None,
+        cache_max_size: int = 1000,
+        cache_ttl_seconds: float | None = None,
     ) -> None:
         super().__init__(
             url,
@@ -79,6 +95,8 @@ class ApicurioRegistryClient(_RegistryClientBase):
             max_retries=max_retries,
             retry_backoff_ms=retry_backoff_ms,
             retry_max_backoff_ms=retry_max_backoff_ms,
+            cache_max_size=cache_max_size,
+            cache_ttl_seconds=cache_ttl_seconds,
         )
         self._owns_http_client = http_client is None
         self._http_client = (
@@ -132,17 +150,19 @@ class ApicurioRegistryClient(_RegistryClientBase):
         """
         self._check_closed()
         cache_key = (self.group_id, artifact_id)
-        if cache_key in self._schema_cache:
-            return self._schema_cache[cache_key]
+        cached = self._schema_cache.peek(cache_key)
+        if cached is not _CacheCore._MISSING:
+            return cached  # type: ignore[return-value]
 
         with self._lock:
             # Double-check after acquiring the lock (NFR-001)
-            if cache_key in self._schema_cache:
-                return self._schema_cache[cache_key]
+            cached = self._schema_cache.get(cache_key)
+            if cached is not _CacheCore._MISSING:
+                return cached  # type: ignore[return-value]
 
             response = self._http_request("GET", self._schema_endpoint(artifact_id))
             cached = self._process_schema_response(response, artifact_id)
-            self._schema_cache[cache_key] = cached
+            self._schema_cache.set(cache_key, cached)
             return cached
 
     def get_schema_by_global_id(self, global_id: int) -> dict[str, Any]:
@@ -216,11 +236,13 @@ class ApicurioRegistryClient(_RegistryClientBase):
         """
         self._check_closed()
         cache_key = (self.group_id, artifact_id)
-        if cache_key in self._schema_cache:
-            return self._schema_cache[cache_key]
+        cached = self._schema_cache.peek(cache_key)
+        if cached is not _CacheCore._MISSING:
+            return cached  # type: ignore[return-value]
         with self._lock:
-            if cache_key in self._schema_cache:
-                return self._schema_cache[cache_key]
+            cached = self._schema_cache.get(cache_key)
+            if cached is not _CacheCore._MISSING:
+                return cached  # type: ignore[return-value]
             response = self._http_request(
                 "POST",
                 self._register_endpoint(),
@@ -228,23 +250,25 @@ class ApicurioRegistryClient(_RegistryClientBase):
                 params={"ifExists": if_exists},
             )
             cached = self._process_registration_response(response, artifact_id, schema)
-            self._schema_cache[cache_key] = cached
+            self._schema_cache.set(cache_key, cached)
             return cached
 
     def _get_schema_by_id(self, id_type: str, id_value: int) -> dict[str, Any]:
         """Shared implementation for ID-based schema lookups (D12)."""
         self._check_closed()
         cache_key = (id_type, id_value)
-        if cache_key in self._id_cache:
-            return self._id_cache[cache_key]
+        cached = self._id_cache.peek(cache_key)
+        if cached is not _CacheCore._MISSING:
+            return cached  # type: ignore[return-value]
 
         with self._lock:
-            if cache_key in self._id_cache:
-                return self._id_cache[cache_key]
+            cached = self._id_cache.get(cache_key)
+            if cached is not _CacheCore._MISSING:
+                return cached  # type: ignore[return-value]
 
             response = self._http_request("GET", self._id_endpoint(id_type, id_value))
             schema = self._process_id_response(response, id_type, id_value)
-            self._id_cache[cache_key] = schema
+            self._id_cache.set(cache_key, schema)
             return schema
 
     def close(self) -> None:

--- a/src/apicurio_serdes/_client.py
+++ b/src/apicurio_serdes/_client.py
@@ -28,6 +28,10 @@ class ApicurioRegistryClient(_RegistryClientBase):
              Example: ``"http://registry:8080/apis/registry/v3"``.
         group_id: Schema group identifier. Applied to every
                   schema lookup made by this client instance.
+        auth: Optional httpx authentication handler. Pass a
+              :class:`~apicurio_serdes.BearerAuth` or
+              :class:`~apicurio_serdes.KeycloakAuth` instance for
+              authenticated registries. Defaults to ``None`` (no auth).
 
     Raises:
         ValueError: If *url* or *group_id* is empty.
@@ -44,9 +48,9 @@ class ApicurioRegistryClient(_RegistryClientBase):
         ```
     """
 
-    def __init__(self, url: str, group_id: str) -> None:
+    def __init__(self, url: str, group_id: str, auth: httpx.Auth | None = None) -> None:
         super().__init__(url, group_id)
-        self._http_client = httpx.Client(base_url=url)
+        self._http_client = httpx.Client(base_url=url, auth=auth)
         self._lock = threading.RLock()
 
     def get_schema(self, artifact_id: str) -> CachedSchema:

--- a/src/apicurio_serdes/_errors.py
+++ b/src/apicurio_serdes/_errors.py
@@ -135,6 +135,21 @@ class SchemaRegistrationError(Exception):
         self.__cause__ = cause
 
 
+class AuthenticationError(Exception):
+    """Raised when authentication with the token endpoint fails.
+
+    Covers: token endpoint unreachable, non-200 response, or a 200 response
+    with a malformed body (missing or empty ``access_token``, missing or
+    non-positive ``expires_in``, or non-JSON).
+
+    Args:
+        message: Description of the authentication failure.
+    """
+
+    def __init__(self, message: str) -> None:
+        super().__init__(message)
+
+
 class RegistryConnectionError(Exception):
     """Raised when the Apicurio Registry is unreachable.
 

--- a/src/apicurio_serdes/avro/_async_deserializer.py
+++ b/src/apicurio_serdes/avro/_async_deserializer.py
@@ -2,13 +2,11 @@
 
 from __future__ import annotations
 
-import io
 import struct
 from typing import TYPE_CHECKING, Any
 
-import fastavro
-
 from apicurio_serdes._errors import DeserializationError
+from apicurio_serdes.avro._deserializer import _BaseAvroDeserializer
 
 if TYPE_CHECKING:
     from collections.abc import Callable
@@ -18,7 +16,7 @@ if TYPE_CHECKING:
     from apicurio_serdes.serialization import SerializationContext
 
 
-class AsyncAvroDeserializer:
+class AsyncAvroDeserializer(_BaseAvroDeserializer):
     """Deserializes Confluent-framed Avro bytes to Python dicts (async).
 
     Non-blocking counterpart to AvroDeserializer. Uses
@@ -34,6 +32,14 @@ class AsyncAvroDeserializer:
         use_id: Which registry identifier type the 4-byte wire format
                 field represents. Must match the serializer's use_id
                 setting. Defaults to "globalId".
+        reader_schema: Optional Avro schema dict used as the reader schema
+                       during deserialization. When provided, fastavro
+                       performs schema resolution between the writer schema
+                       (embedded in the message) and this reader schema,
+                       enabling field defaults to fill gaps for added fields,
+                       type promotions, and other Avro evolution rules. When
+                       None (default), the writer schema is used for both
+                       roles (no evolution). Parsed once at construction time.
 
     Example:
         ```python
@@ -58,11 +64,13 @@ class AsyncAvroDeserializer:
         registry_client: AsyncApicurioRegistryClient,
         from_dict: Callable[[dict[str, Any], SerializationContext], Any] | None = None,
         use_id: Literal["globalId", "contentId"] = "globalId",
+        *,
+        reader_schema: dict[str, Any] | None = None,
     ) -> None:
+        super().__init__(
+            from_dict=from_dict, use_id=use_id, reader_schema=reader_schema
+        )
         self.registry_client = registry_client
-        self.from_dict = from_dict
-        self.use_id = use_id
-        self._parsed_cache: dict[int, Any] = {}
 
     async def __call__(self, data: bytes, ctx: SerializationContext) -> Any:
         """Deserialize Confluent-framed Avro bytes (async).
@@ -105,25 +113,4 @@ class AsyncAvroDeserializer:
         else:
             schema_dict = await self.registry_client.get_schema_by_content_id(schema_id)
 
-        if schema_id not in self._parsed_cache:
-            self._parsed_cache[schema_id] = fastavro.parse_schema(schema_dict)
-        parsed_schema = self._parsed_cache[schema_id]
-
-        try:
-            result: Any = fastavro.schemaless_reader(
-                io.BytesIO(data[5:]), parsed_schema, parsed_schema
-            )
-        except Exception as exc:
-            raise DeserializationError(
-                f"Avro decode failure: {exc}", cause=exc
-            ) from exc
-
-        if self.from_dict is not None:
-            try:
-                return self.from_dict(result, ctx)
-            except Exception as exc:
-                raise DeserializationError(
-                    f"from_dict conversion failed: {exc}", cause=exc
-                ) from exc
-
-        return result
+        return self._decode(schema_id, schema_dict, data[5:], ctx)

--- a/src/apicurio_serdes/avro/_deserializer.py
+++ b/src/apicurio_serdes/avro/_deserializer.py
@@ -18,7 +18,58 @@ if TYPE_CHECKING:
     from apicurio_serdes.serialization import SerializationContext
 
 
-class AvroDeserializer:
+class _BaseAvroDeserializer:
+    """Shared initialisation and decode logic for sync and async deserializers."""
+
+    def __init__(
+        self,
+        from_dict: Callable[[dict[str, Any], SerializationContext], Any] | None,
+        use_id: Literal["globalId", "contentId"],
+        reader_schema: dict[str, Any] | None,
+    ) -> None:
+        self.from_dict = from_dict
+        self.use_id = use_id
+        self._parsed_cache: dict[int, Any] = {}
+        self._parsed_reader_schema = (
+            fastavro.parse_schema(reader_schema) if reader_schema is not None else None
+        )
+
+    def _decode(
+        self,
+        schema_id: int,
+        schema_dict: dict[str, Any],
+        payload: bytes,
+        ctx: SerializationContext,
+    ) -> Any:
+        """Cache the writer schema and decode the Avro payload."""
+        # Cache parsed schema to avoid repeated parse_schema calls (FR-007)
+        if schema_id not in self._parsed_cache:
+            self._parsed_cache[schema_id] = fastavro.parse_schema(schema_dict)
+        parsed_schema = self._parsed_cache[schema_id]
+
+        # FR-011: decode Avro payload
+        try:
+            result: Any = fastavro.schemaless_reader(
+                io.BytesIO(payload), parsed_schema, self._parsed_reader_schema
+            )
+        except Exception as exc:
+            raise DeserializationError(
+                f"Avro decode failure: {exc}", cause=exc
+            ) from exc
+
+        # FR-008, FR-009: apply from_dict hook if configured
+        if self.from_dict is not None:
+            try:
+                return self.from_dict(result, ctx)
+            except Exception as exc:
+                raise DeserializationError(
+                    f"from_dict conversion failed: {exc}", cause=exc
+                ) from exc
+
+        return result
+
+
+class AvroDeserializer(_BaseAvroDeserializer):
     """Deserializes Confluent-framed Avro bytes to Python dicts.
 
     Reads the wire format header to extract the schema identifier,
@@ -33,6 +84,14 @@ class AvroDeserializer:
         use_id: Which registry identifier type the 4-byte wire format
                 field represents. Must match the serializer's use_id
                 setting. Defaults to "globalId".
+        reader_schema: Optional Avro schema dict used as the reader schema
+                       during deserialization. When provided, fastavro
+                       performs schema resolution between the writer schema
+                       (embedded in the message) and this reader schema,
+                       enabling field defaults to fill gaps for added fields,
+                       type promotions, and other Avro evolution rules. When
+                       None (default), the writer schema is used for both
+                       roles (no evolution). Parsed once at construction time.
     """
 
     def __init__(
@@ -40,11 +99,13 @@ class AvroDeserializer:
         registry_client: ApicurioRegistryClient,
         from_dict: Callable[[dict[str, Any], SerializationContext], Any] | None = None,
         use_id: Literal["globalId", "contentId"] = "globalId",
+        *,
+        reader_schema: dict[str, Any] | None = None,
     ) -> None:
+        super().__init__(
+            from_dict=from_dict, use_id=use_id, reader_schema=reader_schema
+        )
         self.registry_client = registry_client
-        self.from_dict = from_dict
-        self.use_id = use_id
-        self._parsed_cache: dict[int, Any] = {}
 
     def __call__(self, data: bytes, ctx: SerializationContext) -> Any:
         """Deserialize Confluent-framed Avro bytes.
@@ -92,28 +153,4 @@ class AvroDeserializer:
         else:
             schema_dict = self.registry_client.get_schema_by_content_id(schema_id)
 
-        # Cache parsed schema to avoid repeated parse_schema calls (FR-007)
-        if schema_id not in self._parsed_cache:
-            self._parsed_cache[schema_id] = fastavro.parse_schema(schema_dict)
-        parsed_schema = self._parsed_cache[schema_id]
-
-        # FR-011: decode Avro payload
-        try:
-            result: Any = fastavro.schemaless_reader(
-                io.BytesIO(data[5:]), parsed_schema, parsed_schema
-            )
-        except Exception as exc:
-            raise DeserializationError(
-                f"Avro decode failure: {exc}", cause=exc
-            ) from exc
-
-        # FR-008, FR-009: apply from_dict hook if configured
-        if self.from_dict is not None:
-            try:
-                return self.from_dict(result, ctx)
-            except Exception as exc:
-                raise DeserializationError(
-                    f"from_dict conversion failed: {exc}", cause=exc
-                ) from exc
-
-        return result
+        return self._decode(schema_id, schema_dict, data[5:], ctx)

--- a/src/apicurio_serdes/avro/_serializer.py
+++ b/src/apicurio_serdes/avro/_serializer.py
@@ -149,6 +149,44 @@ class AvroSerializer:
         self._schema: CachedSchema | None = None
         self._parsed_schema: str | list[Any] | dict[Any, Any] | None = None
 
+    def _ensure_schema(self, ctx: SerializationContext) -> CachedSchema:
+        """Lazily fetch and cache the schema from the registry."""
+        if self._schema is not None:
+            return self._schema
+        if self._artifact_resolver is not None and self._resolved_artifact_id is None:
+            try:
+                resolved = self._artifact_resolver(ctx)
+            except Exception as exc:
+                raise ResolverError(
+                    f"artifact_resolver raised: {exc}", cause=exc
+                ) from exc
+            if not isinstance(resolved, str) or not resolved:
+                raise ResolverError(
+                    f"artifact_resolver must return a non-empty str, got {resolved!r}"
+                )
+            self._resolved_artifact_id = resolved
+        effective_id = (
+            self.artifact_id
+            if self.artifact_id is not None
+            else self._resolved_artifact_id
+        )
+        if effective_id is None:  # pragma: no cover
+            raise RuntimeError(
+                "artifact_id is None and no resolver has produced an ID yet; "
+                "this is an internal invariant violation."
+            )
+        try:
+            cached = self.registry_client.get_schema(effective_id)
+        except SchemaNotFoundError:
+            if not self.auto_register or self._local_schema is None:
+                raise
+            cached = self.registry_client.register_schema(
+                effective_id, self._local_schema, self.if_exists
+            )
+        self._schema = cached
+        self._parsed_schema = fastavro.parse_schema(cached.schema)
+        return cached
+
     def serialize(self, data: Any, ctx: SerializationContext) -> SerializedMessage:
         """Serialize data and return payload bytes plus any Kafka headers.
 
@@ -176,44 +214,7 @@ class AvroSerializer:
             SerializationError: If the to_dict callable raises an exception.
             ValueError: If data does not conform to the Avro schema.
         """
-        # Lazy schema fetch (cached by client)
-        if self._schema is None:
-            if (
-                self._artifact_resolver is not None
-                and self._resolved_artifact_id is None
-            ):
-                try:
-                    resolved = self._artifact_resolver(ctx)
-                except Exception as exc:
-                    raise ResolverError(
-                        f"artifact_resolver raised: {exc}", cause=exc
-                    ) from exc
-                if not isinstance(resolved, str) or not resolved:
-                    raise ResolverError(
-                        f"artifact_resolver must return a non-empty str,"
-                        f" got {resolved!r}"
-                    )
-                self._resolved_artifact_id = resolved
-            effective_id = (
-                self.artifact_id
-                if self.artifact_id is not None
-                else self._resolved_artifact_id
-            )
-            if effective_id is None:  # pragma: no cover
-                raise RuntimeError(
-                    "artifact_id is None and no resolver has produced an ID yet; "
-                    "this is an internal invariant violation."
-                )
-            try:
-                cached = self.registry_client.get_schema(effective_id)
-            except SchemaNotFoundError:
-                if not self.auto_register or self._local_schema is None:
-                    raise
-                cached = self.registry_client.register_schema(
-                    effective_id, self._local_schema, self.if_exists
-                )
-            self._schema = cached
-            self._parsed_schema = fastavro.parse_schema(cached.schema)
+        schema = self._ensure_schema(ctx)
 
         # Apply to_dict hook if provided
         if self.to_dict is not None:
@@ -224,7 +225,7 @@ class AvroSerializer:
 
         # Strict mode validation
         if self.strict:
-            fields = self._schema.schema.get("fields")
+            fields = schema.schema.get("fields")
             if fields is None:
                 raise ValueError("strict mode requires a record schema with 'fields'")
             schema_fields = {f["name"] for f in fields}
@@ -236,9 +237,9 @@ class AvroSerializer:
 
         # Select schema ID based on use_id
         if self.use_id == "contentId":
-            schema_id = self._schema.content_id
+            schema_id = schema.content_id
         else:
-            schema_id = self._schema.global_id
+            schema_id = schema.global_id
 
         # Encode to Avro binary
         buffer = io.BytesIO()

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -166,6 +166,39 @@ def _register_error_route(
     )
 
 
+# ── Reader schema evolution fixtures ──
+
+WRITER_SCHEMA_EVOLUTION: dict[str, Any] = {
+    "type": "record",
+    "name": "UserEventV1",
+    "namespace": "com.example",
+    "fields": [
+        {"name": "userId", "type": "string"},
+    ],
+}
+
+READER_SCHEMA_EVOLUTION: dict[str, Any] = {
+    "type": "record",
+    "name": "UserEventV1",
+    "namespace": "com.example",
+    "fields": [
+        {"name": "userId", "type": "string"},
+        {"name": "version", "type": "string", "default": "v1"},
+    ],
+}
+
+INCOMPATIBLE_READER_SCHEMA: dict[str, Any] = {
+    "type": "record",
+    "name": "UserEventV1",
+    "namespace": "com.example",
+    "fields": [
+        {"name": "userId", "type": "string"},
+        # required field with no default — cannot be filled from writer schema
+        {"name": "required_field", "type": "string"},
+    ],
+}
+
+
 def make_confluent_bytes(
     schema_id: int,
     data: dict[str, Any],

--- a/tests/test_async_client.py
+++ b/tests/test_async_client.py
@@ -4,6 +4,7 @@ from __future__ import annotations
 
 import json
 from typing import Any
+from unittest.mock import AsyncMock, MagicMock, patch
 
 import httpx
 import pytest
@@ -790,3 +791,368 @@ async def test_async_client_accepts_bearer_auth(
     )
     await client.get_schema("Auth")
     assert route.calls[0].request.headers["authorization"] == "Bearer async-wire"
+
+
+# ── Retry and escape hatch tests (#37) ──
+
+
+def _async_flaky_schema_handler(n_failures: int) -> Any:
+    """Side-effect: raises ConnectError n_failures times, then returns 200."""
+    count = 0
+
+    def _handler(request: httpx.Request) -> httpx.Response:
+        nonlocal count
+        count += 1
+        if count <= n_failures:
+            raise httpx.ConnectError("transient failure")
+        return httpx.Response(
+            200,
+            content=json.dumps(USER_EVENT_SCHEMA_JSON).encode(),
+            headers={
+                "X-Registry-GlobalId": str(GLOBAL_ID),
+                "X-Registry-ContentId": str(CONTENT_ID),
+            },
+        )
+
+    return _handler
+
+
+def _async_flaky_status_schema_handler(fail_status: int, n_failures: int) -> Any:
+    """Side-effect: returns fail_status n_failures times, then returns 200."""
+    count = 0
+
+    def _handler(request: httpx.Request) -> httpx.Response:
+        nonlocal count
+        count += 1
+        if count <= n_failures:
+            return httpx.Response(fail_status)
+        return httpx.Response(
+            200,
+            content=json.dumps(USER_EVENT_SCHEMA_JSON).encode(),
+            headers={
+                "X-Registry-GlobalId": str(GLOBAL_ID),
+                "X-Registry-ContentId": str(CONTENT_ID),
+            },
+        )
+
+    return _handler
+
+
+def _async_flaky_id_handler(n_failures: int) -> Any:
+    """Side-effect: ConnectError n times then valid schema response (ID endpoint)."""
+    count = 0
+
+    def _handler(request: httpx.Request) -> httpx.Response:
+        nonlocal count
+        count += 1
+        if count <= n_failures:
+            raise httpx.ConnectError("transient failure")
+        return httpx.Response(200, content=json.dumps(USER_EVENT_SCHEMA_JSON).encode())
+
+    return _handler
+
+
+def _async_flaky_register_handler(n_failures: int) -> Any:
+    """Side-effect: ConnectError n times then valid register response."""
+    count = 0
+
+    def _handler(request: httpx.Request) -> httpx.Response:
+        nonlocal count
+        count += 1
+        if count <= n_failures:
+            raise httpx.ConnectError("transient failure")
+        return httpx.Response(
+            200,
+            json={
+                "artifact": {
+                    "groupId": GROUP_ID,
+                    "artifactId": "UserEvent",
+                    "artifactType": "AVRO",
+                },
+                "version": {
+                    "globalId": GLOBAL_ID,
+                    "contentId": CONTENT_ID,
+                    "artifactType": "AVRO",
+                },
+            },
+        )
+
+    return _handler
+
+
+# Constructor parameter tests
+
+
+def test_async_init_default_max_retries() -> None:
+    """Default max_retries is 3."""
+    client = AsyncApicurioRegistryClient(url=REGISTRY_URL, group_id=GROUP_ID)
+    assert client.max_retries == 3
+
+
+def test_async_init_default_retry_backoff_ms() -> None:
+    """Default retry_backoff_ms is 1000."""
+    client = AsyncApicurioRegistryClient(url=REGISTRY_URL, group_id=GROUP_ID)
+    assert client.retry_backoff_ms == 1000
+
+
+def test_async_init_default_retry_max_backoff_ms() -> None:
+    """Default retry_max_backoff_ms is 20000."""
+    client = AsyncApicurioRegistryClient(url=REGISTRY_URL, group_id=GROUP_ID)
+    assert client.retry_max_backoff_ms == 20000
+
+
+def test_async_init_max_retries_zero_valid() -> None:
+    """max_retries=0 is valid."""
+    client = AsyncApicurioRegistryClient(
+        url=REGISTRY_URL, group_id=GROUP_ID, max_retries=0
+    )
+    assert client.max_retries == 0
+
+
+def test_async_init_max_retries_negative_raises_value_error() -> None:
+    """max_retries=-1 raises ValueError."""
+    with pytest.raises(ValueError, match="max_retries"):
+        AsyncApicurioRegistryClient(url=REGISTRY_URL, group_id=GROUP_ID, max_retries=-1)
+
+
+def test_async_init_signature_matches_sync() -> None:
+    """Async and sync client __init__ have the same parameter names."""
+    import inspect
+
+    from apicurio_serdes import ApicurioRegistryClient
+
+    sync_params = set(inspect.signature(ApicurioRegistryClient.__init__).parameters) - {
+        "self"
+    }
+    async_params = set(
+        inspect.signature(AsyncApicurioRegistryClient.__init__).parameters
+    ) - {"self"}
+    assert sync_params == async_params
+
+
+# Retry on transport error
+
+
+async def test_async_get_schema_retries_on_connect_error_then_succeeds(
+    mock_registry: respx.MockRouter,
+) -> None:
+    """ConnectError on first attempt retried; schema returned on second attempt."""
+    url = (
+        f"{REGISTRY_URL}/groups/{GROUP_ID}/artifacts/UserEvent/versions/latest/content"
+    )
+    mock_registry.get(url).mock(side_effect=_async_flaky_schema_handler(1))
+    client = AsyncApicurioRegistryClient(url=REGISTRY_URL, group_id=GROUP_ID)
+    with patch("apicurio_serdes._async_client.asyncio.sleep", new_callable=AsyncMock):
+        result = await client.get_schema("UserEvent")
+    assert result.schema == USER_EVENT_SCHEMA_JSON
+
+
+async def test_async_get_schema_exhausts_retries_raises_connection_error(
+    mock_registry: respx.MockRouter,
+) -> None:
+    """All attempts fail; RegistryConnectionError raised after max_retries exhausted."""
+    from apicurio_serdes._errors import RegistryConnectionError
+
+    url = (
+        f"{REGISTRY_URL}/groups/{GROUP_ID}/artifacts/UserEvent/versions/latest/content"
+    )
+    route = mock_registry.get(url).mock(side_effect=_async_flaky_schema_handler(99))
+    client = AsyncApicurioRegistryClient(
+        url=REGISTRY_URL, group_id=GROUP_ID, max_retries=2
+    )
+    with (
+        patch("apicurio_serdes._async_client.asyncio.sleep", new_callable=AsyncMock),
+        pytest.raises(RegistryConnectionError),
+    ):
+        await client.get_schema("UserEvent")
+    assert route.call_count == 3
+
+
+async def test_async_get_schema_by_global_id_retries_on_connect_error(
+    mock_registry: respx.MockRouter,
+) -> None:
+    """ID lookup retried on ConnectError."""
+    mock_registry.get(url__startswith=f"{REGISTRY_URL}/ids/globalIds/").mock(
+        side_effect=_async_flaky_id_handler(1)
+    )
+    client = AsyncApicurioRegistryClient(url=REGISTRY_URL, group_id=GROUP_ID)
+    with patch("apicurio_serdes._async_client.asyncio.sleep", new_callable=AsyncMock):
+        result = await client.get_schema_by_global_id(GLOBAL_ID)
+    assert result == USER_EVENT_SCHEMA_JSON
+
+
+async def test_async_register_schema_retries_on_connect_error(
+    mock_registry: respx.MockRouter,
+) -> None:
+    """register_schema retried on ConnectError."""
+    mock_registry.post(url__startswith=f"{REGISTRY_URL}/groups/").mock(
+        side_effect=_async_flaky_register_handler(1)
+    )
+    client = AsyncApicurioRegistryClient(url=REGISTRY_URL, group_id=GROUP_ID)
+    with patch("apicurio_serdes._async_client.asyncio.sleep", new_callable=AsyncMock):
+        result = await client.register_schema("UserEvent", USER_EVENT_SCHEMA_JSON)
+    assert result.global_id == GLOBAL_ID
+
+
+# Retry on retryable HTTP status codes
+
+
+@pytest.mark.parametrize("fail_status", [429, 502, 503, 504])
+async def test_async_get_schema_retries_on_retryable_status(
+    mock_registry: respx.MockRouter, fail_status: int
+) -> None:
+    """Schema GET retried on 429/502/503/504."""
+    url = (
+        f"{REGISTRY_URL}/groups/{GROUP_ID}/artifacts/UserEvent/versions/latest/content"
+    )
+    mock_registry.get(url).mock(
+        side_effect=_async_flaky_status_schema_handler(fail_status, 1)
+    )
+    client = AsyncApicurioRegistryClient(url=REGISTRY_URL, group_id=GROUP_ID)
+    with patch("apicurio_serdes._async_client.asyncio.sleep", new_callable=AsyncMock):
+        result = await client.get_schema("UserEvent")
+    assert result.schema == USER_EVENT_SCHEMA_JSON
+
+
+# No retry on non-retryable errors
+
+
+async def test_async_get_schema_no_retry_on_404(
+    mock_registry: respx.MockRouter,
+) -> None:
+    """404 raises SchemaNotFoundError immediately — no retry."""
+    from apicurio_serdes._errors import SchemaNotFoundError
+
+    url = f"{REGISTRY_URL}/groups/{GROUP_ID}/artifacts/Missing/versions/latest/content"
+    route = mock_registry.get(url).mock(return_value=httpx.Response(404, json={}))
+    client = AsyncApicurioRegistryClient(url=REGISTRY_URL, group_id=GROUP_ID)
+    with pytest.raises(SchemaNotFoundError):
+        await client.get_schema("Missing")
+    assert route.call_count == 1
+
+
+async def test_async_get_schema_no_retry_on_400(
+    mock_registry: respx.MockRouter,
+) -> None:
+    """400 raises RegistryConnectionError immediately — no retry."""
+    from apicurio_serdes._errors import RegistryConnectionError
+
+    url = f"{REGISTRY_URL}/groups/{GROUP_ID}/artifacts/Bad/versions/latest/content"
+    route = mock_registry.get(url).mock(return_value=httpx.Response(400))
+    client = AsyncApicurioRegistryClient(url=REGISTRY_URL, group_id=GROUP_ID)
+    with pytest.raises(RegistryConnectionError):
+        await client.get_schema("Bad")
+    assert route.call_count == 1
+
+
+async def test_async_get_schema_no_retry_on_500(
+    mock_registry: respx.MockRouter,
+) -> None:
+    """500 raises RegistryConnectionError immediately — not retried."""
+    from apicurio_serdes._errors import RegistryConnectionError
+
+    url = f"{REGISTRY_URL}/groups/{GROUP_ID}/artifacts/Broken/versions/latest/content"
+    route = mock_registry.get(url).mock(return_value=httpx.Response(500))
+    client = AsyncApicurioRegistryClient(url=REGISTRY_URL, group_id=GROUP_ID)
+    with pytest.raises(RegistryConnectionError):
+        await client.get_schema("Broken")
+    assert route.call_count == 1
+
+
+async def test_async_get_schema_max_retries_zero_no_retry(
+    mock_registry: respx.MockRouter,
+) -> None:
+    """max_retries=0 disables retry; ConnectError raises after 1 attempt."""
+    from apicurio_serdes._errors import RegistryConnectionError
+
+    url = (
+        f"{REGISTRY_URL}/groups/{GROUP_ID}/artifacts/UserEvent/versions/latest/content"
+    )
+    route = mock_registry.get(url).mock(side_effect=httpx.ConnectError("refused"))
+    client = AsyncApicurioRegistryClient(
+        url=REGISTRY_URL, group_id=GROUP_ID, max_retries=0
+    )
+    with pytest.raises(RegistryConnectionError):
+        await client.get_schema("UserEvent")
+    assert route.call_count == 1
+
+
+async def test_async_get_schema_exhausts_retries_on_503_raises_connection_error(
+    mock_registry: respx.MockRouter,
+) -> None:
+    """When all retries on 503 are exhausted, RegistryConnectionError is raised."""
+    from apicurio_serdes._errors import RegistryConnectionError
+
+    url = (
+        f"{REGISTRY_URL}/groups/{GROUP_ID}/artifacts/UserEvent/versions/latest/content"
+    )
+    mock_registry.get(url).mock(return_value=httpx.Response(503))
+    client = AsyncApicurioRegistryClient(
+        url=REGISTRY_URL, group_id=GROUP_ID, max_retries=1
+    )
+    with (
+        patch("apicurio_serdes._async_client.asyncio.sleep", new_callable=AsyncMock),
+        pytest.raises(RegistryConnectionError),
+    ):
+        await client.get_schema("UserEvent")
+
+
+# Backoff
+
+
+async def test_async_get_schema_sleep_called_between_retries(
+    mock_registry: respx.MockRouter,
+) -> None:
+    """asyncio.sleep is called with a non-negative delay between retry attempts."""
+    url = (
+        f"{REGISTRY_URL}/groups/{GROUP_ID}/artifacts/UserEvent/versions/latest/content"
+    )
+    mock_registry.get(url).mock(side_effect=_async_flaky_schema_handler(1))
+    client = AsyncApicurioRegistryClient(url=REGISTRY_URL, group_id=GROUP_ID)
+    with patch(
+        "apicurio_serdes._async_client.asyncio.sleep", new_callable=AsyncMock
+    ) as mock_sleep:
+        await client.get_schema("UserEvent")
+    mock_sleep.assert_called_once()
+    delay = mock_sleep.call_args[0][0]
+    assert delay >= 0
+
+
+# Escape hatch: custom http_client
+
+
+async def test_async_custom_http_client_is_used() -> None:
+    """User-provided AsyncClient is used for HTTP requests."""
+    mock_client = MagicMock(spec=httpx.AsyncClient)
+    _req = httpx.Request(
+        "GET",
+        f"{REGISTRY_URL}/groups/{GROUP_ID}/artifacts/UserEvent/versions/latest/content",
+    )
+    mock_client.request = AsyncMock(
+        return_value=httpx.Response(
+            200,
+            content=json.dumps(USER_EVENT_SCHEMA_JSON).encode(),
+            headers={
+                "X-Registry-GlobalId": str(GLOBAL_ID),
+                "X-Registry-ContentId": str(CONTENT_ID),
+            },
+            request=_req,
+        )
+    )
+    client = AsyncApicurioRegistryClient(
+        url=REGISTRY_URL, group_id=GROUP_ID, http_client=mock_client
+    )
+    result = await client.get_schema("UserEvent")
+    assert result.schema == USER_EVENT_SCHEMA_JSON
+    assert mock_client.request.called
+
+
+async def test_async_custom_http_client_not_closed_on_aclose() -> None:
+    """User-provided AsyncClient is not closed when aclose() is called."""
+    mock_client = MagicMock(spec=httpx.AsyncClient)
+    mock_client.aclose = AsyncMock()
+    client = AsyncApicurioRegistryClient(
+        url=REGISTRY_URL, group_id=GROUP_ID, http_client=mock_client
+    )
+    await client.aclose()
+    mock_client.aclose.assert_not_called()

--- a/tests/test_async_client.py
+++ b/tests/test_async_client.py
@@ -18,6 +18,7 @@ from tests.conftest import (
     GROUP_ID,
     REGISTRY_URL,
     USER_EVENT_SCHEMA_JSON,
+    _id_schema_route,
     _register_error_route,
     _register_route,
 )
@@ -531,60 +532,60 @@ class TestIdCacheDoubleCheckLocking:
     """Coverage: inner cache-check return path for _id_cache."""
 
     async def test_inner_id_cache_check_returns_cached_value(self) -> None:
+        from apicurio_serdes._base import _CacheCore
 
         client = AsyncApicurioRegistryClient(url=REGISTRY_URL, group_id=GROUP_ID)
 
         cached_schema: dict[str, Any] = {"type": "record", "name": "X", "fields": []}
         cache_key = ("contentId", 42)
-        check_count: dict[str, int] = {"n": 0}
+        get_count: dict[str, int] = {"n": 0}
 
-        class _RaceDict(dict[tuple[str, int], Any]):
-            def __contains__(self, key: object) -> bool:
+        class _RaceCache(_CacheCore):
+            def get(self, key: object) -> object:
                 if key == cache_key:
-                    check_count["n"] += 1
-                    if check_count["n"] == 1:
-                        return False
-                    self[cache_key] = cached_schema  # type: ignore[index]
-                    return True
-                return super().__contains__(key)
+                    get_count["n"] += 1
+                    if get_count["n"] == 1:
+                        super().set(cache_key, cached_schema)
+                        return cached_schema
+                return super().get(key)
 
-        client._id_cache = _RaceDict()  # type: ignore[assignment]
+        client._id_cache = _RaceCache(max_size=1000, ttl=None)  # type: ignore[assignment]
         result = await client.get_schema_by_content_id(42)
         assert result is cached_schema
 
 
 class TestDoubleCheckLocking:
-    """Coverage: exercise the inner cache-check return path (line 70)."""
+    """Coverage: exercise the inner cache-check return path."""
 
     async def test_inner_cache_check_returns_cached_value(self) -> None:
         from apicurio_serdes._async_client import AsyncApicurioRegistryClient
+        from apicurio_serdes._base import _CacheCore
         from apicurio_serdes._client import CachedSchema
 
         client = AsyncApicurioRegistryClient(url=REGISTRY_URL, group_id=GROUP_ID)
 
-        cached = CachedSchema(
+        pre_cached = CachedSchema(
             schema={"type": "record", "name": "X", "fields": []},
             global_id=99,
             content_id=88,
         )
         cache_key = (GROUP_ID, "Race")
-        check_count: dict[str, int] = {"n": 0}
+        get_count: dict[str, int] = {"n": 0}
 
-        class _RaceDict(dict[tuple[str, str], Any]):
-            """Dict that misses the first __contains__ then simulates a race fill."""
+        class _RaceCache(_CacheCore):
+            """_CacheCore whose get() simulates a concurrent fill on the first call."""
 
-            def __contains__(self, key: object) -> bool:
+            def get(self, key: object) -> object:
                 if key == cache_key:
-                    check_count["n"] += 1
-                    if check_count["n"] == 1:
-                        return False  # fast-path miss
-                    self[cache_key] = cached  # type: ignore[index]
-                    return True
-                return super().__contains__(key)
+                    get_count["n"] += 1
+                    if get_count["n"] == 1:
+                        super().set(cache_key, pre_cached)
+                        return pre_cached
+                return super().get(key)
 
-        client._schema_cache = _RaceDict()  # type: ignore[assignment]
+        client._schema_cache = _RaceCache(max_size=1000, ttl=None)  # type: ignore[assignment]
         result = await client.get_schema("Race")
-        assert result is cached
+        assert result is pre_cached
 
 
 # ── register_schema async tests ──
@@ -710,35 +711,34 @@ class TestRegisterSchemaAsync:
             schema=USER_EVENT_SCHEMA_JSON, global_id=99, content_id=88
         )
         client = AsyncApicurioRegistryClient(url=REGISTRY_URL, group_id=GROUP_ID)
-        client._schema_cache[(GROUP_ID, "UserEvent")] = cached
+        client._schema_cache.set((GROUP_ID, "UserEvent"), cached)
         result = await client.register_schema("UserEvent", USER_EVENT_SCHEMA_JSON)
         assert result is cached
 
     async def test_double_check_locking(self) -> None:
         """Exercise the inner double-check path for async register_schema."""
-        from apicurio_serdes._base import CachedSchema
+        from apicurio_serdes._base import CachedSchema, _CacheCore
 
-        cached = CachedSchema(
+        pre_cached = CachedSchema(
             schema=USER_EVENT_SCHEMA_JSON, global_id=99, content_id=88
         )
         client = AsyncApicurioRegistryClient(url=REGISTRY_URL, group_id=GROUP_ID)
 
         cache_key = (GROUP_ID, "UserEvent")
-        check_count: dict[str, int] = {"n": 0}
+        get_count: dict[str, int] = {"n": 0}
 
-        class _RaceDict(dict[tuple[str, str], Any]):
-            def __contains__(self, key: object) -> bool:
+        class _RaceCache(_CacheCore):
+            def get(self, key: object) -> object:
                 if key == cache_key:
-                    check_count["n"] += 1
-                    if check_count["n"] == 1:
-                        return False  # fast-path miss
-                    self[cache_key] = cached  # type: ignore[index]
-                    return True
-                return super().__contains__(key)
+                    get_count["n"] += 1
+                    if get_count["n"] == 1:
+                        super().set(cache_key, pre_cached)
+                        return pre_cached
+                return super().get(key)
 
-        client._schema_cache = _RaceDict()  # type: ignore[assignment]
+        client._schema_cache = _RaceCache(max_size=1000, ttl=None)  # type: ignore[assignment]
         result = await client.register_schema("UserEvent", USER_EVENT_SCHEMA_JSON)
-        assert result is cached
+        assert result is pre_cached
 
     def test_interface_parity_with_sync_client(self) -> None:
         """register_schema signature matches the sync client."""
@@ -1156,3 +1156,158 @@ async def test_async_custom_http_client_not_closed_on_aclose() -> None:
     )
     await client.aclose()
     mock_client.aclose.assert_not_called()
+
+
+# ── Async cache constructor validation tests ──
+
+
+class TestAsyncCacheConstructorValidation:
+    """cache_max_size and cache_ttl_seconds are validated on construction (async client)."""
+
+    def test_cache_max_size_zero_raises(self) -> None:
+        with pytest.raises(ValueError, match="cache_max_size"):
+            AsyncApicurioRegistryClient(
+                url=REGISTRY_URL, group_id=GROUP_ID, cache_max_size=0
+            )
+
+    def test_cache_max_size_negative_raises(self) -> None:
+        with pytest.raises(ValueError, match="cache_max_size"):
+            AsyncApicurioRegistryClient(
+                url=REGISTRY_URL, group_id=GROUP_ID, cache_max_size=-1
+            )
+
+    def test_cache_ttl_seconds_zero_raises(self) -> None:
+        with pytest.raises(ValueError, match="cache_ttl_seconds"):
+            AsyncApicurioRegistryClient(
+                url=REGISTRY_URL, group_id=GROUP_ID, cache_ttl_seconds=0
+            )
+
+    def test_cache_ttl_seconds_negative_raises(self) -> None:
+        with pytest.raises(ValueError, match="cache_ttl_seconds"):
+            AsyncApicurioRegistryClient(
+                url=REGISTRY_URL, group_id=GROUP_ID, cache_ttl_seconds=-1.0
+            )
+
+    def test_valid_cache_params_constructs_without_error(self) -> None:
+        client = AsyncApicurioRegistryClient(
+            url=REGISTRY_URL,
+            group_id=GROUP_ID,
+            cache_max_size=1,
+            cache_ttl_seconds=30.0,
+        )
+        assert client is not None
+
+    def test_default_cache_max_size_is_1000(self) -> None:
+        client = AsyncApicurioRegistryClient(url=REGISTRY_URL, group_id=GROUP_ID)
+        assert client._schema_cache._max_size == 1000
+        assert client._id_cache._max_size == 1000
+
+    def test_default_cache_ttl_seconds_is_none(self) -> None:
+        client = AsyncApicurioRegistryClient(url=REGISTRY_URL, group_id=GROUP_ID)
+        assert client._schema_cache._ttl is None
+        assert client._id_cache._ttl is None
+
+    def test_id_cache_always_has_no_ttl(self) -> None:
+        """_id_cache always constructed with ttl=None regardless of cache_ttl_seconds."""
+        client = AsyncApicurioRegistryClient(
+            url=REGISTRY_URL, group_id=GROUP_ID, cache_ttl_seconds=60.0
+        )
+        assert client._id_cache._ttl is None
+        assert client._schema_cache._ttl == 60.0
+
+
+# ── Async LRU eviction tests ──
+
+
+class TestAsyncClientLRUEviction:
+    """cache_max_size causes LRU eviction in the async schema cache."""
+
+    async def test_lru_eviction_in_schema_cache(
+        self, mock_registry: respx.MockRouter
+    ) -> None:
+        """With cache_max_size=2, fetching 3 schemas evicts the LRU (first) entry."""
+        schema_a: dict[str, Any] = {"type": "record", "name": "A", "fields": []}
+        schema_b: dict[str, Any] = {"type": "record", "name": "B", "fields": []}
+        schema_c: dict[str, Any] = {"type": "record", "name": "C", "fields": []}
+        route_a = _async_schema_route(
+            mock_registry, "A", schema=schema_a, global_id=1, content_id=1
+        )
+        route_b = _async_schema_route(
+            mock_registry, "B", schema=schema_b, global_id=2, content_id=2
+        )
+        _async_schema_route(
+            mock_registry, "C", schema=schema_c, global_id=3, content_id=3
+        )
+
+        client = AsyncApicurioRegistryClient(
+            url=REGISTRY_URL, group_id=GROUP_ID, cache_max_size=2
+        )
+        await client.get_schema("A")  # cache: [A]
+        await client.get_schema("B")  # cache: [A, B]
+        await client.get_schema("C")  # evicts A → cache: [B, C]
+
+        assert route_a.call_count == 1
+        assert route_b.call_count == 1
+
+        # Re-fetch A — was evicted; evicts B → cache: [C, A]
+        await client.get_schema("A")
+        assert route_a.call_count == 2
+
+        # B was evicted when A was re-inserted — must re-fetch
+        await client.get_schema("B")
+        assert route_b.call_count == 2
+
+
+# ── Async TTL expiry tests ──
+
+
+class TestAsyncClientTTLExpiry:
+    """cache_ttl_seconds causes TTL expiry in the async schema cache only."""
+
+    async def test_schema_cache_hit_before_ttl(
+        self, mock_registry: respx.MockRouter
+    ) -> None:
+        """get_schema is a cache hit before TTL elapses."""
+        route = _async_schema_route(mock_registry, "UserEvent")
+        client = AsyncApicurioRegistryClient(
+            url=REGISTRY_URL, group_id=GROUP_ID, cache_ttl_seconds=60.0
+        )
+        with patch("apicurio_serdes._base.time") as mock_time:
+            mock_time.monotonic.return_value = 100.0
+            await client.get_schema("UserEvent")
+            mock_time.monotonic.return_value = 155.0  # within TTL
+            await client.get_schema("UserEvent")
+        assert route.call_count == 1
+
+    async def test_schema_cache_miss_after_ttl(
+        self, mock_registry: respx.MockRouter
+    ) -> None:
+        """get_schema re-fetches from registry after TTL elapses."""
+        route = _async_schema_route(mock_registry, "UserEvent")
+        client = AsyncApicurioRegistryClient(
+            url=REGISTRY_URL, group_id=GROUP_ID, cache_ttl_seconds=60.0
+        )
+        with patch("apicurio_serdes._base.time") as mock_time:
+            mock_time.monotonic.return_value = 100.0
+            await client.get_schema("UserEvent")
+            # Advance past TTL (expiry = 160.0)
+            mock_time.monotonic.return_value = 160.0
+            await client.get_schema("UserEvent")
+        assert route.call_count == 2
+
+    async def test_id_cache_not_expired_after_ttl(
+        self, mock_registry: respx.MockRouter
+    ) -> None:
+        """ID-based lookups are never expired even when cache_ttl_seconds is set."""
+        route = _id_schema_route(mock_registry, "globalId", GLOBAL_ID)
+        client = AsyncApicurioRegistryClient(
+            url=REGISTRY_URL, group_id=GROUP_ID, cache_ttl_seconds=60.0
+        )
+        with patch("apicurio_serdes._base.time") as mock_time:
+            mock_time.monotonic.return_value = 100.0
+            await client.get_schema_by_global_id(GLOBAL_ID)
+            # Advance well past TTL
+            mock_time.monotonic.return_value = 9999.0
+            await client.get_schema_by_global_id(GLOBAL_ID)
+        # Still only 1 HTTP call — ID cache never expired
+        assert route.call_count == 1

--- a/tests/test_async_client.py
+++ b/tests/test_async_client.py
@@ -754,3 +754,39 @@ class TestRegisterSchemaAsync:
             assert (
                 sync_sig.parameters[name].default == async_sig.parameters[name].default
             ), f"Default mismatch for param '{name}'"
+
+
+# ── Auth wiring tests ──
+
+
+def test_async_client_auth_defaults_to_none() -> None:
+    """auth parameter defaults to None; existing tests unaffected."""
+    import inspect
+
+    params = inspect.signature(AsyncApicurioRegistryClient.__init__).parameters
+    assert "auth" in params
+    assert params["auth"].default is None
+
+
+@pytest.mark.asyncio
+async def test_async_client_accepts_bearer_auth(
+    mock_registry: respx.MockRouter,
+) -> None:
+    """AsyncApicurioRegistryClient accepts auth=BearerAuth and passes it to httpx."""
+    from httpx import Response
+
+    from apicurio_serdes._auth import BearerAuth
+
+    url = f"{REGISTRY_URL}/groups/{GROUP_ID}/artifacts/Auth/versions/latest/content"
+    route = mock_registry.get(url).mock(
+        return_value=Response(
+            200,
+            content=b'{"type":"record","name":"X","fields":[]}',
+            headers={"X-Registry-GlobalId": "1", "X-Registry-ContentId": "2"},
+        )
+    )
+    client = AsyncApicurioRegistryClient(
+        url=REGISTRY_URL, group_id=GROUP_ID, auth=BearerAuth(token="async-wire")
+    )
+    await client.get_schema("Auth")
+    assert route.calls[0].request.headers["authorization"] == "Bearer async-wire"

--- a/tests/test_async_deserializer.py
+++ b/tests/test_async_deserializer.py
@@ -14,8 +14,12 @@ from apicurio_serdes.avro import AsyncAvroDeserializer
 from apicurio_serdes.serialization import MessageField, SerializationContext
 from tests.conftest import (
     GROUP_ID,
+    INCOMPATIBLE_READER_SCHEMA,
+    READER_SCHEMA_EVOLUTION,
     REGISTRY_URL,
     VALID_USER_EVENT,
+    WRITER_SCHEMA_EVOLUTION,
+    _id_schema_route,
     make_confluent_bytes,
 )
 
@@ -279,3 +283,78 @@ def test_async_avro_deserializer_importable_from_avro_package() -> None:
     from apicurio_serdes.avro import AsyncAvroDeserializer as Imported
 
     assert Imported is AsyncAvroDeserializer
+
+
+# ── signature parity ──
+
+
+def test_async_deserializer_init_signature_matches_sync() -> None:
+    """AsyncAvroDeserializer.__init__ has the same parameter names as AvroDeserializer."""
+    import inspect
+
+    from apicurio_serdes.avro import AvroDeserializer
+
+    sync_params = set(inspect.signature(AvroDeserializer.__init__).parameters) - {
+        "self"
+    }
+    async_params = set(inspect.signature(AsyncAvroDeserializer.__init__).parameters) - {
+        "self"
+    }
+    assert sync_params == async_params
+
+
+# ── Reader schema (schema evolution) ──
+
+
+class TestReaderSchema:
+    """Reader schema support — Avro schema evolution (async)."""
+
+    async def test_no_reader_schema_returns_writer_fields_only(
+        self, mock_registry: respx.MockRouter
+    ) -> None:
+        """Default (reader_schema=None) decodes using writer schema — no evolution."""
+        _id_schema_route(
+            mock_registry, "globalId", CONTENT_ID, schema=WRITER_SCHEMA_EVOLUTION
+        )
+        client = AsyncApicurioRegistryClient(url=REGISTRY_URL, group_id=GROUP_ID)
+        deser = AsyncAvroDeserializer(registry_client=client)
+        data = make_confluent_bytes(
+            CONTENT_ID, {"userId": "u1"}, schema=WRITER_SCHEMA_EVOLUTION
+        )
+        result = await deser(data, _ctx())
+        assert result == {"userId": "u1"}
+        assert "version" not in result
+
+    async def test_reader_schema_fills_default_for_added_field(
+        self, mock_registry: respx.MockRouter
+    ) -> None:
+        """reader_schema causes fastavro to fill added field with its default."""
+        _id_schema_route(
+            mock_registry, "globalId", CONTENT_ID, schema=WRITER_SCHEMA_EVOLUTION
+        )
+        client = AsyncApicurioRegistryClient(url=REGISTRY_URL, group_id=GROUP_ID)
+        deser = AsyncAvroDeserializer(
+            registry_client=client, reader_schema=READER_SCHEMA_EVOLUTION
+        )
+        data = make_confluent_bytes(
+            CONTENT_ID, {"userId": "u1"}, schema=WRITER_SCHEMA_EVOLUTION
+        )
+        result = await deser(data, _ctx())
+        assert result == {"userId": "u1", "version": "v1"}
+
+    async def test_incompatible_reader_schema_raises_deserialization_error(
+        self, mock_registry: respx.MockRouter
+    ) -> None:
+        """Incompatible reader/writer schemas wrap fastavro error as DeserializationError."""
+        _id_schema_route(
+            mock_registry, "globalId", CONTENT_ID, schema=WRITER_SCHEMA_EVOLUTION
+        )
+        client = AsyncApicurioRegistryClient(url=REGISTRY_URL, group_id=GROUP_ID)
+        deser = AsyncAvroDeserializer(
+            registry_client=client, reader_schema=INCOMPATIBLE_READER_SCHEMA
+        )
+        data = make_confluent_bytes(
+            CONTENT_ID, {"userId": "u1"}, schema=WRITER_SCHEMA_EVOLUTION
+        )
+        with pytest.raises(DeserializationError, match="Avro decode failure"):
+            await deser(data, _ctx())

--- a/tests/test_auth.py
+++ b/tests/test_auth.py
@@ -1,0 +1,516 @@
+"""Tests for authentication classes: BearerAuth and KeycloakAuth."""
+
+from __future__ import annotations
+
+import time
+from unittest.mock import MagicMock
+
+import httpx
+import pytest
+import respx
+from httpx import Response
+
+from apicurio_serdes._auth import BearerAuth, KeycloakAuth
+from apicurio_serdes._errors import AuthenticationError
+
+TOKEN_URL = "https://keycloak.example.com/realms/myrealm/protocol/openid-connect/token"
+REGISTRY_URL = "http://registry:8080/apis/registry/v3"
+ARTIFACT_URL = f"{REGISTRY_URL}/groups/g/artifacts/a/versions/latest/content"
+
+
+# ── Helpers ──
+
+
+def _mock_registry(router: respx.MockRouter) -> respx.Route:
+    return router.get(ARTIFACT_URL).mock(
+        return_value=Response(
+            200,
+            content=b'{"type":"record","name":"X","fields":[]}',
+            headers={"X-Registry-GlobalId": "1", "X-Registry-ContentId": "2"},
+        )
+    )
+
+
+def _token_response(token: str = "tok", expires_in: int = 300) -> Response:
+    return Response(200, json={"access_token": token, "expires_in": expires_in})
+
+
+# ── BearerAuth ──
+
+
+class TestBearerAuth:
+    """BearerAuth injects a static or dynamic Bearer token."""
+
+    def test_static_token_injects_header(self) -> None:
+        with respx.mock() as router:
+            route = _mock_registry(router)
+            with httpx.Client(auth=BearerAuth(token="my-token")) as client:
+                client.get(ARTIFACT_URL)
+            assert route.calls[0].request.headers["authorization"] == "Bearer my-token"
+
+    def test_dynamic_token_calls_provider(self) -> None:
+        provider = MagicMock(return_value="dyn-token")
+        with respx.mock() as router:
+            route = _mock_registry(router)
+            with httpx.Client(auth=BearerAuth(token_provider=provider)) as client:
+                client.get(ARTIFACT_URL)
+            assert route.calls[0].request.headers["authorization"] == "Bearer dyn-token"
+
+    def test_provider_called_on_each_request(self) -> None:
+        call_count = 0
+
+        def provider() -> str:
+            nonlocal call_count
+            call_count += 1
+            return f"token-{call_count}"
+
+        with respx.mock() as router:
+            _mock_registry(router)
+            with httpx.Client(auth=BearerAuth(token_provider=provider)) as client:
+                client.get(ARTIFACT_URL)
+                client.get(ARTIFACT_URL)
+        assert call_count == 2
+
+    def test_no_args_raises_value_error(self) -> None:
+        with pytest.raises(ValueError, match="exactly one"):
+            BearerAuth()
+
+    def test_both_args_raises_value_error(self) -> None:
+        with pytest.raises(ValueError, match="exactly one"):
+            BearerAuth(token="t", token_provider=lambda: "t")
+
+    def test_works_with_sync_httpx_client(self) -> None:
+        with respx.mock() as router:
+            route = _mock_registry(router)
+            with httpx.Client(auth=BearerAuth(token="sync-tok")) as client:
+                client.get(ARTIFACT_URL)
+            assert "Bearer sync-tok" in route.calls[0].request.headers["authorization"]
+
+    @pytest.mark.asyncio
+    async def test_works_with_async_httpx_client(self) -> None:
+        with respx.mock() as router:
+            route = _mock_registry(router)
+            async with httpx.AsyncClient(auth=BearerAuth(token="async-tok")) as client:
+                await client.get(ARTIFACT_URL)
+            assert route.calls[0].request.headers["authorization"] == "Bearer async-tok"
+
+
+# ── KeycloakAuth sync ──
+
+
+class TestKeycloakAuthSync:
+    """KeycloakAuth fetches and auto-refreshes tokens via client credentials (sync)."""
+
+    def _auth(self, scope: str | None = None) -> KeycloakAuth:
+        return KeycloakAuth(
+            token_url=TOKEN_URL,
+            client_id="client",
+            client_secret="secret",
+            scope=scope,
+        )
+
+    def test_happy_path_injects_token(self) -> None:
+        with respx.mock() as router:
+            router.post(TOKEN_URL).mock(return_value=_token_response("tok1"))
+            route = _mock_registry(router)
+            auth = self._auth()
+            with httpx.Client(auth=auth) as client:
+                client.get(ARTIFACT_URL)
+            assert route.calls[0].request.headers["authorization"] == "Bearer tok1"
+
+    def test_token_reused_on_second_request(self) -> None:
+        with respx.mock() as router:
+            token_route = router.post(TOKEN_URL).mock(
+                return_value=_token_response("tok1")
+            )
+            _mock_registry(router)
+            auth = self._auth()
+            with httpx.Client(auth=auth) as client:
+                client.get(ARTIFACT_URL)
+                client.get(ARTIFACT_URL)
+            assert token_route.call_count == 1
+
+    def test_auto_refresh_when_expired(self) -> None:
+        with respx.mock() as router:
+            token_route = router.post(TOKEN_URL).mock(
+                side_effect=[
+                    _token_response("tok1"),
+                    _token_response("tok2"),
+                ]
+            )
+            _mock_registry(router)
+            auth = self._auth()
+            with httpx.Client(auth=auth) as client:
+                client.get(ARTIFACT_URL)
+                # Force expiry
+                auth._expires_at = time.monotonic() - 1
+                client.get(ARTIFACT_URL)
+            assert token_route.call_count == 2
+
+    def test_threshold_refresh_before_expiry(self) -> None:
+        with respx.mock() as router:
+            token_route = router.post(TOKEN_URL).mock(
+                side_effect=[
+                    _token_response("tok1", expires_in=100),
+                    _token_response("tok2", expires_in=100),
+                ]
+            )
+            _mock_registry(router)
+            auth = self._auth()
+            with httpx.Client(auth=auth) as client:
+                client.get(ARTIFACT_URL)
+                # Within 20% threshold (< 20s remaining of 100s)
+                auth._expires_at = time.monotonic() + 10
+                auth._expires_in = 100
+                client.get(ARTIFACT_URL)
+            assert token_route.call_count == 2
+
+    def test_token_endpoint_401_raises_authentication_error(self) -> None:
+        with respx.mock() as router:
+            router.post(TOKEN_URL).mock(return_value=Response(401, text="Unauthorized"))
+            auth = self._auth()
+            with (
+                httpx.Client(auth=auth) as client,
+                pytest.raises(AuthenticationError, match="401"),
+            ):
+                client.get(ARTIFACT_URL)
+
+    def test_token_endpoint_unreachable_raises_authentication_error(self) -> None:
+        with respx.mock() as router:
+            router.post(TOKEN_URL).mock(side_effect=httpx.ConnectError("refused"))
+            auth = self._auth()
+            with httpx.Client(auth=auth) as client, pytest.raises(AuthenticationError):
+                client.get(ARTIFACT_URL)
+
+    def test_token_endpoint_read_timeout_raises_authentication_error(self) -> None:
+        with respx.mock() as router:
+            router.post(TOKEN_URL).mock(side_effect=httpx.ReadTimeout("timed out"))
+            auth = self._auth()
+            with httpx.Client(auth=auth) as client, pytest.raises(AuthenticationError):
+                client.get(ARTIFACT_URL)
+
+    def test_scope_included_in_token_request(self) -> None:
+        with respx.mock() as router:
+            token_route = router.post(TOKEN_URL).mock(return_value=_token_response())
+            _mock_registry(router)
+            auth = self._auth(scope="openid")
+            with httpx.Client(auth=auth) as client:
+                client.get(ARTIFACT_URL)
+            body = token_route.calls[0].request.content.decode()
+            assert "scope=openid" in body
+
+    def test_no_scope_omits_scope_from_request(self) -> None:
+        with respx.mock() as router:
+            token_route = router.post(TOKEN_URL).mock(return_value=_token_response())
+            _mock_registry(router)
+            auth = self._auth()
+            with httpx.Client(auth=auth) as client:
+                client.get(ARTIFACT_URL)
+            body = token_route.calls[0].request.content.decode()
+            assert "scope" not in body
+
+
+# ── KeycloakAuth async ──
+
+
+class TestKeycloakAuthAsync:
+    """KeycloakAuth fetches and auto-refreshes tokens via client credentials (async)."""
+
+    def _auth(self, scope: str | None = None) -> KeycloakAuth:
+        return KeycloakAuth(
+            token_url=TOKEN_URL,
+            client_id="client",
+            client_secret="secret",
+            scope=scope,
+        )
+
+    @pytest.mark.asyncio
+    async def test_happy_path_injects_token(self) -> None:
+        with respx.mock() as router:
+            router.post(TOKEN_URL).mock(return_value=_token_response("atok1"))
+            route = _mock_registry(router)
+            auth = self._auth()
+            async with httpx.AsyncClient(auth=auth) as client:
+                await client.get(ARTIFACT_URL)
+            assert route.calls[0].request.headers["authorization"] == "Bearer atok1"
+
+    @pytest.mark.asyncio
+    async def test_token_reused_on_second_request(self) -> None:
+        with respx.mock() as router:
+            token_route = router.post(TOKEN_URL).mock(
+                return_value=_token_response("atok1")
+            )
+            _mock_registry(router)
+            auth = self._auth()
+            async with httpx.AsyncClient(auth=auth) as client:
+                await client.get(ARTIFACT_URL)
+                await client.get(ARTIFACT_URL)
+            assert token_route.call_count == 1
+
+    @pytest.mark.asyncio
+    async def test_auto_refresh_when_expired(self) -> None:
+        with respx.mock() as router:
+            token_route = router.post(TOKEN_URL).mock(
+                side_effect=[
+                    _token_response("atok1"),
+                    _token_response("atok2"),
+                ]
+            )
+            _mock_registry(router)
+            auth = self._auth()
+            async with httpx.AsyncClient(auth=auth) as client:
+                await client.get(ARTIFACT_URL)
+                auth._expires_at = time.monotonic() - 1
+                await client.get(ARTIFACT_URL)
+            assert token_route.call_count == 2
+
+    @pytest.mark.asyncio
+    async def test_threshold_refresh_before_expiry(self) -> None:
+        with respx.mock() as router:
+            token_route = router.post(TOKEN_URL).mock(
+                side_effect=[
+                    _token_response("atok1", expires_in=100),
+                    _token_response("atok2", expires_in=100),
+                ]
+            )
+            _mock_registry(router)
+            auth = self._auth()
+            async with httpx.AsyncClient(auth=auth) as client:
+                await client.get(ARTIFACT_URL)
+                auth._expires_at = time.monotonic() + 10
+                auth._expires_in = 100
+                await client.get(ARTIFACT_URL)
+            assert token_route.call_count == 2
+
+    @pytest.mark.asyncio
+    async def test_token_endpoint_401_raises_authentication_error(self) -> None:
+        with respx.mock() as router:
+            router.post(TOKEN_URL).mock(return_value=Response(401, text="Unauthorized"))
+            auth = self._auth()
+            async with httpx.AsyncClient(auth=auth) as client:
+                with pytest.raises(AuthenticationError, match="401"):
+                    await client.get(ARTIFACT_URL)
+
+    @pytest.mark.asyncio
+    async def test_token_endpoint_unreachable_raises_authentication_error(
+        self,
+    ) -> None:
+        with respx.mock() as router:
+            router.post(TOKEN_URL).mock(side_effect=httpx.ConnectError("refused"))
+            auth = self._auth()
+            async with httpx.AsyncClient(auth=auth) as client:
+                with pytest.raises(AuthenticationError):
+                    await client.get(ARTIFACT_URL)
+
+    @pytest.mark.asyncio
+    async def test_token_endpoint_read_timeout_raises_authentication_error(
+        self,
+    ) -> None:
+        with respx.mock() as router:
+            router.post(TOKEN_URL).mock(side_effect=httpx.ReadTimeout("timed out"))
+            auth = self._auth()
+            async with httpx.AsyncClient(auth=auth) as client:
+                with pytest.raises(AuthenticationError):
+                    await client.get(ARTIFACT_URL)
+
+    def test_lazy_lock_usable_from_inside_event_loop(self) -> None:
+        """KeycloakAuth created outside event loop works fine when used async."""
+        # Object is created here (outside any event loop)
+        auth = self._auth()
+        # Lock should be None until first async use
+        assert auth._async_lock is None
+
+
+# ── Double-checked locking coverage ──
+
+
+class TestDoubleCheckedLocking:
+    """Cover the second-check-is-False branch in sync and async ensure_token."""
+
+    def _auth(self) -> KeycloakAuth:
+        return KeycloakAuth(
+            token_url=TOKEN_URL,
+            client_id="client",
+            client_secret="secret",
+        )
+
+    def test_sync_second_check_skips_fetch_when_token_refreshed(self) -> None:
+        """Second _is_expired() inside the lock returns False → _sync_fetch_token skipped."""
+        auth = self._auth()
+        call_count = [0]
+
+        def once_then_false() -> bool:
+            call_count[0] += 1
+            # First call (outer): expired; second call (inner lock): already refreshed
+            return call_count[0] == 1
+
+        auth._is_expired = once_then_false  # type: ignore[method-assign]
+        # No HTTP mock needed — fetch should NOT be called
+        auth._sync_ensure_token()
+        assert call_count[0] == 2
+
+    @pytest.mark.asyncio
+    async def test_async_second_check_skips_fetch_when_token_refreshed(
+        self,
+    ) -> None:
+        """Second _is_expired() inside async lock returns False → _async_fetch_token skipped."""
+        auth = self._auth()
+        call_count = [0]
+
+        def once_then_false() -> bool:
+            call_count[0] += 1
+            return call_count[0] == 1
+
+        auth._is_expired = once_then_false  # type: ignore[method-assign]
+        await auth._async_ensure_token()
+        assert call_count[0] == 2
+
+
+# ── Security hardening tests ──
+
+
+class TestKeycloakAuthSecurity:
+    """Cover security hardening: malformed responses, repr masking, URL sanitisation."""
+
+    def _auth(self) -> KeycloakAuth:
+        return KeycloakAuth(
+            token_url=TOKEN_URL,
+            client_id="client",
+            client_secret="super-secret",
+        )
+
+    def test_200_with_missing_access_token_raises_authentication_error(self) -> None:
+        with respx.mock() as router:
+            router.post(TOKEN_URL).mock(
+                return_value=Response(200, json={"expires_in": 300})
+            )
+            auth = self._auth()
+            with (
+                httpx.Client(auth=auth) as client,
+                pytest.raises(AuthenticationError, match="access_token"),
+            ):
+                client.get(ARTIFACT_URL)
+
+    def test_200_with_empty_access_token_raises_authentication_error(self) -> None:
+        with respx.mock() as router:
+            router.post(TOKEN_URL).mock(
+                return_value=Response(200, json={"access_token": "", "expires_in": 300})
+            )
+            auth = self._auth()
+            with (
+                httpx.Client(auth=auth) as client,
+                pytest.raises(AuthenticationError, match="access_token"),
+            ):
+                client.get(ARTIFACT_URL)
+        assert auth._token == ""
+
+    def test_200_with_null_access_token_raises_authentication_error(self) -> None:
+        with respx.mock() as router:
+            router.post(TOKEN_URL).mock(
+                return_value=Response(
+                    200, json={"access_token": None, "expires_in": 300}
+                )
+            )
+            auth = self._auth()
+            with (
+                httpx.Client(auth=auth) as client,
+                pytest.raises(AuthenticationError, match="access_token"),
+            ):
+                client.get(ARTIFACT_URL)
+        assert auth._token == ""
+
+    def test_200_with_missing_expires_in_raises_authentication_error(self) -> None:
+        with respx.mock() as router:
+            router.post(TOKEN_URL).mock(
+                return_value=Response(200, json={"access_token": "tok"})
+            )
+            auth = self._auth()
+            with (
+                httpx.Client(auth=auth) as client,
+                pytest.raises(AuthenticationError, match="expires_in"),
+            ):
+                client.get(ARTIFACT_URL)
+        # Token state must not be partially mutated on failure
+        assert auth._token == ""
+        assert auth._expires_at == 0.0
+
+    @pytest.mark.parametrize("expires_in", [0, -1, -300])
+    def test_200_with_non_positive_expires_in_raises_authentication_error(
+        self, expires_in: int
+    ) -> None:
+        with respx.mock() as router:
+            router.post(TOKEN_URL).mock(
+                return_value=Response(
+                    200, json={"access_token": "tok", "expires_in": expires_in}
+                )
+            )
+            auth = self._auth()
+            with (
+                httpx.Client(auth=auth) as client,
+                pytest.raises(AuthenticationError, match="expires_in"),
+            ):
+                client.get(ARTIFACT_URL)
+        # Token state must not be mutated on failure
+        assert auth._token == ""
+        assert auth._expires_at == 0.0
+
+    def test_200_with_non_json_body_raises_authentication_error(self) -> None:
+        with respx.mock() as router:
+            router.post(TOKEN_URL).mock(return_value=Response(200, text="not json"))
+            auth = self._auth()
+            with httpx.Client(auth=auth) as client, pytest.raises(AuthenticationError):
+                client.get(ARTIFACT_URL)
+
+    def test_401_error_message_does_not_include_full_response_body(self) -> None:
+        sensitive_body = '{"error":"invalid_client","secret_echo":"super-secret"}'
+        with respx.mock() as router:
+            router.post(TOKEN_URL).mock(return_value=Response(401, text=sensitive_body))
+            auth = self._auth()
+            with (
+                httpx.Client(auth=auth) as client,
+                pytest.raises(AuthenticationError) as exc_info,
+            ):
+                client.get(ARTIFACT_URL)
+            # Full body must not appear in the error message
+            assert sensitive_body not in str(exc_info.value)
+
+    def test_repr_masks_client_secret(self) -> None:
+        auth = self._auth()
+        r = repr(auth)
+        assert "super-secret" not in r
+        assert "***" in r
+        assert "client_id='client'" in r
+
+    def test_transport_error_message_strips_embedded_credentials(self) -> None:
+        url_with_creds = "https://user:pass@keycloak.example.com/realms/r/protocol/openid-connect/token"
+        auth = KeycloakAuth(
+            token_url=url_with_creds,
+            client_id="client",
+            client_secret="secret",
+        )
+        with respx.mock() as router:
+            router.post(url_with_creds).mock(side_effect=httpx.ConnectError("refused"))
+            with (
+                httpx.Client(auth=auth) as client,
+                pytest.raises(AuthenticationError) as exc_info,
+            ):
+                client.get(ARTIFACT_URL)
+        assert "pass" not in str(exc_info.value)
+        assert "user" not in str(exc_info.value)
+
+    def test_transport_error_message_preserves_port(self) -> None:
+        url_with_creds = "https://user:pass@keycloak.example.com:8443/realms/r/protocol/openid-connect/token"
+        auth = KeycloakAuth(
+            token_url=url_with_creds,
+            client_id="client",
+            client_secret="secret",
+        )
+        with respx.mock() as router:
+            router.post(url_with_creds).mock(side_effect=httpx.ConnectError("refused"))
+            with (
+                httpx.Client(auth=auth) as client,
+                pytest.raises(AuthenticationError) as exc_info,
+            ):
+                client.get(ARTIFACT_URL)
+        assert "pass" not in str(exc_info.value)
+        assert ":8443" in str(exc_info.value)

--- a/tests/test_cache_core.py
+++ b/tests/test_cache_core.py
@@ -1,0 +1,213 @@
+"""Unit tests for _CacheCore — lock-free LRU+TTL cache core."""
+
+from __future__ import annotations
+
+from unittest.mock import patch
+
+import pytest
+
+from apicurio_serdes._base import _CacheCore
+
+_MISSING = _CacheCore._MISSING
+
+
+# ── Validation ──────────────────────────────────────────────────────────────
+
+
+class TestValidation:
+    """Constructor validation raises ValueError on bad inputs."""
+
+    def test_max_size_zero_raises(self) -> None:
+        with pytest.raises(ValueError, match="cache_max_size must be >= 1"):
+            _CacheCore(max_size=0, ttl=None)
+
+    def test_max_size_negative_raises(self) -> None:
+        with pytest.raises(ValueError, match="cache_max_size must be >= 1"):
+            _CacheCore(max_size=-1, ttl=None)
+
+    def test_ttl_zero_raises(self) -> None:
+        with pytest.raises(ValueError, match="cache_ttl_seconds must be > 0"):
+            _CacheCore(max_size=1, ttl=0)
+
+    def test_ttl_negative_raises(self) -> None:
+        with pytest.raises(ValueError, match="cache_ttl_seconds must be > 0"):
+            _CacheCore(max_size=1, ttl=-1.0)
+
+    def test_max_size_one_no_ttl_valid(self) -> None:
+        cache = _CacheCore(max_size=1, ttl=None)
+        assert cache is not None
+
+    def test_max_size_one_positive_ttl_valid(self) -> None:
+        cache = _CacheCore(max_size=1, ttl=30.0)
+        assert cache is not None
+
+
+# ── Basic get/set ────────────────────────────────────────────────────────────
+
+
+class TestBasicGetSet:
+    """set then get returns the stored value; get on empty cache returns MISSING."""
+
+    def test_get_on_empty_cache_returns_missing(self) -> None:
+        cache = _CacheCore(max_size=10, ttl=None)
+        assert cache.get("missing") is _MISSING
+
+    def test_set_then_get_returns_value(self) -> None:
+        cache = _CacheCore(max_size=10, ttl=None)
+        cache.set("k", "v")
+        assert cache.get("k") == "v"
+
+    def test_set_then_peek_returns_value(self) -> None:
+        cache = _CacheCore(max_size=10, ttl=None)
+        cache.set("k", "v")
+        assert cache.peek("k") == "v"
+
+    def test_peek_on_empty_cache_returns_missing(self) -> None:
+        cache = _CacheCore(max_size=10, ttl=None)
+        assert cache.peek("missing") is _MISSING
+
+
+# ── TTL = None (no expiry) ───────────────────────────────────────────────────
+
+
+class TestNoTTL:
+    """Entries with ttl=None are never expired, even after time advances."""
+
+    def test_entry_still_valid_after_time_advance(self) -> None:
+        cache = _CacheCore(max_size=10, ttl=None)
+        cache.set("k", "v")
+        # Simulate a huge time advance — should not matter
+        with patch("apicurio_serdes._base.time") as mock_time:
+            mock_time.monotonic.return_value = 999_999.0
+            assert cache.get("k") == "v"
+
+    def test_peek_still_valid_after_time_advance(self) -> None:
+        cache = _CacheCore(max_size=10, ttl=None)
+        cache.set("k", "v")
+        with patch("apicurio_serdes._base.time") as mock_time:
+            mock_time.monotonic.return_value = 999_999.0
+            assert cache.peek("k") == "v"
+
+
+# ── TTL > 0 (expiry) ─────────────────────────────────────────────────────────
+
+
+class TestTTLExpiry:
+    """Entries expire after TTL elapses; peek does not delete expired entries."""
+
+    def test_entry_valid_before_ttl(self) -> None:
+        with patch("apicurio_serdes._base.time") as mock_time:
+            mock_time.monotonic.return_value = 100.0
+            cache = _CacheCore(max_size=10, ttl=60.0)
+            cache.set("k", "v")
+            # Still within TTL window
+            mock_time.monotonic.return_value = 155.0
+            assert cache.get("k") == "v"
+
+    def test_peek_valid_before_ttl(self) -> None:
+        with patch("apicurio_serdes._base.time") as mock_time:
+            mock_time.monotonic.return_value = 100.0
+            cache = _CacheCore(max_size=10, ttl=60.0)
+            cache.set("k", "v")
+            mock_time.monotonic.return_value = 155.0
+            assert cache.peek("k") == "v"
+
+    def test_get_returns_missing_after_ttl(self) -> None:
+        with patch("apicurio_serdes._base.time") as mock_time:
+            mock_time.monotonic.return_value = 100.0
+            cache = _CacheCore(max_size=10, ttl=60.0)
+            cache.set("k", "v")
+            # TTL elapsed (expiry = 160.0)
+            mock_time.monotonic.return_value = 160.0
+            assert cache.get("k") is _MISSING
+
+    def test_get_deletes_entry_after_ttl(self) -> None:
+        with patch("apicurio_serdes._base.time") as mock_time:
+            mock_time.monotonic.return_value = 100.0
+            cache = _CacheCore(max_size=10, ttl=60.0)
+            cache.set("k", "v")
+            mock_time.monotonic.return_value = 160.0
+            cache.get("k")  # triggers deletion
+            # Entry must no longer exist in internal store
+            assert "k" not in cache._store
+
+    def test_peek_returns_missing_after_ttl(self) -> None:
+        with patch("apicurio_serdes._base.time") as mock_time:
+            mock_time.monotonic.return_value = 100.0
+            cache = _CacheCore(max_size=10, ttl=60.0)
+            cache.set("k", "v")
+            mock_time.monotonic.return_value = 160.0
+            assert cache.peek("k") is _MISSING
+
+    def test_peek_does_not_delete_expired_entry(self) -> None:
+        """peek must not mutate _store — deletion requires a lock."""
+        with patch("apicurio_serdes._base.time") as mock_time:
+            mock_time.monotonic.return_value = 100.0
+            cache = _CacheCore(max_size=10, ttl=60.0)
+            cache.set("k", "v")
+            mock_time.monotonic.return_value = 160.0
+            cache.peek("k")  # should NOT delete
+            # Entry still in store (not yet deleted)
+            assert "k" in cache._store
+
+    def test_set_resets_expiry(self) -> None:
+        with patch("apicurio_serdes._base.time") as mock_time:
+            mock_time.monotonic.return_value = 100.0
+            cache = _CacheCore(max_size=10, ttl=60.0)
+            cache.set("k", "v1")
+            # Advance close to expiry
+            mock_time.monotonic.return_value = 155.0
+            # Overwrite — new expiry = 155 + 60 = 215
+            cache.set("k", "v2")
+            # Advance past original expiry (160) but before new expiry
+            mock_time.monotonic.return_value = 200.0
+            assert cache.get("k") == "v2"
+
+
+# ── LRU eviction ─────────────────────────────────────────────────────────────
+
+
+class TestLRUEviction:
+    """LRU eviction removes the least-recently-used entry when over capacity."""
+
+    def test_oldest_evicted_on_overflow(self) -> None:
+        cache = _CacheCore(max_size=2, ttl=None)
+        cache.set("a", 1)
+        cache.set("b", 2)
+        cache.set("c", 3)
+        # "a" was LRU — must be evicted
+        assert cache.get("a") is _MISSING
+        assert cache.get("b") == 2
+        assert cache.get("c") == 3
+
+    def test_get_promotes_entry_to_mru(self) -> None:
+        """Accessing "a" via get() makes "b" the LRU; inserting "c" evicts "b"."""
+        cache = _CacheCore(max_size=2, ttl=None)
+        cache.set("a", 1)
+        cache.set("b", 2)
+        cache.get("a")  # promotes "a" to MRU; "b" is now LRU
+        cache.set("c", 3)
+        assert cache.get("b") is _MISSING
+        assert cache.get("a") == 1
+        assert cache.get("c") == 3
+
+    def test_peek_does_not_promote_entry(self) -> None:
+        """peek() must not update LRU order; "a" should still be evicted."""
+        cache = _CacheCore(max_size=2, ttl=None)
+        cache.set("a", 1)
+        cache.set("b", 2)
+        cache.peek("a")  # must NOT promote "a"
+        cache.set("c", 3)
+        # "a" is still LRU (peek didn't move it) → evicted
+        assert cache.get("a") is _MISSING
+        assert cache.get("b") == 2
+        assert cache.get("c") == 3
+
+    def test_overwrite_does_not_evict(self) -> None:
+        """Updating an existing key doesn't increase size — no eviction."""
+        cache = _CacheCore(max_size=2, ttl=None)
+        cache.set("a", 1)
+        cache.set("b", 2)
+        cache.set("a", "new")  # overwrite — size stays at 2
+        assert cache.get("a") == "new"
+        assert cache.get("b") == 2

--- a/tests/test_client.py
+++ b/tests/test_client.py
@@ -793,3 +793,36 @@ def test_id_cache_double_check_locking(mock_registry: respx.MockRouter) -> None:
     client._id_cache = _RaceDict()  # type: ignore[assignment]
     result = client.get_schema_by_content_id(42)
     assert result is cached_schema
+
+
+# ── Auth wiring tests ──
+
+
+def test_client_auth_defaults_to_none() -> None:
+    """auth parameter defaults to None; existing tests unaffected."""
+    import inspect
+
+    params = inspect.signature(ApicurioRegistryClient.__init__).parameters
+    assert "auth" in params
+    assert params["auth"].default is None
+
+
+def test_client_accepts_bearer_auth(mock_registry: respx.MockRouter) -> None:
+    """ApicurioRegistryClient accepts auth=BearerAuth and passes it to httpx."""
+    from httpx import Response
+
+    from apicurio_serdes._auth import BearerAuth
+
+    url = f"{REGISTRY_URL}/groups/{GROUP_ID}/artifacts/Auth/versions/latest/content"
+    route = mock_registry.get(url).mock(
+        return_value=Response(
+            200,
+            content=b'{"type":"record","name":"X","fields":[]}',
+            headers={"X-Registry-GlobalId": "1", "X-Registry-ContentId": "2"},
+        )
+    )
+    client = ApicurioRegistryClient(
+        url=REGISTRY_URL, group_id=GROUP_ID, auth=BearerAuth(token="wire-tok")
+    )
+    client.get_schema("Auth")
+    assert route.calls[0].request.headers["authorization"] == "Bearer wire-tok"

--- a/tests/test_client.py
+++ b/tests/test_client.py
@@ -399,40 +399,42 @@ def test_get_schema_by_content_id_network_error(
 
 
 def test_double_check_locking_cache_hit(mock_registry: respx.MockRouter) -> None:
-    """Exercise the double-checked locking return path (line 80).
+    """Exercise the double-checked locking return path.
 
     Simulates a race where another thread populates the cache between
-    the fast-path check (line 74) and the lock-guarded check (line 79).
+    the fast-path peek (outside lock) and the lock-guarded get (inside lock).
+    Uses a _CacheCore subclass whose get() populates the entry on the second
+    call to mimic a concurrent cache fill.
     """
+    from apicurio_serdes._base import _CacheCore
     from apicurio_serdes._client import CachedSchema
 
     _schema_route(mock_registry, "Race")
     client = ApicurioRegistryClient(url=REGISTRY_URL, group_id=GROUP_ID)
 
-    cached = CachedSchema(
+    pre_cached = CachedSchema(
         schema={"type": "record", "name": "X", "fields": []},
         global_id=99,
         content_id=88,
     )
     cache_key = (GROUP_ID, "Race")
-    check_count: dict[str, int] = {"n": 0}
+    get_count: dict[str, int] = {"n": 0}
 
-    class _RaceDict(dict[tuple[str, str], Any]):
-        """Dict that misses the first __contains__ then simulates a race fill."""
+    class _RaceCache(_CacheCore):
+        """_CacheCore whose get() simulates a concurrent fill on the second call."""
 
-        def __contains__(self, key: object) -> bool:
+        def get(self, key: object) -> object:
             if key == cache_key:
-                check_count["n"] += 1
-                if check_count["n"] == 1:
-                    return False  # fast-path miss
-                # Inside the lock: simulate another thread having filled cache
-                self[cache_key] = cached  # type: ignore[index]
-                return True
-            return super().__contains__(key)
+                get_count["n"] += 1
+                if get_count["n"] == 1:
+                    # Inside the lock, first get: simulate concurrent thread fill
+                    super().set(cache_key, pre_cached)
+                    return pre_cached
+            return super().get(key)
 
-    client._schema_cache = _RaceDict()  # type: ignore[assignment]
+    client._schema_cache = _RaceCache(max_size=1000, ttl=None)  # type: ignore[assignment]
     result = client.get_schema("Race")
-    assert result is cached
+    assert result is pre_cached
 
 
 def test_global_id_outside_int64_raises_value_error(
@@ -733,7 +735,7 @@ def test_register_schema_fast_path_cache_hit(mock_registry: respx.MockRouter) ->
 
     cached = CachedSchema(schema=USER_EVENT_SCHEMA_JSON, global_id=99, content_id=88)
     client = ApicurioRegistryClient(url=REGISTRY_URL, group_id=GROUP_ID)
-    client._schema_cache[(GROUP_ID, "UserEvent")] = cached
+    client._schema_cache.set((GROUP_ID, "UserEvent"), cached)
     result = client.register_schema("UserEvent", USER_EVENT_SCHEMA_JSON)
     assert result is cached
 
@@ -742,57 +744,59 @@ def test_register_schema_double_check_locking(mock_registry: respx.MockRouter) -
     """Exercise the inner double-check path for register_schema.
 
     Simulates a race where another thread populates the cache between
-    the fast-path check and the lock-guarded check.
+    the fast-path peek and the lock-guarded get.
     """
-    from apicurio_serdes._base import CachedSchema
+    from apicurio_serdes._base import CachedSchema, _CacheCore
 
-    cached = CachedSchema(schema=USER_EVENT_SCHEMA_JSON, global_id=99, content_id=88)
+    pre_cached = CachedSchema(
+        schema=USER_EVENT_SCHEMA_JSON, global_id=99, content_id=88
+    )
     client = ApicurioRegistryClient(url=REGISTRY_URL, group_id=GROUP_ID)
 
     cache_key = (GROUP_ID, "UserEvent")
-    check_count: dict[str, int] = {"n": 0}
+    get_count: dict[str, int] = {"n": 0}
 
-    class _RaceDict(dict[tuple[str, str], Any]):
-        def __contains__(self, key: object) -> bool:
+    class _RaceCache(_CacheCore):
+        def get(self, key: object) -> object:
             if key == cache_key:
-                check_count["n"] += 1
-                if check_count["n"] == 1:
-                    return False  # fast-path miss
-                self[cache_key] = cached  # type: ignore[index]
-                return True
-            return super().__contains__(key)
+                get_count["n"] += 1
+                if get_count["n"] == 1:
+                    super().set(cache_key, pre_cached)
+                    return pre_cached
+            return super().get(key)
 
-    client._schema_cache = _RaceDict()  # type: ignore[assignment]
+    client._schema_cache = _RaceCache(max_size=1000, ttl=None)  # type: ignore[assignment]
     result = client.register_schema("UserEvent", USER_EVENT_SCHEMA_JSON)
-    assert result is cached
+    assert result is pre_cached
 
 
 def test_id_cache_double_check_locking(mock_registry: respx.MockRouter) -> None:
-    """Exercise the double-checked locking return path for _id_cache (line 156).
+    """Exercise the double-checked locking return path for _id_cache.
 
     Simulates a race where another thread populates the ID cache between
-    the fast-path check and the lock-guarded check.
+    the fast-path peek and the lock-guarded get.
     """
+    from apicurio_serdes._base import _CacheCore
+
     _id_schema_route(mock_registry, "contentId", 42)
     client = ApicurioRegistryClient(url=REGISTRY_URL, group_id=GROUP_ID)
 
     cached_schema: dict[str, Any] = {"type": "record", "name": "X", "fields": []}
     cache_key = ("contentId", 42)
-    check_count: dict[str, int] = {"n": 0}
+    get_count: dict[str, int] = {"n": 0}
 
-    class _RaceDict(dict[tuple[str, int], Any]):
-        """Dict that misses the first __contains__ then simulates a race fill."""
+    class _RaceCache(_CacheCore):
+        """_CacheCore whose get() simulates a concurrent fill on the first call."""
 
-        def __contains__(self, key: object) -> bool:
+        def get(self, key: object) -> object:
             if key == cache_key:
-                check_count["n"] += 1
-                if check_count["n"] == 1:
-                    return False  # fast-path miss
-                self[cache_key] = cached_schema  # type: ignore[index]
-                return True
-            return super().__contains__(key)
+                get_count["n"] += 1
+                if get_count["n"] == 1:
+                    super().set(cache_key, cached_schema)
+                    return cached_schema
+            return super().get(key)
 
-    client._id_cache = _RaceDict()  # type: ignore[assignment]
+    client._id_cache = _RaceCache(max_size=1000, ttl=None)  # type: ignore[assignment]
     result = client.get_schema_by_content_id(42)
     assert result is cached_schema
 
@@ -1165,3 +1169,156 @@ def test_custom_http_client_not_closed_on_close() -> None:
     )
     client.close()
     mock_client.close.assert_not_called()
+
+
+# ── Cache constructor validation tests ──
+
+
+class TestCacheConstructorValidation:
+    """cache_max_size and cache_ttl_seconds are validated on construction."""
+
+    def test_cache_max_size_zero_raises(self) -> None:
+        with pytest.raises(ValueError, match="cache_max_size"):
+            ApicurioRegistryClient(
+                url=REGISTRY_URL, group_id=GROUP_ID, cache_max_size=0
+            )
+
+    def test_cache_max_size_negative_raises(self) -> None:
+        with pytest.raises(ValueError, match="cache_max_size"):
+            ApicurioRegistryClient(
+                url=REGISTRY_URL, group_id=GROUP_ID, cache_max_size=-1
+            )
+
+    def test_cache_ttl_seconds_zero_raises(self) -> None:
+        with pytest.raises(ValueError, match="cache_ttl_seconds"):
+            ApicurioRegistryClient(
+                url=REGISTRY_URL, group_id=GROUP_ID, cache_ttl_seconds=0
+            )
+
+    def test_cache_ttl_seconds_negative_raises(self) -> None:
+        with pytest.raises(ValueError, match="cache_ttl_seconds"):
+            ApicurioRegistryClient(
+                url=REGISTRY_URL, group_id=GROUP_ID, cache_ttl_seconds=-1.0
+            )
+
+    def test_valid_cache_params_constructs_without_error(self) -> None:
+        client = ApicurioRegistryClient(
+            url=REGISTRY_URL,
+            group_id=GROUP_ID,
+            cache_max_size=1,
+            cache_ttl_seconds=30.0,
+        )
+        assert client is not None
+
+    def test_default_cache_max_size_is_1000(self) -> None:
+        client = ApicurioRegistryClient(url=REGISTRY_URL, group_id=GROUP_ID)
+        assert client._schema_cache._max_size == 1000
+        assert client._id_cache._max_size == 1000
+
+    def test_default_cache_ttl_seconds_is_none(self) -> None:
+        client = ApicurioRegistryClient(url=REGISTRY_URL, group_id=GROUP_ID)
+        assert client._schema_cache._ttl is None
+        assert client._id_cache._ttl is None
+
+    def test_id_cache_always_has_no_ttl(self) -> None:
+        """_id_cache always constructed with ttl=None regardless of cache_ttl_seconds."""
+        client = ApicurioRegistryClient(
+            url=REGISTRY_URL, group_id=GROUP_ID, cache_ttl_seconds=60.0
+        )
+        assert client._id_cache._ttl is None
+        assert client._schema_cache._ttl == 60.0
+
+
+# ── LRU eviction tests for sync client ──
+
+
+class TestSyncClientLRUEviction:
+    """cache_max_size causes LRU eviction in the schema cache."""
+
+    def test_lru_eviction_in_schema_cache(
+        self, mock_registry: respx.MockRouter
+    ) -> None:
+        """With cache_max_size=2, fetching 3 schemas evicts the LRU (first) entry.
+
+        Access sequence: fetch A → fetch B → fetch C (evicts A) → fetch A again
+        (re-fetches, evicts B) → verify B was evicted (needs a new HTTP call).
+        """
+        schema_a = {"type": "record", "name": "A", "fields": []}
+        schema_b = {"type": "record", "name": "B", "fields": []}
+        schema_c = {"type": "record", "name": "C", "fields": []}
+        route_a = _schema_route(
+            mock_registry, "A", schema=schema_a, global_id=1, content_id=1
+        )
+        route_b = _schema_route(
+            mock_registry, "B", schema=schema_b, global_id=2, content_id=2
+        )
+        _schema_route(mock_registry, "C", schema=schema_c, global_id=3, content_id=3)
+
+        client = ApicurioRegistryClient(
+            url=REGISTRY_URL, group_id=GROUP_ID, cache_max_size=2
+        )
+        client.get_schema("A")  # cache: [A]
+        client.get_schema("B")  # cache: [A, B]
+        client.get_schema("C")  # evicts "A" (LRU) → cache: [B, C]
+
+        assert route_a.call_count == 1
+        assert route_b.call_count == 1
+
+        # Re-fetch "A" — must hit HTTP (was evicted); evicts "B" → cache: [C, A]
+        client.get_schema("A")
+        assert route_a.call_count == 2
+
+        # "B" was evicted when "A" was re-inserted — must hit HTTP again
+        client.get_schema("B")
+        assert route_b.call_count == 2
+
+
+# ── TTL expiry tests for sync client ──
+
+
+class TestSyncClientTTLExpiry:
+    """cache_ttl_seconds causes TTL expiry in the schema cache only."""
+
+    def test_schema_cache_hit_before_ttl(self, mock_registry: respx.MockRouter) -> None:
+        """get_schema is a cache hit before TTL elapses."""
+        route = _schema_route(mock_registry, "UserEvent")
+        client = ApicurioRegistryClient(
+            url=REGISTRY_URL, group_id=GROUP_ID, cache_ttl_seconds=60.0
+        )
+        with patch("apicurio_serdes._base.time") as mock_time:
+            mock_time.monotonic.return_value = 100.0
+            client.get_schema("UserEvent")
+            mock_time.monotonic.return_value = 155.0  # within TTL
+            client.get_schema("UserEvent")
+        assert route.call_count == 1
+
+    def test_schema_cache_miss_after_ttl(self, mock_registry: respx.MockRouter) -> None:
+        """get_schema re-fetches from registry after TTL elapses."""
+        route = _schema_route(mock_registry, "UserEvent")
+        client = ApicurioRegistryClient(
+            url=REGISTRY_URL, group_id=GROUP_ID, cache_ttl_seconds=60.0
+        )
+        with patch("apicurio_serdes._base.time") as mock_time:
+            mock_time.monotonic.return_value = 100.0
+            client.get_schema("UserEvent")
+            # Advance past TTL (expiry = 160.0)
+            mock_time.monotonic.return_value = 160.0
+            client.get_schema("UserEvent")
+        assert route.call_count == 2
+
+    def test_id_cache_not_expired_after_ttl(
+        self, mock_registry: respx.MockRouter
+    ) -> None:
+        """ID-based lookups are never expired even when cache_ttl_seconds is set."""
+        route = _id_schema_route(mock_registry, "globalId", GLOBAL_ID)
+        client = ApicurioRegistryClient(
+            url=REGISTRY_URL, group_id=GROUP_ID, cache_ttl_seconds=60.0
+        )
+        with patch("apicurio_serdes._base.time") as mock_time:
+            mock_time.monotonic.return_value = 100.0
+            client.get_schema_by_global_id(GLOBAL_ID)
+            # Advance well past TTL
+            mock_time.monotonic.return_value = 9999.0
+            client.get_schema_by_global_id(GLOBAL_ID)
+        # Still only 1 HTTP call — ID cache never expired
+        assert route.call_count == 1

--- a/tests/test_client.py
+++ b/tests/test_client.py
@@ -2,8 +2,10 @@
 
 from __future__ import annotations
 
+import json
 from concurrent.futures import ThreadPoolExecutor
 from typing import Any
+from unittest.mock import MagicMock, patch
 
 import httpx
 import pytest
@@ -826,3 +828,340 @@ def test_client_accepts_bearer_auth(mock_registry: respx.MockRouter) -> None:
     )
     client.get_schema("Auth")
     assert route.calls[0].request.headers["authorization"] == "Bearer wire-tok"
+
+
+# ── Retry and escape hatch tests (#37) ──
+
+
+def _flaky_schema_handler(n_failures: int) -> Any:
+    """Side-effect handler: raises ConnectError n_failures times, then returns 200."""
+    count = 0
+
+    def _handler(request: httpx.Request) -> httpx.Response:
+        nonlocal count
+        count += 1
+        if count <= n_failures:
+            raise httpx.ConnectError("transient failure")
+        return httpx.Response(
+            200,
+            content=json.dumps(USER_EVENT_SCHEMA_JSON).encode(),
+            headers={
+                "X-Registry-GlobalId": str(GLOBAL_ID),
+                "X-Registry-ContentId": str(CONTENT_ID),
+            },
+        )
+
+    return _handler
+
+
+def _flaky_status_schema_handler(fail_status: int, n_failures: int) -> Any:
+    """Side-effect handler: returns fail_status n_failures times, then returns 200."""
+    count = 0
+
+    def _handler(request: httpx.Request) -> httpx.Response:
+        nonlocal count
+        count += 1
+        if count <= n_failures:
+            return httpx.Response(fail_status)
+        return httpx.Response(
+            200,
+            content=json.dumps(USER_EVENT_SCHEMA_JSON).encode(),
+            headers={
+                "X-Registry-GlobalId": str(GLOBAL_ID),
+                "X-Registry-ContentId": str(CONTENT_ID),
+            },
+        )
+
+    return _handler
+
+
+def _flaky_id_handler(n_failures: int) -> Any:
+    """Side-effect: ConnectError n times then valid schema response (ID endpoint)."""
+    count = 0
+
+    def _handler(request: httpx.Request) -> httpx.Response:
+        nonlocal count
+        count += 1
+        if count <= n_failures:
+            raise httpx.ConnectError("transient failure")
+        return httpx.Response(200, content=json.dumps(USER_EVENT_SCHEMA_JSON).encode())
+
+    return _handler
+
+
+def _flaky_register_handler(n_failures: int) -> Any:
+    """Side-effect: ConnectError n times then valid register response."""
+    count = 0
+
+    def _handler(request: httpx.Request) -> httpx.Response:
+        nonlocal count
+        count += 1
+        if count <= n_failures:
+            raise httpx.ConnectError("transient failure")
+        return httpx.Response(
+            200,
+            json={
+                "artifact": {
+                    "groupId": GROUP_ID,
+                    "artifactId": "UserEvent",
+                    "artifactType": "AVRO",
+                },
+                "version": {
+                    "globalId": GLOBAL_ID,
+                    "contentId": CONTENT_ID,
+                    "artifactType": "AVRO",
+                },
+            },
+        )
+
+    return _handler
+
+
+# Constructor parameter tests
+
+
+def test_init_default_max_retries() -> None:
+    """Default max_retries is 3."""
+    client = ApicurioRegistryClient(url=REGISTRY_URL, group_id=GROUP_ID)
+    assert client.max_retries == 3
+
+
+def test_init_default_retry_backoff_ms() -> None:
+    """Default retry_backoff_ms is 1000."""
+    client = ApicurioRegistryClient(url=REGISTRY_URL, group_id=GROUP_ID)
+    assert client.retry_backoff_ms == 1000
+
+
+def test_init_default_retry_max_backoff_ms() -> None:
+    """Default retry_max_backoff_ms is 20000."""
+    client = ApicurioRegistryClient(url=REGISTRY_URL, group_id=GROUP_ID)
+    assert client.retry_max_backoff_ms == 20000
+
+
+def test_init_custom_max_retries() -> None:
+    """Custom max_retries is stored."""
+    client = ApicurioRegistryClient(url=REGISTRY_URL, group_id=GROUP_ID, max_retries=5)
+    assert client.max_retries == 5
+
+
+def test_init_max_retries_zero_valid() -> None:
+    """max_retries=0 disables retries without error."""
+    client = ApicurioRegistryClient(url=REGISTRY_URL, group_id=GROUP_ID, max_retries=0)
+    assert client.max_retries == 0
+
+
+def test_init_max_retries_negative_raises_value_error() -> None:
+    """max_retries=-1 raises ValueError."""
+    with pytest.raises(ValueError, match="max_retries"):
+        ApicurioRegistryClient(url=REGISTRY_URL, group_id=GROUP_ID, max_retries=-1)
+
+
+# Retry on transport error
+
+
+def test_get_schema_retries_on_connect_error_then_succeeds(
+    mock_registry: respx.MockRouter,
+) -> None:
+    """ConnectError on first attempt retried; schema returned on second attempt."""
+    url = (
+        f"{REGISTRY_URL}/groups/{GROUP_ID}/artifacts/UserEvent/versions/latest/content"
+    )
+    mock_registry.get(url).mock(side_effect=_flaky_schema_handler(1))
+    client = ApicurioRegistryClient(url=REGISTRY_URL, group_id=GROUP_ID)
+    with patch("apicurio_serdes._client.time.sleep"):
+        result = client.get_schema("UserEvent")
+    assert result.schema == USER_EVENT_SCHEMA_JSON
+
+
+def test_get_schema_exhausts_retries_raises_connection_error(
+    mock_registry: respx.MockRouter,
+) -> None:
+    """ConnectError on all attempts raises RegistryConnectionError after max_retries."""
+    from apicurio_serdes._errors import RegistryConnectionError
+
+    url = (
+        f"{REGISTRY_URL}/groups/{GROUP_ID}/artifacts/UserEvent/versions/latest/content"
+    )
+    route = mock_registry.get(url).mock(side_effect=_flaky_schema_handler(99))
+    client = ApicurioRegistryClient(url=REGISTRY_URL, group_id=GROUP_ID, max_retries=2)
+    with (
+        patch("apicurio_serdes._client.time.sleep"),
+        pytest.raises(RegistryConnectionError),
+    ):
+        client.get_schema("UserEvent")
+    assert route.call_count == 3  # 1 initial + 2 retries
+
+
+def test_get_schema_by_global_id_retries_on_connect_error(
+    mock_registry: respx.MockRouter,
+) -> None:
+    """ID lookup retried on ConnectError."""
+    mock_registry.get(url__startswith=f"{REGISTRY_URL}/ids/globalIds/").mock(
+        side_effect=_flaky_id_handler(1)
+    )
+    client = ApicurioRegistryClient(url=REGISTRY_URL, group_id=GROUP_ID)
+    with patch("apicurio_serdes._client.time.sleep"):
+        result = client.get_schema_by_global_id(GLOBAL_ID)
+    assert result == USER_EVENT_SCHEMA_JSON
+
+
+def test_register_schema_retries_on_connect_error(
+    mock_registry: respx.MockRouter,
+) -> None:
+    """register_schema retried on ConnectError."""
+    mock_registry.post(url__startswith=f"{REGISTRY_URL}/groups/").mock(
+        side_effect=_flaky_register_handler(1)
+    )
+    client = ApicurioRegistryClient(url=REGISTRY_URL, group_id=GROUP_ID)
+    with patch("apicurio_serdes._client.time.sleep"):
+        result = client.register_schema("UserEvent", USER_EVENT_SCHEMA_JSON)
+    assert result.global_id == GLOBAL_ID
+
+
+# Retry on retryable HTTP status codes
+
+
+@pytest.mark.parametrize("fail_status", [429, 502, 503, 504])
+def test_get_schema_retries_on_retryable_status(
+    mock_registry: respx.MockRouter, fail_status: int
+) -> None:
+    """Schema GET retried on 429/502/503/504, succeeds on next attempt."""
+    url = (
+        f"{REGISTRY_URL}/groups/{GROUP_ID}/artifacts/UserEvent/versions/latest/content"
+    )
+    mock_registry.get(url).mock(
+        side_effect=_flaky_status_schema_handler(fail_status, 1)
+    )
+    client = ApicurioRegistryClient(url=REGISTRY_URL, group_id=GROUP_ID)
+    with patch("apicurio_serdes._client.time.sleep"):
+        result = client.get_schema("UserEvent")
+    assert result.schema == USER_EVENT_SCHEMA_JSON
+
+
+# No retry on non-retryable errors
+
+
+def test_get_schema_no_retry_on_404(mock_registry: respx.MockRouter) -> None:
+    """404 raises SchemaNotFoundError immediately — no retry."""
+    from apicurio_serdes._errors import SchemaNotFoundError
+
+    url = f"{REGISTRY_URL}/groups/{GROUP_ID}/artifacts/Missing/versions/latest/content"
+    route = mock_registry.get(url).mock(return_value=httpx.Response(404, json={}))
+    client = ApicurioRegistryClient(url=REGISTRY_URL, group_id=GROUP_ID)
+    with pytest.raises(SchemaNotFoundError):
+        client.get_schema("Missing")
+    assert route.call_count == 1
+
+
+def test_get_schema_no_retry_on_400(mock_registry: respx.MockRouter) -> None:
+    """400 raises RegistryConnectionError immediately — no retry."""
+    from apicurio_serdes._errors import RegistryConnectionError
+
+    url = f"{REGISTRY_URL}/groups/{GROUP_ID}/artifacts/Bad/versions/latest/content"
+    route = mock_registry.get(url).mock(return_value=httpx.Response(400))
+    client = ApicurioRegistryClient(url=REGISTRY_URL, group_id=GROUP_ID)
+    with pytest.raises(RegistryConnectionError):
+        client.get_schema("Bad")
+    assert route.call_count == 1
+
+
+def test_get_schema_no_retry_on_500(mock_registry: respx.MockRouter) -> None:
+    """500 raises RegistryConnectionError immediately — not retried (ambiguous)."""
+    from apicurio_serdes._errors import RegistryConnectionError
+
+    url = f"{REGISTRY_URL}/groups/{GROUP_ID}/artifacts/Broken/versions/latest/content"
+    route = mock_registry.get(url).mock(return_value=httpx.Response(500))
+    client = ApicurioRegistryClient(url=REGISTRY_URL, group_id=GROUP_ID)
+    with pytest.raises(RegistryConnectionError):
+        client.get_schema("Broken")
+    assert route.call_count == 1
+
+
+def test_get_schema_max_retries_zero_no_retry(
+    mock_registry: respx.MockRouter,
+) -> None:
+    """max_retries=0 disables retry; ConnectError raises immediately after 1 attempt."""
+    from apicurio_serdes._errors import RegistryConnectionError
+
+    url = (
+        f"{REGISTRY_URL}/groups/{GROUP_ID}/artifacts/UserEvent/versions/latest/content"
+    )
+    route = mock_registry.get(url).mock(side_effect=httpx.ConnectError("refused"))
+    client = ApicurioRegistryClient(url=REGISTRY_URL, group_id=GROUP_ID, max_retries=0)
+    with pytest.raises(RegistryConnectionError):
+        client.get_schema("UserEvent")
+    assert route.call_count == 1
+
+
+def test_get_schema_exhausts_retries_on_503_raises_connection_error(
+    mock_registry: respx.MockRouter,
+) -> None:
+    """When all retries on 503 are exhausted, RegistryConnectionError is raised."""
+    from apicurio_serdes._errors import RegistryConnectionError
+
+    url = (
+        f"{REGISTRY_URL}/groups/{GROUP_ID}/artifacts/UserEvent/versions/latest/content"
+    )
+    mock_registry.get(url).mock(return_value=httpx.Response(503))
+    client = ApicurioRegistryClient(url=REGISTRY_URL, group_id=GROUP_ID, max_retries=1)
+    with (
+        patch("apicurio_serdes._client.time.sleep"),
+        pytest.raises(RegistryConnectionError),
+    ):
+        client.get_schema("UserEvent")
+
+
+# Backoff
+
+
+def test_get_schema_sleep_called_between_retries(
+    mock_registry: respx.MockRouter,
+) -> None:
+    """time.sleep is called with a positive delay between retry attempts."""
+    url = (
+        f"{REGISTRY_URL}/groups/{GROUP_ID}/artifacts/UserEvent/versions/latest/content"
+    )
+    mock_registry.get(url).mock(side_effect=_flaky_schema_handler(1))
+    client = ApicurioRegistryClient(url=REGISTRY_URL, group_id=GROUP_ID)
+    with patch("apicurio_serdes._client.time.sleep") as mock_sleep:
+        client.get_schema("UserEvent")
+    mock_sleep.assert_called_once()
+    delay = mock_sleep.call_args[0][0]
+    assert delay >= 0
+
+
+# Escape hatch: custom http_client
+
+
+def test_custom_http_client_is_used() -> None:
+    """User-provided http_client is used for HTTP requests."""
+    mock_client = MagicMock(spec=httpx.Client)
+    _req = httpx.Request(
+        "GET",
+        f"{REGISTRY_URL}/groups/{GROUP_ID}/artifacts/UserEvent/versions/latest/content",
+    )
+    mock_client.request.return_value = httpx.Response(
+        200,
+        content=json.dumps(USER_EVENT_SCHEMA_JSON).encode(),
+        headers={
+            "X-Registry-GlobalId": str(GLOBAL_ID),
+            "X-Registry-ContentId": str(CONTENT_ID),
+        },
+        request=_req,
+    )
+    client = ApicurioRegistryClient(
+        url=REGISTRY_URL, group_id=GROUP_ID, http_client=mock_client
+    )
+    result = client.get_schema("UserEvent")
+    assert result.schema == USER_EVENT_SCHEMA_JSON
+    assert mock_client.request.called
+
+
+def test_custom_http_client_not_closed_on_close() -> None:
+    """User-provided http_client is not closed when client.close() is called."""
+    mock_client = MagicMock(spec=httpx.Client)
+    client = ApicurioRegistryClient(
+        url=REGISTRY_URL, group_id=GROUP_ID, http_client=mock_client
+    )
+    client.close()
+    mock_client.close.assert_not_called()

--- a/tests/test_deserializer.py
+++ b/tests/test_deserializer.py
@@ -15,8 +15,11 @@ from apicurio_serdes.avro import AvroDeserializer
 from apicurio_serdes.serialization import MessageField, SerializationContext
 from tests.conftest import (
     GROUP_ID,
+    INCOMPATIBLE_READER_SCHEMA,
+    READER_SCHEMA_EVOLUTION,
     REGISTRY_URL,
     VALID_USER_EVENT,
+    WRITER_SCHEMA_EVOLUTION,
     _id_not_found_route,
     _id_schema_route,
     make_confluent_bytes,
@@ -223,3 +226,60 @@ def test_from_dict_error_wrapped(mock_registry: respx.MockRouter) -> None:
     with pytest.raises(DeserializationError, match="from_dict") as exc_info:
         deser(data, _ctx())
     assert isinstance(exc_info.value.__cause__, RuntimeError)
+
+
+# ── Reader schema (schema evolution) ──
+
+
+class TestReaderSchema:
+    """Reader schema support — Avro schema evolution."""
+
+    def test_no_reader_schema_returns_writer_fields_only(
+        self, mock_registry: respx.MockRouter
+    ) -> None:
+        """Default (reader_schema=None) decodes using writer schema — no evolution."""
+        _id_schema_route(
+            mock_registry, "globalId", CONTENT_ID, schema=WRITER_SCHEMA_EVOLUTION
+        )
+        client = ApicurioRegistryClient(url=REGISTRY_URL, group_id=GROUP_ID)
+        deser = AvroDeserializer(registry_client=client)
+        data = make_confluent_bytes(
+            CONTENT_ID, {"userId": "u1"}, schema=WRITER_SCHEMA_EVOLUTION
+        )
+        result = deser(data, _ctx())
+        assert result == {"userId": "u1"}
+        assert "version" not in result
+
+    def test_reader_schema_fills_default_for_added_field(
+        self, mock_registry: respx.MockRouter
+    ) -> None:
+        """reader_schema causes fastavro to fill added field with its default."""
+        _id_schema_route(
+            mock_registry, "globalId", CONTENT_ID, schema=WRITER_SCHEMA_EVOLUTION
+        )
+        client = ApicurioRegistryClient(url=REGISTRY_URL, group_id=GROUP_ID)
+        deser = AvroDeserializer(
+            registry_client=client, reader_schema=READER_SCHEMA_EVOLUTION
+        )
+        data = make_confluent_bytes(
+            CONTENT_ID, {"userId": "u1"}, schema=WRITER_SCHEMA_EVOLUTION
+        )
+        result = deser(data, _ctx())
+        assert result == {"userId": "u1", "version": "v1"}
+
+    def test_incompatible_reader_schema_raises_deserialization_error(
+        self, mock_registry: respx.MockRouter
+    ) -> None:
+        """Incompatible reader/writer schemas wrap fastavro error as DeserializationError."""
+        _id_schema_route(
+            mock_registry, "globalId", CONTENT_ID, schema=WRITER_SCHEMA_EVOLUTION
+        )
+        client = ApicurioRegistryClient(url=REGISTRY_URL, group_id=GROUP_ID)
+        deser = AvroDeserializer(
+            registry_client=client, reader_schema=INCOMPATIBLE_READER_SCHEMA
+        )
+        data = make_confluent_bytes(
+            CONTENT_ID, {"userId": "u1"}, schema=WRITER_SCHEMA_EVOLUTION
+        )
+        with pytest.raises(DeserializationError, match="Avro decode failure"):
+            deser(data, _ctx())

--- a/uv.lock
+++ b/uv.lock
@@ -26,6 +26,7 @@ dependencies = [
 
 [package.dev-dependencies]
 dev = [
+    { name = "bandit" },
     { name = "mypy" },
     { name = "pip-audit" },
     { name = "pytest" },
@@ -51,6 +52,7 @@ requires-dist = [
 
 [package.metadata.requires-dev]
 dev = [
+    { name = "bandit", specifier = ">=1.7.0" },
     { name = "mypy", specifier = ">=1.10.0" },
     { name = "pip-audit", specifier = ">=2.7.0" },
     { name = "pytest", specifier = ">=8.0.0" },
@@ -98,6 +100,21 @@ wheels = [
     { url = "https://files.pythonhosted.org/packages/c5/71/c754b1737ad99102e03fa3235acb6cb6d3ac9d6f596cbc3e5f236705abd8/backrefs-6.2-py313-none-any.whl", hash = "sha256:12df81596ab511f783b7d87c043ce26bc5b0288cf3bb03610fe76b8189282b2b", size = 400747, upload-time = "2026-02-16T19:10:09.791Z" },
     { url = "https://files.pythonhosted.org/packages/af/75/be12ba31a6eb20dccef2320cd8ccb3f7d9013b68ba4c70156259fee9e409/backrefs-6.2-py314-none-any.whl", hash = "sha256:e5f805ae09819caa1aa0623b4a83790e7028604aa2b8c73ba602c4454e665de7", size = 412602, upload-time = "2026-02-16T19:10:12.317Z" },
     { url = "https://files.pythonhosted.org/packages/21/f8/d02f650c47d05034dcd6f9c8cf94f39598b7a89c00ecda0ecb2911bc27e9/backrefs-6.2-py39-none-any.whl", hash = "sha256:664e33cd88c6840b7625b826ecf2555f32d491800900f5a541f772c485f7cda7", size = 381077, upload-time = "2026-02-16T19:10:13.74Z" },
+]
+
+[[package]]
+name = "bandit"
+version = "1.9.4"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "colorama", marker = "sys_platform == 'win32'" },
+    { name = "pyyaml" },
+    { name = "rich" },
+    { name = "stevedore" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/aa/c3/0cb80dfe0f3076e5da7e4c5ad8e57bac6ac357ff4a6406205501cade4965/bandit-1.9.4.tar.gz", hash = "sha256:b589e5de2afe70bd4d53fa0c1da6199f4085af666fde00e8a034f152a52cd628", size = 4242677, upload-time = "2026-02-25T06:44:15.503Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/05/a4/a26d5b25671d27e03afb5401a0be5899d94ff8fab6a698b1ac5be3ec29ef/bandit-1.9.4-py3-none-any.whl", hash = "sha256:f89ffa663767f5a0585ea075f01020207e966a9c0f2b9ef56a57c7963a3f6f8e", size = 134741, upload-time = "2026-02-25T06:44:13.694Z" },
 ]
 
 [[package]]
@@ -1446,6 +1463,15 @@ source = { registry = "https://pypi.org/simple" }
 sdist = { url = "https://files.pythonhosted.org/packages/e8/c4/ba2f8066cceb6f23394729afe52f3bf7adec04bf9ed2c820b39e19299111/sortedcontainers-2.4.0.tar.gz", hash = "sha256:25caa5a06cc30b6b83d11423433f65d1f9d76c4c6a0c90e3379eaa43b9bfdb88", size = 30594, upload-time = "2021-05-16T22:03:42.897Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/32/46/9cb0e58b2deb7f82b84065f37f3bffeb12413f947f9388e4cac22c4621ce/sortedcontainers-2.4.0-py2.py3-none-any.whl", hash = "sha256:a163dcaede0f1c021485e957a39245190e74249897e2ae4b2aa38595db237ee0", size = 29575, upload-time = "2021-05-16T22:03:41.177Z" },
+]
+
+[[package]]
+name = "stevedore"
+version = "5.7.0"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/a2/6d/90764092216fa560f6587f83bb70113a8ba510ba436c6476a2b47359057c/stevedore-5.7.0.tar.gz", hash = "sha256:31dd6fe6b3cbe921e21dcefabc9a5f1cf848cf538a1f27543721b8ca09948aa3", size = 516200, upload-time = "2026-02-20T13:27:06.765Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/69/06/36d260a695f383345ab5bbc3fd447249594ae2fa8dfd19c533d5ae23f46b/stevedore-5.7.0-py3-none-any.whl", hash = "sha256:fd25efbb32f1abb4c9e502f385f0018632baac11f9ee5d1b70f88cc5e22ad4ed", size = 54483, upload-time = "2026-02-20T13:27:05.561Z" },
 ]
 
 [[package]]


### PR DESCRIPTION
## v0.4.0

This PR merges `release/v0.4.0` into `main`.

### What's in this release

**Features**
- `BearerAuth` and `KeycloakAuth` — httpx-compatible authentication handlers for protected registries (#38)
- Retry with exponential backoff and full jitter on transient failures; `http_client` escape hatch (#37)
- `reader_schema` on `AvroDeserializer` / `AsyncAvroDeserializer` for Avro schema evolution (#35)
- `register_schema()` on both clients; `auto_register` on `AvroSerializer` (#36)
- `QualifiedRecordIdStrategy` and `TopicRecordIdStrategy` artifact resolver strategies (#34)
- LRU+TTL cache eviction via `_CacheCore` — `cache_max_size` and `cache_ttl_seconds` on both clients (#39)

**CI / Supply chain**
- SLSA Level 3 provenance on GitHub releases (#64)
- ruff C901 complexity gate and Bandit SAST added to pre-commit (#68)
- CI gating improvements and retroactive signing workflow

**Docs**
- Authentication how-to (EN + FR)
- Schema evolution section in deserializer guide
- Three new exceptions in error-handling how-to
- Full API reference for all public symbols
- French translations synced throughout

### Checklist
- [x] All feature branches merged into `release/v0.4.0`
- [x] Documentation gaps filled (#72 / #74)
- [x] Changelogs updated (EN + FR)

🤖 Generated with [Claude Code](https://claude.com/claude-code)