### PR TITLE
chore: address non-blocking code review notes from v0.4.0

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -37,7 +37,7 @@ jobs:
       actions: read
       id-token: write
       contents: write
-    uses: slsa-framework/slsa-github-generator/.github/workflows/generator_generic_slsa3.yml@v2.1.0
+    uses: slsa-framework/slsa-github-generator/.github/workflows/generator_generic_slsa3.yml@f7dd8c54c2067bafc12ca7a55595d5ee9b75204a  # v2.1.0
     with:
       base64-subjects: "${{ needs.build.outputs.hashes }}"
       upload-assets: true

--- a/.github/workflows/sign-release-retroactive.yml
+++ b/.github/workflows/sign-release-retroactive.yml
@@ -7,6 +7,8 @@ on:
         description: "Release tag to sign (e.g. v0.3.0)"
         required: true
 
+permissions: {}  # deny all at workflow level; job declares only what it needs
+
 jobs:
   sign:
     runs-on: ubuntu-latest

--- a/src/apicurio_serdes/_auth.py
+++ b/src/apicurio_serdes/_auth.py
@@ -222,6 +222,8 @@ class KeycloakAuth(httpx.Auth):
     # ── Async path ──
 
     def _get_async_lock(self) -> asyncio.Lock:
+        # note: this lock is bound to the event loop active on first async use;
+        # do not share a KeycloakAuth instance across multiple event loops.
         if self._async_lock is None:
             self._async_lock = asyncio.Lock()
         return self._async_lock

--- a/src/apicurio_serdes/_base.py
+++ b/src/apicurio_serdes/_base.py
@@ -50,7 +50,11 @@ class _CacheCore:
         self._store: OrderedDict[Any, tuple[Any, float | None]] = OrderedDict()
 
     def peek(self, key: object) -> object:
-        """TTL check without LRU update — safe to call outside a lock (no mutation)."""
+        """TTL check without LRU update — safe to call outside a lock (no mutation).
+
+        "Safe" here means the calling thread holds no lock *but the owning thread is
+        the only writer* — ``OrderedDict.get()`` is not atomic under concurrent resize.
+        """
         raw: tuple[Any, float | None] | None = self._store.get(key)
         if raw is None:
             return self._MISSING
@@ -165,6 +169,7 @@ class _RegistryClientBase:
 
     def _retry_delays(self) -> Iterator[float]:
         """Yield one delay (seconds) per retry attempt, up to max_retries values."""
+        # yields one delay per *retry*; the first attempt happens before any delay
         for attempt in range(self.max_retries):
             yield self._compute_delay(attempt)
 


### PR DESCRIPTION
Closes #77, closes #78.

## Summary

- `_CacheCore.peek()` docstring updated with lock-safety caveat (the "safe" qualifier depends on the owning thread being the only writer)
- `_retry_delays()` gets an inline comment clarifying retries vs attempts semantics
- `KeycloakAuth._get_async_lock()` gets an inline comment on event-loop affinity
- `permissions: {}` deny-all added at workflow level in `sign-release-retroactive.yml` (#78)
- SLSA generator pinned to commit SHA `f7dd8c54` in `publish.yml` instead of mutable tag `v2.1.0`

## Test plan

- [x] 493 tests pass, 100% coverage
- [x] No logic changes — documentation and CI-only fixes