### PR TITLE
fix(ci): pin SLSA generator to commit SHA

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -37,7 +37,7 @@ jobs:
       actions: read
       id-token: write
       contents: write
-    uses: slsa-framework/slsa-github-generator/.github/workflows/generator_generic_slsa3.yml@v2.1.0
+    uses: slsa-framework/slsa-github-generator/.github/workflows/generator_generic_slsa3.yml@f7dd8c54c2067bafc12ca7a55595d5ee9b75204a  # v2.1.0
     with:
       base64-subjects: "${{ needs.build.outputs.hashes }}"
       upload-assets: true


### PR DESCRIPTION
## Summary

- Replaces `@v2.1.0` tag reference with the resolved commit SHA `f7dd8c54c2067bafc12ca7a55595d5ee9b75204a` for the SLSA generator reusable workflow
- Consistent with every other third-party action in the workflow, which are all already SHA-pinned

Closes #79

## Why

A mutable tag reference means a compromised or force-pushed tag could silently swap the workflow used to generate provenance — undermining the supply-chain guarantee the SLSA integration provides. Pinning to a commit SHA makes the action immutable.

## Verification

```bash
gh api repos/slsa-framework/slsa-github-generator/git/ref/tags/v2.1.0 --jq '.object.sha'
# f7dd8c54c2067bafc12ca7a55595d5ee9b75204a
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)