### PR TITLE
fix(ci): run CI on push to release branches for CodeCov BASE reports

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -4,7 +4,7 @@ on:
   pull_request:
     types: [opened, synchronize, reopened, ready_for_review]
   push:
-    branches: [main]
+    branches: [main, "release/v*"]
 
 permissions: {}
 

--- a/tests/ci/test_ci_workflow.py
+++ b/tests/ci/test_ci_workflow.py
@@ -14,7 +14,8 @@ class TestCITriggers:
     def test_triggers_on_push_to_main(self, ci_workflow: dict[str, Any]) -> None:
         triggers = ci_workflow[True]
         assert "push" in triggers
-        assert triggers["push"]["branches"] == ["main"]
+        assert "main" in triggers["push"]["branches"]
+        assert any(b.startswith("release/") for b in triggers["push"]["branches"])
 
     def test_triggers_on_pull_request(self, ci_workflow: dict[str, Any]) -> None:
         triggers = ci_workflow[True]


### PR DESCRIPTION
## Summary

- Adds `release/v*` to the CI push trigger branches alongside `main`

## Problem

CodeCov warns "Please upload report for BASE (release/v0.5.0@ed51cb2)" on every PR targeting the release branch. The root cause: CI only ran on push to `main`, so merges to `release/v*` never uploaded a coverage report — CodeCov had no baseline to diff against.

## Fix

```yaml
push:
  branches: [main, "release/v*"]
```

After merging, the first push to `release/v0.5.0` will upload a coverage report and resolve the CodeCov warning on subsequent PRs.

## Test plan

- [x] CI tests pass (73/73)