### PR TITLE
feat: client authentication — BearerAuth and KeycloakAuth (#38)

### DIFF
--- a/src/apicurio_serdes/_auth.py
+++ b/src/apicurio_serdes/_auth.py
@@ -32,7 +32,8 @@ class BearerAuth(httpx.Auth):
             GCP OIDC identity tokens retrieved via ``google-auth``).
 
     Raises:
-        ValueError: If neither or both of *token* and *token_provider* are given.
+        ValueError: If neither or both of *token* and *token_provider* are given,
+            or if *token* is an empty string.
 
     Example:
         ```python

--- a/src/apicurio_serdes/_auth.py
+++ b/src/apicurio_serdes/_auth.py
@@ -55,13 +55,16 @@ class BearerAuth(httpx.Auth):
             raise ValueError(
                 "BearerAuth requires exactly one of 'token' or 'token_provider'."
             )
+        if token is not None and not token:
+            raise ValueError("BearerAuth 'token' must be a non-empty string.")
         self._token = token
         self._token_provider = token_provider
 
     def _get_token(self) -> str:
         if self._token_provider is not None:
             return self._token_provider()
-        return self._token  # type: ignore[return-value]
+        assert self._token is not None
+        return self._token
 
     def auth_flow(
         self, request: httpx.Request
@@ -222,8 +225,10 @@ class KeycloakAuth(httpx.Auth):
     # ── Async path ──
 
     def _get_async_lock(self) -> asyncio.Lock:
-        # note: this lock is bound to the event loop active on first async use;
-        # do not share a KeycloakAuth instance across multiple event loops.
+        # Note: the Lock is bound to the event loop on which it is first
+        # *awaited*. Do not share a KeycloakAuth instance across multiple
+        # event loops (e.g. separate asyncio.run() calls in tests or
+        # per-request loops in some ASGI frameworks).
         if self._async_lock is None:
             self._async_lock = asyncio.Lock()
         return self._async_lock

--- a/tests/test_auth.py
+++ b/tests/test_auth.py
@@ -71,6 +71,10 @@ class TestBearerAuth:
                 client.get(ARTIFACT_URL)
         assert call_count == 2
 
+    def test_empty_token_raises_value_error(self) -> None:
+        with pytest.raises(ValueError, match="non-empty"):
+            BearerAuth(token="")
+
     def test_no_args_raises_value_error(self) -> None:
         with pytest.raises(ValueError, match="exactly one"):
             BearerAuth()


### PR DESCRIPTION
## Summary

- Add `BearerAuth` (static token or callable provider, covers GCP OIDC and any Bearer scheme)
- Add `KeycloakAuth` (client credentials flow with threshold-based auto-refresh, works sync and async)
- Wire `auth=` kwarg into `ApicurioRegistryClient` and `AsyncApicurioRegistryClient`
- Export `BearerAuth`, `KeycloakAuth`, `AuthenticationError` from top-level package

## Test plan

- [ ] `uv run pytest tests/test_auth.py` passes
- [ ] `uv run pytest` (full suite) passes with 100% coverage
- [ ] `uv run mypy src/` reports zero errors

Closes #38

🤖 Generated with [Claude Code](https://claude.com/claude-code)