### PR TITLE
feat(serdes): add use_latest_version parameter (#40)

### DIFF
--- a/docs/changelog.en.md
+++ b/docs/changelog.en.md
@@ -6,6 +6,13 @@ All user-visible changes are documented here.
 
 ### Added
 
+- `AvroSerializer`, `AvroDeserializer`, and `AsyncAvroDeserializer` now accept
+  `use_latest_version=True`. For the serializer, the flag validates that it is not
+  combined with `auto_register` (they are mutually exclusive). For the deserializers,
+  it enables dynamic reader schema resolution: the latest registry schema for the
+  given `artifact_id` (or `artifact_resolver`) is fetched on the first call and
+  cached per instance. Mutually exclusive with the static `reader_schema` parameter.
+
 - `cache_max_size` (default `1000`) and `cache_ttl_seconds` (default `None`) constructor parameters on both clients.
   `cache_max_size` caps both caches with LRU eviction. `cache_ttl_seconds` enables optional TTL expiry on
   artifact-based lookups (`get_schema`, `register_schema`); ID-based lookups (`get_schema_by_global_id`,

--- a/docs/changelog.fr.md
+++ b/docs/changelog.fr.md
@@ -6,6 +6,14 @@ Toutes les modifications visibles par les utilisateurs sont documentées ici.
 
 ### Ajouts
 
+- `AvroSerializer`, `AvroDeserializer` et `AsyncAvroDeserializer` acceptent
+  désormais `use_latest_version=True`. Pour le sérialiseur, le paramètre valide
+  qu'il n'est pas combiné avec `auto_register` (ils sont mutuellement exclusifs).
+  Pour les désérialiseurs, il active la résolution dynamique du schema lecteur :
+  le schema le plus récent du registre pour l'`artifact_id` (ou `artifact_resolver`)
+  fourni est récupéré au premier appel et mis en cache par instance. Mutuellement
+  exclusif avec le paramètre statique `reader_schema`.
+
 - Paramètres de constructeur `cache_max_size` (défaut `1000`) et `cache_ttl_seconds` (défaut `None`) sur les deux
   clients. `cache_max_size` limite les deux caches avec éviction LRU. `cache_ttl_seconds` active un TTL optionnel sur
   les lookups basés sur l'artifact (`get_schema`, `register_schema`) ; les lookups basés sur l'identifiant

--- a/docs/user-guide/avro-deserializer.en.md
+++ b/docs/user-guide/avro-deserializer.en.md
@@ -28,7 +28,10 @@ record = deserializer(kafka_message.value(), ctx)
 | `registry_client` | `ApicurioRegistryClient` | required | The registry client used to resolve schema identifiers. |
 | `from_dict` | callable | `None` | Optional `(dict, ctx) -> Any` transformation applied after decoding. |
 | `use_id` | `"contentId"` or `"globalId"` | `"globalId"` | How to interpret the 4-byte schema identifier in the wire format header. |
-| `reader_schema` | `dict` | `None` | Optional Avro schema dict used as the reader schema. When provided, fastavro performs schema resolution between the writer schema (from the message) and this schema, enabling field additions with defaults, type promotions, and alias-based renames. Parsed once at construction time. |
+| `artifact_id` | `str` | `None` | Static artifact identifier used to fetch the latest registry schema as the reader schema. Requires `use_latest_version=True`. Mutually exclusive with `artifact_resolver`. |
+| `artifact_resolver` | callable | `None` | Callable `(ctx) -> str` that derives the artifact identifier at call time. Requires `use_latest_version=True`. Mutually exclusive with `artifact_id`. |
+| `use_latest_version` | `bool` | `False` | When `True`, fetches the latest registry schema for the resolved artifact on the first call and uses it as the reader schema (cached per instance). Requires `artifact_id` or `artifact_resolver`. Mutually exclusive with `reader_schema`. |
+| `reader_schema` | `dict` | `None` | Optional Avro schema dict used as the reader schema. When provided, fastavro performs schema resolution between the writer schema (from the message) and this schema, enabling field additions with defaults, type promotions, and alias-based renames. Parsed once at construction time. Mutually exclusive with `use_latest_version`. |
 
 ### Schema identifier mode (`use_id`)
 
@@ -125,6 +128,44 @@ A few things to keep in mind during resolution:
 
 If the schemas are incompatible — say, a new required field has no default — fastavro
 raises a `ValueError` wrapped in `DeserializationError`.
+
+## Dynamic reader schema (`use_latest_version`)
+
+When the consumer schema evolves frequently, maintaining a static `reader_schema` in code
+can be cumbersome. `use_latest_version=True` delegates schema resolution to the registry:
+the deserializer fetches the latest version of the given artifact on the first call and
+uses it as the reader schema, cached for the lifetime of the instance.
+
+```python
+deserializer = AvroDeserializer(
+    client,
+    artifact_id="UserEvent",
+    use_latest_version=True,
+)
+ctx = SerializationContext("user-events", MessageField.VALUE)
+# On the first call, the deserializer fetches the latest "UserEvent" schema
+# from the registry and uses it as the reader schema. Subsequent calls use
+# the cached version — no extra HTTP request.
+record = deserializer(payload, ctx)
+```
+
+You can also use `artifact_resolver` instead of a static `artifact_id`:
+
+```python
+from apicurio_serdes.avro import SimpleTopicIdStrategy
+
+deserializer = AvroDeserializer(
+    client,
+    artifact_resolver=SimpleTopicIdStrategy(),
+    use_latest_version=True,
+)
+```
+
+**Constraints**:
+
+- Requires exactly one of `artifact_id` or `artifact_resolver`.
+- Mutually exclusive with the static `reader_schema` parameter.
+- Providing `artifact_id` or `artifact_resolver` without `use_latest_version=True` raises `ValueError`.
 
 ## Schema caching
 

--- a/docs/user-guide/avro-deserializer.fr.md
+++ b/docs/user-guide/avro-deserializer.fr.md
@@ -28,7 +28,10 @@ record = deserializer(kafka_message.value(), ctx)
 | `registry_client` | `ApicurioRegistryClient` | obligatoire | Le client registry utilisé pour résoudre les identifiants de schema. |
 | `from_dict` | callable | `None` | Transformation optionnelle `(dict, ctx) -> Any` appliquée après le décodage. |
 | `use_id` | `"contentId"` ou `"globalId"` | `"globalId"` | Comment interpréter l'identifiant de schema de 4 octets dans l'en-tête du wire format. |
-| `reader_schema` | `dict` | `None` | Schema Avro optionnel utilisé comme schema lecteur. Quand il est fourni, fastavro effectue une résolution de schema entre le schema d'écriture (issu du message) et ce schema, permettant les ajouts de champs avec valeurs par défaut, les promotions de type et les renommages par alias. Parsé une seule fois à la construction. |
+| `artifact_id` | `str` | `None` | Identifiant d'artifact statique utilisé pour récupérer le schema le plus récent du registry comme schema lecteur. Requiert `use_latest_version=True`. Mutuellement exclusif avec `artifact_resolver`. |
+| `artifact_resolver` | callable | `None` | Callable `(ctx) -> str` qui dérive l'identifiant d'artifact à l'appel. Requiert `use_latest_version=True`. Mutuellement exclusif avec `artifact_id`. |
+| `use_latest_version` | `bool` | `False` | Quand `True`, récupère le schema le plus récent du registry pour l'artifact résolu lors du premier appel et l'utilise comme schema lecteur (mis en cache par instance). Requiert `artifact_id` ou `artifact_resolver`. Mutuellement exclusif avec `reader_schema`. |
+| `reader_schema` | `dict` | `None` | Schema Avro optionnel utilisé comme schema lecteur. Quand il est fourni, fastavro effectue une résolution de schema entre le schema d'écriture (issu du message) et ce schema, permettant les ajouts de champs avec valeurs par défaut, les promotions de type et les renommages par alias. Parsé une seule fois à la construction. Mutuellement exclusif avec `use_latest_version`. |
 
 ### Mode d'identifiant de schema (`use_id`)
 
@@ -125,6 +128,45 @@ Quelques points à garder en tête lors de la résolution :
 
 Si les schemas sont incompatibles — par exemple, un nouveau champ obligatoire sans valeur par
 défaut — fastavro lève une `ValueError` encapsulée dans `DeserializationError`.
+
+## Schema lecteur dynamique (`use_latest_version`)
+
+Lorsque le schema côté consommateur évolue fréquemment, maintenir un `reader_schema`
+statique dans le code peut devenir contraignant. `use_latest_version=True` délègue la
+résolution du schema au registry : le désérialiseur récupère la dernière version de
+l'artifact donné lors du premier appel et l'utilise comme schema lecteur, mis en cache
+pour toute la durée de vie de l'instance.
+
+```python
+deserializer = AvroDeserializer(
+    client,
+    artifact_id="UserEvent",
+    use_latest_version=True,
+)
+ctx = SerializationContext("user-events", MessageField.VALUE)
+# Au premier appel, le désérialiseur récupère le schema "UserEvent" le plus
+# récent depuis le registry et l'utilise comme schema lecteur. Les appels
+# suivants utilisent la version mise en cache — aucune requête HTTP supplémentaire.
+record = deserializer(payload, ctx)
+```
+
+Vous pouvez également utiliser `artifact_resolver` à la place d'un `artifact_id` statique :
+
+```python
+from apicurio_serdes.avro import SimpleTopicIdStrategy
+
+deserializer = AvroDeserializer(
+    client,
+    artifact_resolver=SimpleTopicIdStrategy(),
+    use_latest_version=True,
+)
+```
+
+**Contraintes** :
+
+- Requiert exactement l'un de `artifact_id` ou `artifact_resolver`.
+- Mutuellement exclusif avec le paramètre statique `reader_schema`.
+- Fournir `artifact_id` ou `artifact_resolver` sans `use_latest_version=True` lève une `ValueError`.
 
 ## Mise en cache du schema
 

--- a/docs/user-guide/avro-serializer.en.md
+++ b/docs/user-guide/avro-serializer.en.md
@@ -32,6 +32,7 @@ payload = serializer({"userId": "abc-123", "country": "FR"}, ctx)
 | `to_dict` | callable | `None` | Converts non-dict input to a dict before encoding. See [Custom Serialization](../how-to/custom-serialization.md). |
 | `use_id` | `"globalId"` or `"contentId"` | `"globalId"` | Which schema identifier to embed in the wire format header. See [Choosing Between globalId and contentId](../how-to/identifier-selection.md). |
 | `strict` | `bool` | `False` | Reject input fields not present in the schema with `ValueError`. |
+| `use_latest_version` | `bool` | `False` | Reserved for API consistency with `AvroDeserializer`. Must not be combined with `auto_register=True` (they are mutually exclusive). Has no effect on serialization behaviour. |
 
 ## Artifact resolver strategies
 

--- a/docs/user-guide/avro-serializer.fr.md
+++ b/docs/user-guide/avro-serializer.fr.md
@@ -33,6 +33,7 @@ payload = serializer({"userId": "abc-123", "country": "FR"}, ctx)
 | `to_dict` | callable | `None` | Convertit une entrée non-dict en dict avant l'encodage. Voir [Sérialisation personnalisée](../how-to/custom-serialization.md). |
 | `use_id` | `"globalId"` ou `"contentId"` | `"globalId"` | L'identifiant de schema à intégrer dans l'en-tête du wire format. Voir [Choisir entre globalId et contentId](../how-to/identifier-selection.md). |
 | `strict` | `bool` | `False` | Rejette les champs d'entrée absents du schema avec une `ValueError`. |
+| `use_latest_version` | `bool` | `False` | Réservé pour la cohérence d'API avec `AvroDeserializer`. Ne peut pas être combiné avec `auto_register=True` (ils sont mutuellement exclusifs). N'a aucun effet sur le comportement de sérialisation. |
 
 ## Stratégies de résolution d'artifact
 

--- a/src/apicurio_serdes/avro/_async_deserializer.py
+++ b/src/apicurio_serdes/avro/_async_deserializer.py
@@ -35,6 +35,20 @@ class AsyncAvroDeserializer(_BaseAvroDeserializer):
         use_id: Which registry identifier type the 4-byte wire format
                 field represents. Must match the serializer's use_id
                 setting. Defaults to "globalId".
+        artifact_id: Artifact identifier used to fetch the latest registry
+                     schema as the reader schema. Requires
+                     ``use_latest_version=True``. Mutually exclusive with
+                     ``artifact_resolver``.
+        artifact_resolver: Callable ``(ctx) -> str`` that returns the
+                           artifact identifier at call time. Requires
+                           ``use_latest_version=True``. Mutually exclusive
+                           with ``artifact_id``. The resolved value is cached
+                           after the first successful call.
+        use_latest_version: When ``True``, fetches the latest registry schema
+                            for the resolved artifact on the first call and
+                            uses it as the reader schema (cached per instance).
+                            Requires ``artifact_id`` or ``artifact_resolver``.
+                            Mutually exclusive with ``reader_schema``.
         reader_schema: Optional Avro schema dict used as the reader schema
                        during deserialization. When provided, fastavro
                        performs schema resolution between the writer schema
@@ -43,6 +57,16 @@ class AsyncAvroDeserializer(_BaseAvroDeserializer):
                        type promotions, and other Avro evolution rules. When
                        None (default), the writer schema is used for both
                        roles (no evolution). Parsed once at construction time.
+                       Mutually exclusive with ``use_latest_version``.
+
+    Raises:
+        ValueError: If ``artifact_id`` and ``artifact_resolver`` are both
+                    provided, if ``use_latest_version=True`` is used without
+                    ``artifact_id`` or ``artifact_resolver``, if
+                    ``use_latest_version=True`` is combined with
+                    ``reader_schema``, or if ``artifact_id`` /
+                    ``artifact_resolver`` is provided without
+                    ``use_latest_version=True``.
 
     Example:
         ```python

--- a/src/apicurio_serdes/avro/_async_deserializer.py
+++ b/src/apicurio_serdes/avro/_async_deserializer.py
@@ -5,6 +5,8 @@ from __future__ import annotations
 import struct
 from typing import TYPE_CHECKING, Any
 
+import fastavro
+
 from apicurio_serdes._errors import DeserializationError
 from apicurio_serdes.avro._deserializer import _BaseAvroDeserializer
 
@@ -13,6 +15,7 @@ if TYPE_CHECKING:
     from typing import Literal
 
     from apicurio_serdes._async_client import AsyncApicurioRegistryClient
+    from apicurio_serdes.avro._strategies import ArtifactResolver
     from apicurio_serdes.serialization import SerializationContext
 
 
@@ -65,10 +68,18 @@ class AsyncAvroDeserializer(_BaseAvroDeserializer):
         from_dict: Callable[[dict[str, Any], SerializationContext], Any] | None = None,
         use_id: Literal["globalId", "contentId"] = "globalId",
         *,
+        artifact_id: str | None = None,
+        artifact_resolver: ArtifactResolver | None = None,
+        use_latest_version: bool = False,
         reader_schema: dict[str, Any] | None = None,
     ) -> None:
         super().__init__(
-            from_dict=from_dict, use_id=use_id, reader_schema=reader_schema
+            from_dict=from_dict,
+            use_id=use_id,
+            reader_schema=reader_schema,
+            artifact_id=artifact_id,
+            artifact_resolver=artifact_resolver,
+            use_latest_version=use_latest_version,
         )
         self.registry_client = registry_client
 
@@ -112,5 +123,10 @@ class AsyncAvroDeserializer(_BaseAvroDeserializer):
             schema_dict = await self.registry_client.get_schema_by_global_id(schema_id)
         else:
             schema_dict = await self.registry_client.get_schema_by_content_id(schema_id)
+
+        if self._use_latest_version and self._parsed_reader_schema is None:
+            effective_id = self._resolve_artifact_id(ctx)
+            cached = await self.registry_client.get_schema(effective_id)
+            self._parsed_reader_schema = fastavro.parse_schema(cached.schema)
 
         return self._decode(schema_id, schema_dict, data[5:], ctx)

--- a/src/apicurio_serdes/avro/_async_deserializer.py
+++ b/src/apicurio_serdes/avro/_async_deserializer.py
@@ -130,6 +130,9 @@ class AsyncAvroDeserializer(_BaseAvroDeserializer):
                 correspond to any schema in the registry.
             RegistryConnectionError: If the registry is unreachable
                 during schema resolution.
+            ResolverError: If ``use_latest_version=True`` with an
+                ``artifact_resolver`` and the resolver raises or returns
+                a non-string value.
         """
         if len(data) < 5:
             raise DeserializationError(

--- a/src/apicurio_serdes/avro/_deserializer.py
+++ b/src/apicurio_serdes/avro/_deserializer.py
@@ -234,6 +234,9 @@ class AvroDeserializer(_BaseAvroDeserializer):
                 to any schema in the registry (FR-010).
             RegistryConnectionError: If the registry is unreachable during
                 schema resolution (FR-012).
+            ResolverError: If ``use_latest_version=True`` with an
+                ``artifact_resolver`` and the resolver raises or returns
+                a non-string value.
         """
         # FR-004: validate minimum length
         if len(data) < 5:

--- a/src/apicurio_serdes/avro/_deserializer.py
+++ b/src/apicurio_serdes/avro/_deserializer.py
@@ -135,6 +135,20 @@ class AvroDeserializer(_BaseAvroDeserializer):
         use_id: Which registry identifier type the 4-byte wire format
                 field represents. Must match the serializer's use_id
                 setting. Defaults to "globalId".
+        artifact_id: Artifact identifier used to fetch the latest registry
+                     schema as the reader schema. Requires
+                     ``use_latest_version=True``. Mutually exclusive with
+                     ``artifact_resolver``.
+        artifact_resolver: Callable ``(ctx) -> str`` that returns the
+                           artifact identifier at call time. Requires
+                           ``use_latest_version=True``. Mutually exclusive
+                           with ``artifact_id``. The resolved value is cached
+                           after the first successful call.
+        use_latest_version: When ``True``, fetches the latest registry schema
+                            for the resolved artifact on the first call and
+                            uses it as the reader schema (cached per instance).
+                            Requires ``artifact_id`` or ``artifact_resolver``.
+                            Mutually exclusive with ``reader_schema``.
         reader_schema: Optional Avro schema dict used as the reader schema
                        during deserialization. When provided, fastavro
                        performs schema resolution between the writer schema
@@ -143,6 +157,36 @@ class AvroDeserializer(_BaseAvroDeserializer):
                        type promotions, and other Avro evolution rules. When
                        None (default), the writer schema is used for both
                        roles (no evolution). Parsed once at construction time.
+                       Mutually exclusive with ``use_latest_version``.
+
+    Raises:
+        ValueError: If ``artifact_id`` and ``artifact_resolver`` are both
+                    provided, if ``use_latest_version=True`` is used without
+                    ``artifact_id`` or ``artifact_resolver``, if
+                    ``use_latest_version=True`` is combined with
+                    ``reader_schema``, or if ``artifact_id`` /
+                    ``artifact_resolver`` is provided without
+                    ``use_latest_version=True``.
+
+    Example:
+        ```python
+        from apicurio_serdes import ApicurioRegistryClient
+        from apicurio_serdes.avro import AvroDeserializer
+        from apicurio_serdes.serialization import SerializationContext, MessageField
+
+        client = ApicurioRegistryClient(
+            url="http://localhost:8080/apis/registry/v3",
+            group_id="com.example.schemas",
+        )
+        # Dynamically use the latest registry schema as the reader schema:
+        deserializer = AvroDeserializer(
+            registry_client=client,
+            artifact_id="UserEvent",
+            use_latest_version=True,
+        )
+        ctx = SerializationContext(topic="user-events", field=MessageField.VALUE)
+        result = deserializer(raw_bytes, ctx)
+        ```
     """
 
     def __init__(

--- a/src/apicurio_serdes/avro/_deserializer.py
+++ b/src/apicurio_serdes/avro/_deserializer.py
@@ -8,13 +8,14 @@ from typing import TYPE_CHECKING, Any
 
 import fastavro
 
-from apicurio_serdes._errors import DeserializationError
+from apicurio_serdes._errors import DeserializationError, ResolverError
 
 if TYPE_CHECKING:
     from collections.abc import Callable
     from typing import Literal
 
     from apicurio_serdes._client import ApicurioRegistryClient
+    from apicurio_serdes.avro._strategies import ArtifactResolver
     from apicurio_serdes.serialization import SerializationContext
 
 
@@ -26,13 +27,63 @@ class _BaseAvroDeserializer:
         from_dict: Callable[[dict[str, Any], SerializationContext], Any] | None,
         use_id: Literal["globalId", "contentId"],
         reader_schema: dict[str, Any] | None,
+        artifact_id: str | None = None,
+        artifact_resolver: ArtifactResolver | None = None,
+        use_latest_version: bool = False,
     ) -> None:
+        if artifact_id is not None and artifact_resolver is not None:
+            raise ValueError(
+                "artifact_id and artifact_resolver are mutually exclusive."
+            )
+        has_artifact_source = artifact_id is not None or artifact_resolver is not None
+        if use_latest_version and not has_artifact_source:
+            raise ValueError(
+                "use_latest_version=True requires artifact_id or artifact_resolver."
+            )
+        if use_latest_version and reader_schema is not None:
+            raise ValueError(
+                "use_latest_version and reader_schema are mutually exclusive."
+            )
+        if has_artifact_source and not use_latest_version:
+            raise ValueError(
+                "artifact_id and artifact_resolver require use_latest_version=True."
+            )
         self.from_dict = from_dict
         self.use_id = use_id
+        self._artifact_id = artifact_id
+        self._artifact_resolver: ArtifactResolver | None = artifact_resolver
+        self._resolved_artifact_id: str | None = None
+        self._use_latest_version = use_latest_version
         self._parsed_cache: dict[int, Any] = {}
         self._parsed_reader_schema = (
             fastavro.parse_schema(reader_schema) if reader_schema is not None else None
         )
+
+    def _resolve_artifact_id(self, ctx: SerializationContext) -> str:
+        """Resolve artifact_id from static value or resolver, with caching."""
+        if self._artifact_resolver is not None and self._resolved_artifact_id is None:
+            try:
+                resolved = self._artifact_resolver(ctx)
+            except Exception as exc:
+                raise ResolverError(
+                    f"artifact_resolver raised: {exc}", cause=exc
+                ) from exc
+            if not isinstance(resolved, str) or not resolved:
+                raise ResolverError(
+                    f"artifact_resolver must return a non-empty str, got {resolved!r}"
+                )
+            self._resolved_artifact_id = resolved
+        effective_id = (
+            self._artifact_id
+            if self._artifact_id is not None
+            else self._resolved_artifact_id
+        )
+        if effective_id is None:  # pragma: no cover
+            raise RuntimeError(
+                "artifact_id is None and no resolver produced an ID; "
+                "this is an internal invariant violation."
+            )
+        return effective_id
 
     def _decode(
         self,
@@ -100,10 +151,18 @@ class AvroDeserializer(_BaseAvroDeserializer):
         from_dict: Callable[[dict[str, Any], SerializationContext], Any] | None = None,
         use_id: Literal["globalId", "contentId"] = "globalId",
         *,
+        artifact_id: str | None = None,
+        artifact_resolver: ArtifactResolver | None = None,
+        use_latest_version: bool = False,
         reader_schema: dict[str, Any] | None = None,
     ) -> None:
         super().__init__(
-            from_dict=from_dict, use_id=use_id, reader_schema=reader_schema
+            from_dict=from_dict,
+            use_id=use_id,
+            reader_schema=reader_schema,
+            artifact_id=artifact_id,
+            artifact_resolver=artifact_resolver,
+            use_latest_version=use_latest_version,
         )
         self.registry_client = registry_client
 
@@ -152,5 +211,10 @@ class AvroDeserializer(_BaseAvroDeserializer):
             schema_dict = self.registry_client.get_schema_by_global_id(schema_id)
         else:
             schema_dict = self.registry_client.get_schema_by_content_id(schema_id)
+
+        if self._use_latest_version and self._parsed_reader_schema is None:
+            effective_id = self._resolve_artifact_id(ctx)
+            cached = self.registry_client.get_schema(effective_id)
+            self._parsed_reader_schema = fastavro.parse_schema(cached.schema)
 
         return self._decode(schema_id, schema_dict, data[5:], ctx)

--- a/src/apicurio_serdes/avro/_serializer.py
+++ b/src/apicurio_serdes/avro/_serializer.py
@@ -112,6 +112,7 @@ class AvroSerializer:
         use_id: Literal["globalId", "contentId"] = "globalId",
         strict: bool = False,
         wire_format: WireFormat = WireFormat.CONFLUENT_PAYLOAD,
+        use_latest_version: bool = False,
     ) -> None:
         if artifact_id is not None and artifact_resolver is not None:
             raise ValueError(
@@ -135,6 +136,10 @@ class AvroSerializer:
             )
         if auto_register and schema is None:
             raise ValueError("schema must be provided when auto_register=True")
+        if use_latest_version and auto_register:
+            raise ValueError(
+                "use_latest_version and auto_register are mutually exclusive."
+            )
         self.registry_client = registry_client
         self.artifact_id: str | None = artifact_id
         self._artifact_resolver: ArtifactResolver | None = artifact_resolver
@@ -146,6 +151,7 @@ class AvroSerializer:
         self.use_id = use_id
         self.strict = strict
         self.wire_format = wire_format
+        self.use_latest_version = use_latest_version
         self._schema: CachedSchema | None = None
         self._parsed_schema: str | list[Any] | dict[Any, Any] | None = None
 

--- a/src/apicurio_serdes/avro/_serializer.py
+++ b/src/apicurio_serdes/avro/_serializer.py
@@ -61,13 +61,18 @@ class AvroSerializer:
         strict: When ``True``, reject extra fields not in the schema.
         wire_format: The wire format framing mode. Defaults to
                      WireFormat.CONFLUENT_PAYLOAD (FR-003).
+        use_latest_version: Reserved flag for API consistency with
+                            ``AvroDeserializer``. Must not be combined with
+                            ``auto_register=True`` (they are mutually
+                            exclusive). Defaults to ``False``.
 
     Raises:
         ValueError: If both or neither of ``artifact_id`` / ``artifact_resolver``
             are provided; if ``wire_format`` is not a WireFormat enum member;
             if ``use_id`` is not ``"globalId"`` or ``"contentId"``; if
-            ``if_exists`` is not one of the four allowed values; or if
-            ``auto_register=True`` and ``schema`` is not provided.
+            ``if_exists`` is not one of the four allowed values; if
+            ``auto_register=True`` and ``schema`` is not provided; or if
+            ``use_latest_version=True`` and ``auto_register=True``.
 
     Example:
         ```python

--- a/tests/test_async_deserializer.py
+++ b/tests/test_async_deserializer.py
@@ -20,6 +20,7 @@ from tests.conftest import (
     VALID_USER_EVENT,
     WRITER_SCHEMA_EVOLUTION,
     _id_schema_route,
+    _schema_route,
     make_confluent_bytes,
 )
 
@@ -358,3 +359,119 @@ class TestReaderSchema:
         )
         with pytest.raises(DeserializationError, match="Avro decode failure"):
             await deser(data, _ctx())
+
+
+class TestUseLatestVersion:
+    """AsyncAvroDeserializer use_latest_version feature."""
+
+    def test_use_latest_version_without_artifact_raises(self) -> None:
+        """use_latest_version=True without artifact_id or artifact_resolver raises ValueError."""
+        client = AsyncApicurioRegistryClient(url=REGISTRY_URL, group_id=GROUP_ID)
+        with pytest.raises(ValueError, match="artifact_id or artifact_resolver"):
+            AsyncAvroDeserializer(registry_client=client, use_latest_version=True)
+
+    def test_use_latest_version_with_reader_schema_raises(self) -> None:
+        """use_latest_version=True + reader_schema raises ValueError (mutually exclusive)."""
+        client = AsyncApicurioRegistryClient(url=REGISTRY_URL, group_id=GROUP_ID)
+        with pytest.raises(ValueError, match="mutually exclusive"):
+            AsyncAvroDeserializer(
+                registry_client=client,
+                artifact_id="UserEvent",
+                use_latest_version=True,
+                reader_schema=READER_SCHEMA_EVOLUTION,
+            )
+
+    def test_artifact_id_and_resolver_raises(self) -> None:
+        """artifact_id + artifact_resolver raises ValueError (mutually exclusive)."""
+        from apicurio_serdes.avro import SimpleTopicIdStrategy
+
+        client = AsyncApicurioRegistryClient(url=REGISTRY_URL, group_id=GROUP_ID)
+        with pytest.raises(ValueError, match="mutually exclusive"):
+            AsyncAvroDeserializer(
+                registry_client=client,
+                artifact_id="UserEvent",
+                artifact_resolver=SimpleTopicIdStrategy(),
+                use_latest_version=True,
+            )
+
+    def test_artifact_id_without_use_latest_version_raises(self) -> None:
+        """artifact_id without use_latest_version=True raises ValueError."""
+        client = AsyncApicurioRegistryClient(url=REGISTRY_URL, group_id=GROUP_ID)
+        with pytest.raises(ValueError, match="use_latest_version"):
+            AsyncAvroDeserializer(registry_client=client, artifact_id="UserEvent")
+
+    async def test_use_latest_version_with_artifact_id_fills_default(
+        self, mock_registry: respx.MockRouter
+    ) -> None:
+        """use_latest_version=True + artifact_id uses latest schema as reader schema."""
+        _schema_route(mock_registry, "UserEvent", schema=READER_SCHEMA_EVOLUTION)
+        _id_schema_route(
+            mock_registry, "globalId", CONTENT_ID, schema=WRITER_SCHEMA_EVOLUTION
+        )
+        client = AsyncApicurioRegistryClient(url=REGISTRY_URL, group_id=GROUP_ID)
+        deser = AsyncAvroDeserializer(
+            registry_client=client,
+            artifact_id="UserEvent",
+            use_latest_version=True,
+        )
+        data = make_confluent_bytes(
+            CONTENT_ID, {"userId": "u1"}, schema=WRITER_SCHEMA_EVOLUTION
+        )
+        result = await deser(data, _ctx())
+        assert result == {"userId": "u1", "version": "v1"}
+
+    async def test_use_latest_version_with_artifact_resolver_fills_default(
+        self, mock_registry: respx.MockRouter
+    ) -> None:
+        """use_latest_version=True + artifact_resolver uses latest schema as reader schema."""
+        from apicurio_serdes.avro import SimpleTopicIdStrategy
+
+        _schema_route(mock_registry, "test", schema=READER_SCHEMA_EVOLUTION)
+        _id_schema_route(
+            mock_registry, "globalId", CONTENT_ID, schema=WRITER_SCHEMA_EVOLUTION
+        )
+        client = AsyncApicurioRegistryClient(url=REGISTRY_URL, group_id=GROUP_ID)
+        deser = AsyncAvroDeserializer(
+            registry_client=client,
+            artifact_resolver=SimpleTopicIdStrategy(),
+            use_latest_version=True,
+        )
+        data = make_confluent_bytes(
+            CONTENT_ID, {"userId": "u1"}, schema=WRITER_SCHEMA_EVOLUTION
+        )
+        result = await deser(data, _ctx())
+        assert result == {"userId": "u1", "version": "v1"}
+
+    async def test_use_latest_version_reader_schema_cached(
+        self, mock_registry: respx.MockRouter
+    ) -> None:
+        """use_latest_version=True: second call does not re-fetch the latest schema."""
+        schema_route = _schema_route(
+            mock_registry, "UserEvent", schema=READER_SCHEMA_EVOLUTION
+        )
+        _id_schema_route(
+            mock_registry, "globalId", CONTENT_ID, schema=WRITER_SCHEMA_EVOLUTION
+        )
+        client = AsyncApicurioRegistryClient(url=REGISTRY_URL, group_id=GROUP_ID)
+        deser = AsyncAvroDeserializer(
+            registry_client=client,
+            artifact_id="UserEvent",
+            use_latest_version=True,
+        )
+        data = make_confluent_bytes(
+            CONTENT_ID, {"userId": "u1"}, schema=WRITER_SCHEMA_EVOLUTION
+        )
+        await deser(data, _ctx())
+        await deser(data, _ctx())
+        assert schema_route.call_count == 1
+
+    async def test_use_latest_version_false_is_backward_compatible(
+        self, mock_registry: respx.MockRouter
+    ) -> None:
+        """use_latest_version=False (default) with no artifact params works as before."""
+        _id_schema_route(mock_registry, "globalId", CONTENT_ID)
+        client = AsyncApicurioRegistryClient(url=REGISTRY_URL, group_id=GROUP_ID)
+        deser = AsyncAvroDeserializer(registry_client=client)
+        data = make_confluent_bytes(CONTENT_ID, VALID_USER_EVENT)
+        result = await deser(data, _ctx())
+        assert result == VALID_USER_EVENT

--- a/tests/test_async_deserializer.py
+++ b/tests/test_async_deserializer.py
@@ -475,3 +475,53 @@ class TestUseLatestVersion:
         data = make_confluent_bytes(CONTENT_ID, VALID_USER_EVENT)
         result = await deser(data, _ctx())
         assert result == VALID_USER_EVENT
+
+    async def test_resolver_raises_wraps_as_resolver_error(
+        self, mock_registry: respx.MockRouter
+    ) -> None:
+        """artifact_resolver that raises is wrapped as ResolverError."""
+        from apicurio_serdes._errors import ResolverError
+
+        _id_schema_route(
+            mock_registry, "globalId", CONTENT_ID, schema=WRITER_SCHEMA_EVOLUTION
+        )
+
+        def bad_resolver(ctx: object) -> str:
+            raise RuntimeError("boom")
+
+        client = AsyncApicurioRegistryClient(url=REGISTRY_URL, group_id=GROUP_ID)
+        deser = AsyncAvroDeserializer(
+            registry_client=client,
+            artifact_resolver=bad_resolver,
+            use_latest_version=True,
+        )
+        data = make_confluent_bytes(
+            CONTENT_ID, {"userId": "u1"}, schema=WRITER_SCHEMA_EVOLUTION
+        )
+        with pytest.raises(ResolverError, match="artifact_resolver raised"):
+            await deser(data, _ctx())
+
+    async def test_resolver_returns_non_string_raises_resolver_error(
+        self, mock_registry: respx.MockRouter
+    ) -> None:
+        """artifact_resolver returning non-string raises ResolverError."""
+        from apicurio_serdes._errors import ResolverError
+
+        _id_schema_route(
+            mock_registry, "globalId", CONTENT_ID, schema=WRITER_SCHEMA_EVOLUTION
+        )
+
+        def bad_resolver(ctx: object) -> str:
+            return 42  # type: ignore[return-value]
+
+        client = AsyncApicurioRegistryClient(url=REGISTRY_URL, group_id=GROUP_ID)
+        deser = AsyncAvroDeserializer(
+            registry_client=client,
+            artifact_resolver=bad_resolver,
+            use_latest_version=True,
+        )
+        data = make_confluent_bytes(
+            CONTENT_ID, {"userId": "u1"}, schema=WRITER_SCHEMA_EVOLUTION
+        )
+        with pytest.raises(ResolverError, match="non-empty str"):
+            await deser(data, _ctx())

--- a/tests/test_deserializer.py
+++ b/tests/test_deserializer.py
@@ -22,6 +22,7 @@ from tests.conftest import (
     WRITER_SCHEMA_EVOLUTION,
     _id_not_found_route,
     _id_schema_route,
+    _schema_route,
     make_confluent_bytes,
 )
 
@@ -282,4 +283,170 @@ class TestReaderSchema:
             CONTENT_ID, {"userId": "u1"}, schema=WRITER_SCHEMA_EVOLUTION
         )
         with pytest.raises(DeserializationError, match="Avro decode failure"):
+            deser(data, _ctx())
+
+
+class TestUseLatestVersion:
+    """AvroDeserializer use_latest_version feature."""
+
+    def test_use_latest_version_without_artifact_raises(self) -> None:
+        """use_latest_version=True without artifact_id or artifact_resolver raises ValueError."""
+        client = ApicurioRegistryClient(url=REGISTRY_URL, group_id=GROUP_ID)
+        with pytest.raises(ValueError, match="artifact_id or artifact_resolver"):
+            AvroDeserializer(registry_client=client, use_latest_version=True)
+
+    def test_use_latest_version_with_reader_schema_raises(self) -> None:
+        """use_latest_version=True + reader_schema raises ValueError (mutually exclusive)."""
+        client = ApicurioRegistryClient(url=REGISTRY_URL, group_id=GROUP_ID)
+        with pytest.raises(ValueError, match="mutually exclusive"):
+            AvroDeserializer(
+                registry_client=client,
+                artifact_id="UserEvent",
+                use_latest_version=True,
+                reader_schema=READER_SCHEMA_EVOLUTION,
+            )
+
+    def test_artifact_id_and_resolver_raises(self) -> None:
+        """artifact_id + artifact_resolver raises ValueError (mutually exclusive)."""
+        from apicurio_serdes.avro import SimpleTopicIdStrategy
+
+        client = ApicurioRegistryClient(url=REGISTRY_URL, group_id=GROUP_ID)
+        with pytest.raises(ValueError, match="mutually exclusive"):
+            AvroDeserializer(
+                registry_client=client,
+                artifact_id="UserEvent",
+                artifact_resolver=SimpleTopicIdStrategy(),
+                use_latest_version=True,
+            )
+
+    def test_artifact_id_without_use_latest_version_raises(self) -> None:
+        """artifact_id without use_latest_version=True raises ValueError."""
+        client = ApicurioRegistryClient(url=REGISTRY_URL, group_id=GROUP_ID)
+        with pytest.raises(ValueError, match="use_latest_version"):
+            AvroDeserializer(registry_client=client, artifact_id="UserEvent")
+
+    def test_use_latest_version_with_artifact_id_fills_default(
+        self, mock_registry: respx.MockRouter
+    ) -> None:
+        """use_latest_version=True + artifact_id uses latest schema as reader schema."""
+        _schema_route(mock_registry, "UserEvent", schema=READER_SCHEMA_EVOLUTION)
+        _id_schema_route(
+            mock_registry, "globalId", CONTENT_ID, schema=WRITER_SCHEMA_EVOLUTION
+        )
+        client = ApicurioRegistryClient(url=REGISTRY_URL, group_id=GROUP_ID)
+        deser = AvroDeserializer(
+            registry_client=client,
+            artifact_id="UserEvent",
+            use_latest_version=True,
+        )
+        data = make_confluent_bytes(
+            CONTENT_ID, {"userId": "u1"}, schema=WRITER_SCHEMA_EVOLUTION
+        )
+        result = deser(data, _ctx())
+        assert result == {"userId": "u1", "version": "v1"}
+
+    def test_use_latest_version_with_artifact_resolver_fills_default(
+        self, mock_registry: respx.MockRouter
+    ) -> None:
+        """use_latest_version=True + artifact_resolver uses latest schema as reader schema."""
+        from apicurio_serdes.avro import SimpleTopicIdStrategy
+
+        _schema_route(mock_registry, "test", schema=READER_SCHEMA_EVOLUTION)
+        _id_schema_route(
+            mock_registry, "globalId", CONTENT_ID, schema=WRITER_SCHEMA_EVOLUTION
+        )
+        client = ApicurioRegistryClient(url=REGISTRY_URL, group_id=GROUP_ID)
+        deser = AvroDeserializer(
+            registry_client=client,
+            artifact_resolver=SimpleTopicIdStrategy(),
+            use_latest_version=True,
+        )
+        data = make_confluent_bytes(
+            CONTENT_ID, {"userId": "u1"}, schema=WRITER_SCHEMA_EVOLUTION
+        )
+        result = deser(data, _ctx())
+        assert result == {"userId": "u1", "version": "v1"}
+
+    def test_use_latest_version_reader_schema_cached(
+        self, mock_registry: respx.MockRouter
+    ) -> None:
+        """use_latest_version=True: second call does not re-fetch the latest schema."""
+        schema_route = _schema_route(
+            mock_registry, "UserEvent", schema=READER_SCHEMA_EVOLUTION
+        )
+        _id_schema_route(
+            mock_registry, "globalId", CONTENT_ID, schema=WRITER_SCHEMA_EVOLUTION
+        )
+        client = ApicurioRegistryClient(url=REGISTRY_URL, group_id=GROUP_ID)
+        deser = AvroDeserializer(
+            registry_client=client,
+            artifact_id="UserEvent",
+            use_latest_version=True,
+        )
+        data = make_confluent_bytes(
+            CONTENT_ID, {"userId": "u1"}, schema=WRITER_SCHEMA_EVOLUTION
+        )
+        deser(data, _ctx())
+        deser(data, _ctx())
+        assert schema_route.call_count == 1
+
+    def test_use_latest_version_false_is_backward_compatible(
+        self, mock_registry: respx.MockRouter
+    ) -> None:
+        """use_latest_version=False (default) with no artifact params works as before."""
+        _id_schema_route(mock_registry, "globalId", CONTENT_ID)
+        client = ApicurioRegistryClient(url=REGISTRY_URL, group_id=GROUP_ID)
+        deser = AvroDeserializer(registry_client=client)
+        data = make_confluent_bytes(CONTENT_ID, VALID_USER_EVENT)
+        result = deser(data, _ctx())
+        assert result == VALID_USER_EVENT
+
+    def test_resolver_raises_wraps_as_resolver_error(
+        self, mock_registry: respx.MockRouter
+    ) -> None:
+        """artifact_resolver that raises is wrapped as ResolverError."""
+        from apicurio_serdes._errors import ResolverError
+
+        _id_schema_route(
+            mock_registry, "globalId", CONTENT_ID, schema=WRITER_SCHEMA_EVOLUTION
+        )
+
+        def bad_resolver(ctx: object) -> str:
+            raise RuntimeError("boom")
+
+        client = ApicurioRegistryClient(url=REGISTRY_URL, group_id=GROUP_ID)
+        deser = AvroDeserializer(
+            registry_client=client,
+            artifact_resolver=bad_resolver,
+            use_latest_version=True,
+        )
+        data = make_confluent_bytes(
+            CONTENT_ID, {"userId": "u1"}, schema=WRITER_SCHEMA_EVOLUTION
+        )
+        with pytest.raises(ResolverError, match="artifact_resolver raised"):
+            deser(data, _ctx())
+
+    def test_resolver_returns_non_string_raises_resolver_error(
+        self, mock_registry: respx.MockRouter
+    ) -> None:
+        """artifact_resolver returning non-string raises ResolverError."""
+        from apicurio_serdes._errors import ResolverError
+
+        _id_schema_route(
+            mock_registry, "globalId", CONTENT_ID, schema=WRITER_SCHEMA_EVOLUTION
+        )
+
+        def bad_resolver(ctx: object) -> str:
+            return 42  # type: ignore[return-value]
+
+        client = ApicurioRegistryClient(url=REGISTRY_URL, group_id=GROUP_ID)
+        deser = AvroDeserializer(
+            registry_client=client,
+            artifact_resolver=bad_resolver,
+            use_latest_version=True,
+        )
+        data = make_confluent_bytes(
+            CONTENT_ID, {"userId": "u1"}, schema=WRITER_SCHEMA_EVOLUTION
+        )
+        with pytest.raises(ResolverError, match="non-empty str"):
             deser(data, _ctx())

--- a/tests/test_serializer.py
+++ b/tests/test_serializer.py
@@ -990,3 +990,82 @@ class TestAutoRegister:
         ctx = SerializationContext(topic="test", field=MessageField.VALUE)
         result = ser.serialize(VALID_USER_EVENT, ctx)
         assert result.payload[0:1] == b"\x00"
+
+
+class TestUseLatestVersion:
+    """Tests for AvroSerializer use_latest_version feature."""
+
+    def test_use_latest_version_and_auto_register_raises_value_error(self) -> None:
+        """use_latest_version=True + auto_register=True raises ValueError at construction."""
+        client = ApicurioRegistryClient(url=REGISTRY_URL, group_id=GROUP_ID)
+        with pytest.raises(ValueError, match="mutually exclusive"):
+            AvroSerializer(
+                registry_client=client,
+                artifact_id="UserEvent",
+                use_latest_version=True,
+                auto_register=True,
+                schema=USER_EVENT_SCHEMA_JSON,
+            )
+
+    def test_use_latest_version_with_artifact_id_serializes(
+        self, mock_registry: respx.MockRouter
+    ) -> None:
+        """use_latest_version=True with artifact_id fetches latest and serializes."""
+        _schema_route(mock_registry, "UserEvent")
+        client = ApicurioRegistryClient(url=REGISTRY_URL, group_id=GROUP_ID)
+        ser = AvroSerializer(
+            registry_client=client,
+            artifact_id="UserEvent",
+            use_latest_version=True,
+        )
+        ctx = SerializationContext(topic="test", field=MessageField.VALUE)
+        result = ser.serialize(VALID_USER_EVENT, ctx)
+        assert result.payload[0:1] == b"\x00"
+        assert len(result.payload) > 5
+
+    def test_use_latest_version_with_artifact_resolver_serializes(
+        self, mock_registry: respx.MockRouter
+    ) -> None:
+        """use_latest_version=True with artifact_resolver fetches latest and serializes."""
+        from apicurio_serdes.avro import SimpleTopicIdStrategy
+
+        _schema_route(mock_registry, "test")
+        client = ApicurioRegistryClient(url=REGISTRY_URL, group_id=GROUP_ID)
+        ser = AvroSerializer(
+            registry_client=client,
+            artifact_resolver=SimpleTopicIdStrategy(),
+            use_latest_version=True,
+        )
+        ctx = SerializationContext(topic="test", field=MessageField.VALUE)
+        result = ser.serialize(VALID_USER_EVENT, ctx)
+        assert result.payload[0:1] == b"\x00"
+
+    def test_use_latest_version_second_call_is_cache_hit(
+        self, mock_registry: respx.MockRouter
+    ) -> None:
+        """use_latest_version=True: second serialize call is an instance-cache hit."""
+        schema_route = _schema_route(mock_registry, "UserEvent")
+        client = ApicurioRegistryClient(url=REGISTRY_URL, group_id=GROUP_ID)
+        ser = AvroSerializer(
+            registry_client=client,
+            artifact_id="UserEvent",
+            use_latest_version=True,
+        )
+        ctx = SerializationContext(topic="test", field=MessageField.VALUE)
+        ser.serialize(VALID_USER_EVENT, ctx)
+        ser.serialize(VALID_USER_EVENT, ctx)
+        assert schema_route.call_count == 1
+
+    def test_use_latest_version_false_default_is_backward_compatible(
+        self, mock_registry: respx.MockRouter
+    ) -> None:
+        """use_latest_version=False (default) constructs and serializes without error."""
+        _schema_route(mock_registry, "UserEvent")
+        client = ApicurioRegistryClient(url=REGISTRY_URL, group_id=GROUP_ID)
+        ser = AvroSerializer(
+            registry_client=client,
+            artifact_id="UserEvent",
+        )
+        ctx = SerializationContext(topic="test", field=MessageField.VALUE)
+        result = ser.serialize(VALID_USER_EVENT, ctx)
+        assert result.payload[0:1] == b"\x00"


### PR DESCRIPTION
## Summary

- Add `use_latest_version: bool = False` to `AvroSerializer`, `AvroDeserializer`, and `AsyncAvroDeserializer`
- For the serializer: validates mutual exclusivity with `auto_register`
- For deserializers: fetches the latest registry schema as the reader schema on first call, cached per instance; requires `artifact_id` or `artifact_resolver`; mutually exclusive with static `reader_schema`

## Test plan

- [ ] 516 tests pass, 100% coverage maintained
- [ ] `ruff check` and `mypy` exit 0 with no issues
- [ ] All success criteria from `docs/plans/2026-03-26-use-latest-version-plan.md` validated

🤖 Generated with [Claude Code](https://claude.com/claude-code)