### PR TITLE
release: v0.5.0

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -86,8 +86,34 @@ jobs:
           languages: python
       - uses: github/codeql-action/analyze@0d579ffd059c29b07949a3cce3983f0780820c98  # v4.32.6
 
+  quality:
+    if: github.event.pull_request.draft == false || github.event_name == 'push'
+    runs-on: ubuntu-latest
+    timeout-minutes: 10
+    steps:
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd  # v6.0.2
+        with:
+          fetch-depth: 0  # wily needs full history to build its index
+      - uses: actions/setup-python@a309ff8b426b58ec0e2a45f0f869d46889d02405  # v6.2.0
+        with:
+          python-version: "3.13"
+      - uses: astral-sh/setup-uv@37802adc94f370d6bfd71619e3f0bf239e1f3b78  # v7.6.0
+      - run: uv sync --group dev
+      - name: Xenon complexity gate
+        # Thresholds calibrated from v0.4.0 baseline:
+        #   --max-absolute C  (two C-ranked blocks in avro/_serializer.py)
+        #   --max-modules  B  (avro/_serializer.py module rank)
+        #   --max-average  A  (mean across all blocks)
+        run: uv run xenon --max-absolute C --max-modules B --max-average A src/
+      - name: Wily complexity trend (informational)
+        if: github.event_name == 'pull_request'
+        continue-on-error: true
+        run: |
+          uv run wily build src/
+          uv run wily diff src/ -r ${{ github.base_ref }}
+
   publish-testpypi:
-    needs: [lint, typecheck, test, docs-build]
+    needs: [lint, typecheck, test, docs-build, quality]
     if: >-
       github.event_name == 'pull_request'
       && github.event.pull_request.draft == false

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -4,7 +4,7 @@ on:
   pull_request:
     types: [opened, synchronize, reopened, ready_for_review]
   push:
-    branches: [main]
+    branches: [main, "release/v*"]
 
 permissions: {}
 

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -37,7 +37,7 @@ jobs:
       actions: read
       id-token: write
       contents: write
-    uses: slsa-framework/slsa-github-generator/.github/workflows/generator_generic_slsa3.yml@v2.1.0
+    uses: slsa-framework/slsa-github-generator/.github/workflows/generator_generic_slsa3.yml@f7dd8c54c2067bafc12ca7a55595d5ee9b75204a  # v2.1.0
     with:
       base64-subjects: "${{ needs.build.outputs.hashes }}"
       upload-assets: true

--- a/.github/workflows/sign-release-retroactive.yml
+++ b/.github/workflows/sign-release-retroactive.yml
@@ -7,6 +7,8 @@ on:
         description: "Release tag to sign (e.g. v0.3.0)"
         required: true
 
+permissions: {}  # deny all at workflow level; job declares only what it needs
+
 jobs:
   sign:
     runs-on: ubuntu-latest

--- a/DEVELOPMENT.md
+++ b/DEVELOPMENT.md
@@ -2,6 +2,86 @@
 
 This document is for project maintainers.
 
+## Complexity tracking
+
+Complexity is enforced in CI via **Xenon** and tracked over time with **Wily**.
+
+### Xenon — CI gate
+
+Xenon runs automatically on every PR. Thresholds (calibrated from the v0.4.0 baseline):
+
+| Flag | Threshold | What it checks |
+|---|---|---|
+| `--max-absolute` | C | Worst single block in the codebase |
+| `--max-modules` | B | Worst module-level average |
+| `--max-average` | A | Mean across all blocks |
+
+Run locally with `uv run xenon --max-absolute C --max-modules B --max-average A src/`.
+
+### Wily — trend analysis
+
+Wily tracks complexity metrics across commits and is the right tool for assessing
+whether a PR improves or worsens maintainability.
+
+#### Setup (once per machine)
+
+```bash
+# Index the full git history — run once, or after rebasing
+uv run wily build src/
+```
+
+This reads the git log and snapshots metrics for every commit. The index is stored in
+`.wily/` (gitignored). It only needs to be re-run when you want to include new commits
+that aren't yet indexed.
+
+#### PR assessment workflow
+
+Before opening a PR, run a diff against the release branch:
+
+```bash
+uv run wily diff src/ -r release/v0.5.0
+```
+
+This compares the files **on disk** against the indexed state of `release/v0.5.0`.
+Only files that changed are shown. Metrics that improved are highlighted green,
+regressions are red.
+
+Example output (this PR):
+
+```
+_strategies.py   MI: 39.46 → 52.45   LOC: 183 → 153
+```
+
+#### Two commands, two purposes
+
+| Command | What it shows | When to use |
+|---|---|---|
+| `wily diff src/ -r <base>` | Before→after for changed files only | PR assessment |
+| `wily report src/apicurio_serdes/_base.py` | Per-file history over all indexed commits | Investigating a file's trajectory |
+
+#### Important: `report` is file-scoped, not directory-scoped
+
+`wily report src/` does **not** aggregate all files — it looks for a literal file
+named `src/` in the index and returns nothing useful. Always pass a specific file path
+to `report`:
+
+```bash
+# Correct
+uv run wily report src/apicurio_serdes/_base.py
+
+# Wrong — returns "Not found"
+uv run wily report src/
+```
+
+`wily diff src/` works at directory level because it expands to individual files internally.
+
+#### Gating behaviour
+
+Wily is **informational only** — `wily diff` always exits 0 regardless of regressions.
+The Xenon job in CI is the hard gate. Wily is the signal you check manually before
+merging to confirm you are not quietly degrading MI on a file that stays within
+Xenon's absolute thresholds.
+
 ## Cutting a release
 
 1. Update `version` in `pyproject.toml` and `src/apicurio_serdes/_version.py`.

--- a/docs/changelog.en.md
+++ b/docs/changelog.en.md
@@ -57,6 +57,14 @@ All user-visible changes are documented here.
   `"{topic}-{name}"` otherwise. Matches the Confluent
   `TopicRecordNameStrategy`. Raises `ValueError` at construction if the
   schema has no `"name"` field.
+- `BearerAuth` — authentication handler for static Bearer tokens or dynamic
+  token providers (e.g. GCP OIDC). Pass a `token` string or a zero-argument
+  `token_provider` callable. Rejects empty tokens at construction.
+- `KeycloakAuth` — OAuth2 client-credentials authentication against a Keycloak
+  token endpoint. Fetches a token on first use and automatically refreshes it
+  when less than 20% of its TTL remains. Works with both sync and async clients.
+- `AuthenticationError` — new typed exception raised on authentication failures
+  (token fetch errors, invalid responses). Exported from the package root.
 
 ## 0.2.0 (2026-03-11)
 

--- a/docs/changelog.en.md
+++ b/docs/changelog.en.md
@@ -6,6 +6,13 @@ All user-visible changes are documented here.
 
 ### Added
 
+- `AvroSerializer`, `AvroDeserializer`, and `AsyncAvroDeserializer` now accept
+  `use_latest_version=True`. For the serializer, the flag validates that it is not
+  combined with `auto_register` (they are mutually exclusive). For the deserializers,
+  it enables dynamic reader schema resolution: the latest registry schema for the
+  given `artifact_id` (or `artifact_resolver`) is fetched on the first call and
+  cached per instance. Mutually exclusive with the static `reader_schema` parameter.
+
 - `cache_max_size` (default `1000`) and `cache_ttl_seconds` (default `None`) constructor parameters on both clients.
   `cache_max_size` caps both caches with LRU eviction. `cache_ttl_seconds` enables optional TTL expiry on
   artifact-based lookups (`get_schema`, `register_schema`); ID-based lookups (`get_schema_by_global_id`,

--- a/docs/changelog.fr.md
+++ b/docs/changelog.fr.md
@@ -6,6 +6,14 @@ Toutes les modifications visibles par les utilisateurs sont documentées ici.
 
 ### Ajouts
 
+- `AvroSerializer`, `AvroDeserializer` et `AsyncAvroDeserializer` acceptent
+  désormais `use_latest_version=True`. Pour le sérialiseur, le paramètre valide
+  qu'il n'est pas combiné avec `auto_register` (ils sont mutuellement exclusifs).
+  Pour les désérialiseurs, il active la résolution dynamique du schema lecteur :
+  le schema le plus récent du registre pour l'`artifact_id` (ou `artifact_resolver`)
+  fourni est récupéré au premier appel et mis en cache par instance. Mutuellement
+  exclusif avec le paramètre statique `reader_schema`.
+
 - Paramètres de constructeur `cache_max_size` (défaut `1000`) et `cache_ttl_seconds` (défaut `None`) sur les deux
   clients. `cache_max_size` limite les deux caches avec éviction LRU. `cache_ttl_seconds` active un TTL optionnel sur
   les lookups basés sur l'artifact (`get_schema`, `register_schema`) ; les lookups basés sur l'identifiant

--- a/docs/changelog.fr.md
+++ b/docs/changelog.fr.md
@@ -61,6 +61,17 @@ Toutes les modifications visibles par les utilisateurs sont documentées ici.
   `"{topic}-{name}"` sinon. Correspond à la `TopicRecordNameStrategy` de Confluent.
   Lève une `ValueError` à la construction si le schema ne possède pas de champ
   `"name"`.
+- `BearerAuth` — gestionnaire d'authentification pour les tokens Bearer statiques
+  ou les fournisseurs de tokens dynamiques (ex. GCP OIDC). Accepte un `token`
+  statique ou un `token_provider` callable sans argument. Rejette les tokens
+  vides à la construction.
+- `KeycloakAuth` — authentification OAuth2 client-credentials contre un endpoint
+  de tokens Keycloak. Récupère un token au premier usage et le rafraîchit
+  automatiquement quand il reste moins de 20% de son TTL. Fonctionne avec les
+  clients sync et async.
+- `AuthenticationError` — nouvelle exception typée levée en cas d'échec
+  d'authentification (erreurs de récupération de token, réponses invalides).
+  Exportée depuis la racine du paquet.
 
 ## 0.2.0 (2026-03-11)
 

--- a/docs/user-guide/avro-deserializer.en.md
+++ b/docs/user-guide/avro-deserializer.en.md
@@ -28,7 +28,10 @@ record = deserializer(kafka_message.value(), ctx)
 | `registry_client` | `ApicurioRegistryClient` | required | The registry client used to resolve schema identifiers. |
 | `from_dict` | callable | `None` | Optional `(dict, ctx) -> Any` transformation applied after decoding. |
 | `use_id` | `"contentId"` or `"globalId"` | `"globalId"` | How to interpret the 4-byte schema identifier in the wire format header. |
-| `reader_schema` | `dict` | `None` | Optional Avro schema dict used as the reader schema. When provided, fastavro performs schema resolution between the writer schema (from the message) and this schema, enabling field additions with defaults, type promotions, and alias-based renames. Parsed once at construction time. |
+| `artifact_id` | `str` | `None` | Static artifact identifier used to fetch the latest registry schema as the reader schema. Requires `use_latest_version=True`. Mutually exclusive with `artifact_resolver`. |
+| `artifact_resolver` | callable | `None` | Callable `(ctx) -> str` that derives the artifact identifier at call time. Requires `use_latest_version=True`. Mutually exclusive with `artifact_id`. |
+| `use_latest_version` | `bool` | `False` | When `True`, fetches the latest registry schema for the resolved artifact on the first call and uses it as the reader schema (cached per instance). Requires `artifact_id` or `artifact_resolver`. Mutually exclusive with `reader_schema`. |
+| `reader_schema` | `dict` | `None` | Optional Avro schema dict used as the reader schema. When provided, fastavro performs schema resolution between the writer schema (from the message) and this schema, enabling field additions with defaults, type promotions, and alias-based renames. Parsed once at construction time. Mutually exclusive with `use_latest_version`. |
 
 ### Schema identifier mode (`use_id`)
 
@@ -125,6 +128,44 @@ A few things to keep in mind during resolution:
 
 If the schemas are incompatible — say, a new required field has no default — fastavro
 raises a `ValueError` wrapped in `DeserializationError`.
+
+## Dynamic reader schema (`use_latest_version`)
+
+When the consumer schema evolves frequently, maintaining a static `reader_schema` in code
+can be cumbersome. `use_latest_version=True` delegates schema resolution to the registry:
+the deserializer fetches the latest version of the given artifact on the first call and
+uses it as the reader schema, cached for the lifetime of the instance.
+
+```python
+deserializer = AvroDeserializer(
+    client,
+    artifact_id="UserEvent",
+    use_latest_version=True,
+)
+ctx = SerializationContext("user-events", MessageField.VALUE)
+# On the first call, the deserializer fetches the latest "UserEvent" schema
+# from the registry and uses it as the reader schema. Subsequent calls use
+# the cached version — no extra HTTP request.
+record = deserializer(payload, ctx)
+```
+
+You can also use `artifact_resolver` instead of a static `artifact_id`:
+
+```python
+from apicurio_serdes.avro import SimpleTopicIdStrategy
+
+deserializer = AvroDeserializer(
+    client,
+    artifact_resolver=SimpleTopicIdStrategy(),
+    use_latest_version=True,
+)
+```
+
+**Constraints**:
+
+- Requires exactly one of `artifact_id` or `artifact_resolver`.
+- Mutually exclusive with the static `reader_schema` parameter.
+- Providing `artifact_id` or `artifact_resolver` without `use_latest_version=True` raises `ValueError`.
 
 ## Schema caching
 

--- a/docs/user-guide/avro-deserializer.fr.md
+++ b/docs/user-guide/avro-deserializer.fr.md
@@ -28,7 +28,10 @@ record = deserializer(kafka_message.value(), ctx)
 | `registry_client` | `ApicurioRegistryClient` | obligatoire | Le client registry utilisé pour résoudre les identifiants de schema. |
 | `from_dict` | callable | `None` | Transformation optionnelle `(dict, ctx) -> Any` appliquée après le décodage. |
 | `use_id` | `"contentId"` ou `"globalId"` | `"globalId"` | Comment interpréter l'identifiant de schema de 4 octets dans l'en-tête du wire format. |
-| `reader_schema` | `dict` | `None` | Schema Avro optionnel utilisé comme schema lecteur. Quand il est fourni, fastavro effectue une résolution de schema entre le schema d'écriture (issu du message) et ce schema, permettant les ajouts de champs avec valeurs par défaut, les promotions de type et les renommages par alias. Parsé une seule fois à la construction. |
+| `artifact_id` | `str` | `None` | Identifiant d'artifact statique utilisé pour récupérer le schema le plus récent du registry comme schema lecteur. Requiert `use_latest_version=True`. Mutuellement exclusif avec `artifact_resolver`. |
+| `artifact_resolver` | callable | `None` | Callable `(ctx) -> str` qui dérive l'identifiant d'artifact à l'appel. Requiert `use_latest_version=True`. Mutuellement exclusif avec `artifact_id`. |
+| `use_latest_version` | `bool` | `False` | Quand `True`, récupère le schema le plus récent du registry pour l'artifact résolu lors du premier appel et l'utilise comme schema lecteur (mis en cache par instance). Requiert `artifact_id` ou `artifact_resolver`. Mutuellement exclusif avec `reader_schema`. |
+| `reader_schema` | `dict` | `None` | Schema Avro optionnel utilisé comme schema lecteur. Quand il est fourni, fastavro effectue une résolution de schema entre le schema d'écriture (issu du message) et ce schema, permettant les ajouts de champs avec valeurs par défaut, les promotions de type et les renommages par alias. Parsé une seule fois à la construction. Mutuellement exclusif avec `use_latest_version`. |
 
 ### Mode d'identifiant de schema (`use_id`)
 
@@ -125,6 +128,45 @@ Quelques points à garder en tête lors de la résolution :
 
 Si les schemas sont incompatibles — par exemple, un nouveau champ obligatoire sans valeur par
 défaut — fastavro lève une `ValueError` encapsulée dans `DeserializationError`.
+
+## Schema lecteur dynamique (`use_latest_version`)
+
+Lorsque le schema côté consommateur évolue fréquemment, maintenir un `reader_schema`
+statique dans le code peut devenir contraignant. `use_latest_version=True` délègue la
+résolution du schema au registry : le désérialiseur récupère la dernière version de
+l'artifact donné lors du premier appel et l'utilise comme schema lecteur, mis en cache
+pour toute la durée de vie de l'instance.
+
+```python
+deserializer = AvroDeserializer(
+    client,
+    artifact_id="UserEvent",
+    use_latest_version=True,
+)
+ctx = SerializationContext("user-events", MessageField.VALUE)
+# Au premier appel, le désérialiseur récupère le schema "UserEvent" le plus
+# récent depuis le registry et l'utilise comme schema lecteur. Les appels
+# suivants utilisent la version mise en cache — aucune requête HTTP supplémentaire.
+record = deserializer(payload, ctx)
+```
+
+Vous pouvez également utiliser `artifact_resolver` à la place d'un `artifact_id` statique :
+
+```python
+from apicurio_serdes.avro import SimpleTopicIdStrategy
+
+deserializer = AvroDeserializer(
+    client,
+    artifact_resolver=SimpleTopicIdStrategy(),
+    use_latest_version=True,
+)
+```
+
+**Contraintes** :
+
+- Requiert exactement l'un de `artifact_id` ou `artifact_resolver`.
+- Mutuellement exclusif avec le paramètre statique `reader_schema`.
+- Fournir `artifact_id` ou `artifact_resolver` sans `use_latest_version=True` lève une `ValueError`.
 
 ## Mise en cache du schema
 

--- a/docs/user-guide/avro-serializer.en.md
+++ b/docs/user-guide/avro-serializer.en.md
@@ -32,6 +32,7 @@ payload = serializer({"userId": "abc-123", "country": "FR"}, ctx)
 | `to_dict` | callable | `None` | Converts non-dict input to a dict before encoding. See [Custom Serialization](../how-to/custom-serialization.md). |
 | `use_id` | `"globalId"` or `"contentId"` | `"globalId"` | Which schema identifier to embed in the wire format header. See [Choosing Between globalId and contentId](../how-to/identifier-selection.md). |
 | `strict` | `bool` | `False` | Reject input fields not present in the schema with `ValueError`. |
+| `use_latest_version` | `bool` | `False` | Reserved for API consistency with `AvroDeserializer`. Must not be combined with `auto_register=True` (they are mutually exclusive). Has no effect on serialization behaviour. |
 
 ## Artifact resolver strategies
 

--- a/docs/user-guide/avro-serializer.fr.md
+++ b/docs/user-guide/avro-serializer.fr.md
@@ -33,6 +33,7 @@ payload = serializer({"userId": "abc-123", "country": "FR"}, ctx)
 | `to_dict` | callable | `None` | Convertit une entrée non-dict en dict avant l'encodage. Voir [Sérialisation personnalisée](../how-to/custom-serialization.md). |
 | `use_id` | `"globalId"` ou `"contentId"` | `"globalId"` | L'identifiant de schema à intégrer dans l'en-tête du wire format. Voir [Choisir entre globalId et contentId](../how-to/identifier-selection.md). |
 | `strict` | `bool` | `False` | Rejette les champs d'entrée absents du schema avec une `ValueError`. |
+| `use_latest_version` | `bool` | `False` | Réservé pour la cohérence d'API avec `AvroDeserializer`. Ne peut pas être combiné avec `auto_register=True` (ils sont mutuellement exclusifs). N'a aucun effet sur le comportement de sérialisation. |
 
 ## Stratégies de résolution d'artifact
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -53,6 +53,8 @@ dev = [
     "pip-audit>=2.7.0",
     "pyyaml>=6.0",
     "bandit>=1.7.0",
+    "xenon>=0.9.0",
+    "wily>=1.25.0",
 ]
 
 [tool.pytest.ini_options]

--- a/src/apicurio_serdes/_auth.py
+++ b/src/apicurio_serdes/_auth.py
@@ -32,7 +32,8 @@ class BearerAuth(httpx.Auth):
             GCP OIDC identity tokens retrieved via ``google-auth``).
 
     Raises:
-        ValueError: If neither or both of *token* and *token_provider* are given.
+        ValueError: If neither or both of *token* and *token_provider* are given,
+            or if *token* is an empty string.
 
     Example:
         ```python
@@ -55,13 +56,16 @@ class BearerAuth(httpx.Auth):
             raise ValueError(
                 "BearerAuth requires exactly one of 'token' or 'token_provider'."
             )
+        if token is not None and not token:
+            raise ValueError("BearerAuth 'token' must be a non-empty string.")
         self._token = token
         self._token_provider = token_provider
 
     def _get_token(self) -> str:
         if self._token_provider is not None:
             return self._token_provider()
-        return self._token  # type: ignore[return-value]
+        assert self._token is not None
+        return self._token
 
     def auth_flow(
         self, request: httpx.Request
@@ -222,8 +226,10 @@ class KeycloakAuth(httpx.Auth):
     # ── Async path ──
 
     def _get_async_lock(self) -> asyncio.Lock:
-        # note: this lock is bound to the event loop active on first async use;
-        # do not share a KeycloakAuth instance across multiple event loops.
+        # Note: the Lock is bound to the event loop on which it is first
+        # *awaited*. Do not share a KeycloakAuth instance across multiple
+        # event loops (e.g. separate asyncio.run() calls in tests or
+        # per-request loops in some ASGI frameworks).
         if self._async_lock is None:
             self._async_lock = asyncio.Lock()
         return self._async_lock

--- a/src/apicurio_serdes/_auth.py
+++ b/src/apicurio_serdes/_auth.py
@@ -222,6 +222,8 @@ class KeycloakAuth(httpx.Auth):
     # ── Async path ──
 
     def _get_async_lock(self) -> asyncio.Lock:
+        # note: this lock is bound to the event loop active on first async use;
+        # do not share a KeycloakAuth instance across multiple event loops.
         if self._async_lock is None:
             self._async_lock = asyncio.Lock()
         return self._async_lock

--- a/src/apicurio_serdes/_base.py
+++ b/src/apicurio_serdes/_base.py
@@ -50,7 +50,11 @@ class _CacheCore:
         self._store: OrderedDict[Any, tuple[Any, float | None]] = OrderedDict()
 
     def peek(self, key: object) -> object:
-        """TTL check without LRU update — safe to call outside a lock (no mutation)."""
+        """TTL check without LRU update — safe to call outside a lock (no mutation).
+
+        "Safe" here means the calling thread holds no lock *but the owning thread is
+        the only writer* — ``OrderedDict.get()`` is not atomic under concurrent resize.
+        """
         raw: tuple[Any, float | None] | None = self._store.get(key)
         if raw is None:
             return self._MISSING
@@ -165,6 +169,7 @@ class _RegistryClientBase:
 
     def _retry_delays(self) -> Iterator[float]:
         """Yield one delay (seconds) per retry attempt, up to max_retries values."""
+        # yields one delay per *retry*; the first attempt happens before any delay
         for attempt in range(self.max_retries):
             yield self._compute_delay(attempt)
 

--- a/src/apicurio_serdes/avro/_async_deserializer.py
+++ b/src/apicurio_serdes/avro/_async_deserializer.py
@@ -5,6 +5,8 @@ from __future__ import annotations
 import struct
 from typing import TYPE_CHECKING, Any
 
+import fastavro
+
 from apicurio_serdes._errors import DeserializationError
 from apicurio_serdes.avro._deserializer import _BaseAvroDeserializer
 
@@ -13,6 +15,7 @@ if TYPE_CHECKING:
     from typing import Literal
 
     from apicurio_serdes._async_client import AsyncApicurioRegistryClient
+    from apicurio_serdes.avro._strategies import ArtifactResolver
     from apicurio_serdes.serialization import SerializationContext
 
 
@@ -32,6 +35,20 @@ class AsyncAvroDeserializer(_BaseAvroDeserializer):
         use_id: Which registry identifier type the 4-byte wire format
                 field represents. Must match the serializer's use_id
                 setting. Defaults to "globalId".
+        artifact_id: Artifact identifier used to fetch the latest registry
+                     schema as the reader schema. Requires
+                     ``use_latest_version=True``. Mutually exclusive with
+                     ``artifact_resolver``.
+        artifact_resolver: Callable ``(ctx) -> str`` that returns the
+                           artifact identifier at call time. Requires
+                           ``use_latest_version=True``. Mutually exclusive
+                           with ``artifact_id``. The resolved value is cached
+                           after the first successful call.
+        use_latest_version: When ``True``, fetches the latest registry schema
+                            for the resolved artifact on the first call and
+                            uses it as the reader schema (cached per instance).
+                            Requires ``artifact_id`` or ``artifact_resolver``.
+                            Mutually exclusive with ``reader_schema``.
         reader_schema: Optional Avro schema dict used as the reader schema
                        during deserialization. When provided, fastavro
                        performs schema resolution between the writer schema
@@ -40,6 +57,16 @@ class AsyncAvroDeserializer(_BaseAvroDeserializer):
                        type promotions, and other Avro evolution rules. When
                        None (default), the writer schema is used for both
                        roles (no evolution). Parsed once at construction time.
+                       Mutually exclusive with ``use_latest_version``.
+
+    Raises:
+        ValueError: If ``artifact_id`` and ``artifact_resolver`` are both
+                    provided, if ``use_latest_version=True`` is used without
+                    ``artifact_id`` or ``artifact_resolver``, if
+                    ``use_latest_version=True`` is combined with
+                    ``reader_schema``, or if ``artifact_id`` /
+                    ``artifact_resolver`` is provided without
+                    ``use_latest_version=True``.
 
     Example:
         ```python
@@ -65,10 +92,18 @@ class AsyncAvroDeserializer(_BaseAvroDeserializer):
         from_dict: Callable[[dict[str, Any], SerializationContext], Any] | None = None,
         use_id: Literal["globalId", "contentId"] = "globalId",
         *,
+        artifact_id: str | None = None,
+        artifact_resolver: ArtifactResolver | None = None,
+        use_latest_version: bool = False,
         reader_schema: dict[str, Any] | None = None,
     ) -> None:
         super().__init__(
-            from_dict=from_dict, use_id=use_id, reader_schema=reader_schema
+            from_dict=from_dict,
+            use_id=use_id,
+            reader_schema=reader_schema,
+            artifact_id=artifact_id,
+            artifact_resolver=artifact_resolver,
+            use_latest_version=use_latest_version,
         )
         self.registry_client = registry_client
 
@@ -95,6 +130,9 @@ class AsyncAvroDeserializer(_BaseAvroDeserializer):
                 correspond to any schema in the registry.
             RegistryConnectionError: If the registry is unreachable
                 during schema resolution.
+            ResolverError: If ``use_latest_version=True`` with an
+                ``artifact_resolver`` and the resolver raises or returns
+                a non-string value.
         """
         if len(data) < 5:
             raise DeserializationError(
@@ -112,5 +150,10 @@ class AsyncAvroDeserializer(_BaseAvroDeserializer):
             schema_dict = await self.registry_client.get_schema_by_global_id(schema_id)
         else:
             schema_dict = await self.registry_client.get_schema_by_content_id(schema_id)
+
+        if self._use_latest_version and self._parsed_reader_schema is None:
+            effective_id = self._resolve_artifact_id(ctx)
+            cached = await self.registry_client.get_schema(effective_id)
+            self._parsed_reader_schema = fastavro.parse_schema(cached.schema)
 
         return self._decode(schema_id, schema_dict, data[5:], ctx)

--- a/src/apicurio_serdes/avro/_deserializer.py
+++ b/src/apicurio_serdes/avro/_deserializer.py
@@ -8,13 +8,14 @@ from typing import TYPE_CHECKING, Any
 
 import fastavro
 
-from apicurio_serdes._errors import DeserializationError
+from apicurio_serdes._errors import DeserializationError, ResolverError
 
 if TYPE_CHECKING:
     from collections.abc import Callable
     from typing import Literal
 
     from apicurio_serdes._client import ApicurioRegistryClient
+    from apicurio_serdes.avro._strategies import ArtifactResolver
     from apicurio_serdes.serialization import SerializationContext
 
 
@@ -26,13 +27,63 @@ class _BaseAvroDeserializer:
         from_dict: Callable[[dict[str, Any], SerializationContext], Any] | None,
         use_id: Literal["globalId", "contentId"],
         reader_schema: dict[str, Any] | None,
+        artifact_id: str | None = None,
+        artifact_resolver: ArtifactResolver | None = None,
+        use_latest_version: bool = False,
     ) -> None:
+        if artifact_id is not None and artifact_resolver is not None:
+            raise ValueError(
+                "artifact_id and artifact_resolver are mutually exclusive."
+            )
+        has_artifact_source = artifact_id is not None or artifact_resolver is not None
+        if use_latest_version and not has_artifact_source:
+            raise ValueError(
+                "use_latest_version=True requires artifact_id or artifact_resolver."
+            )
+        if use_latest_version and reader_schema is not None:
+            raise ValueError(
+                "use_latest_version and reader_schema are mutually exclusive."
+            )
+        if has_artifact_source and not use_latest_version:
+            raise ValueError(
+                "artifact_id and artifact_resolver require use_latest_version=True."
+            )
         self.from_dict = from_dict
         self.use_id = use_id
+        self._artifact_id = artifact_id
+        self._artifact_resolver: ArtifactResolver | None = artifact_resolver
+        self._resolved_artifact_id: str | None = None
+        self._use_latest_version = use_latest_version
         self._parsed_cache: dict[int, Any] = {}
         self._parsed_reader_schema = (
             fastavro.parse_schema(reader_schema) if reader_schema is not None else None
         )
+
+    def _resolve_artifact_id(self, ctx: SerializationContext) -> str:
+        """Resolve artifact_id from static value or resolver, with caching."""
+        if self._artifact_resolver is not None and self._resolved_artifact_id is None:
+            try:
+                resolved = self._artifact_resolver(ctx)
+            except Exception as exc:
+                raise ResolverError(
+                    f"artifact_resolver raised: {exc}", cause=exc
+                ) from exc
+            if not isinstance(resolved, str) or not resolved:
+                raise ResolverError(
+                    f"artifact_resolver must return a non-empty str, got {resolved!r}"
+                )
+            self._resolved_artifact_id = resolved
+        effective_id = (
+            self._artifact_id
+            if self._artifact_id is not None
+            else self._resolved_artifact_id
+        )
+        if effective_id is None:  # pragma: no cover
+            raise RuntimeError(
+                "artifact_id is None and no resolver produced an ID; "
+                "this is an internal invariant violation."
+            )
+        return effective_id
 
     def _decode(
         self,
@@ -84,6 +135,20 @@ class AvroDeserializer(_BaseAvroDeserializer):
         use_id: Which registry identifier type the 4-byte wire format
                 field represents. Must match the serializer's use_id
                 setting. Defaults to "globalId".
+        artifact_id: Artifact identifier used to fetch the latest registry
+                     schema as the reader schema. Requires
+                     ``use_latest_version=True``. Mutually exclusive with
+                     ``artifact_resolver``.
+        artifact_resolver: Callable ``(ctx) -> str`` that returns the
+                           artifact identifier at call time. Requires
+                           ``use_latest_version=True``. Mutually exclusive
+                           with ``artifact_id``. The resolved value is cached
+                           after the first successful call.
+        use_latest_version: When ``True``, fetches the latest registry schema
+                            for the resolved artifact on the first call and
+                            uses it as the reader schema (cached per instance).
+                            Requires ``artifact_id`` or ``artifact_resolver``.
+                            Mutually exclusive with ``reader_schema``.
         reader_schema: Optional Avro schema dict used as the reader schema
                        during deserialization. When provided, fastavro
                        performs schema resolution between the writer schema
@@ -92,6 +157,36 @@ class AvroDeserializer(_BaseAvroDeserializer):
                        type promotions, and other Avro evolution rules. When
                        None (default), the writer schema is used for both
                        roles (no evolution). Parsed once at construction time.
+                       Mutually exclusive with ``use_latest_version``.
+
+    Raises:
+        ValueError: If ``artifact_id`` and ``artifact_resolver`` are both
+                    provided, if ``use_latest_version=True`` is used without
+                    ``artifact_id`` or ``artifact_resolver``, if
+                    ``use_latest_version=True`` is combined with
+                    ``reader_schema``, or if ``artifact_id`` /
+                    ``artifact_resolver`` is provided without
+                    ``use_latest_version=True``.
+
+    Example:
+        ```python
+        from apicurio_serdes import ApicurioRegistryClient
+        from apicurio_serdes.avro import AvroDeserializer
+        from apicurio_serdes.serialization import SerializationContext, MessageField
+
+        client = ApicurioRegistryClient(
+            url="http://localhost:8080/apis/registry/v3",
+            group_id="com.example.schemas",
+        )
+        # Dynamically use the latest registry schema as the reader schema:
+        deserializer = AvroDeserializer(
+            registry_client=client,
+            artifact_id="UserEvent",
+            use_latest_version=True,
+        )
+        ctx = SerializationContext(topic="user-events", field=MessageField.VALUE)
+        result = deserializer(raw_bytes, ctx)
+        ```
     """
 
     def __init__(
@@ -100,10 +195,18 @@ class AvroDeserializer(_BaseAvroDeserializer):
         from_dict: Callable[[dict[str, Any], SerializationContext], Any] | None = None,
         use_id: Literal["globalId", "contentId"] = "globalId",
         *,
+        artifact_id: str | None = None,
+        artifact_resolver: ArtifactResolver | None = None,
+        use_latest_version: bool = False,
         reader_schema: dict[str, Any] | None = None,
     ) -> None:
         super().__init__(
-            from_dict=from_dict, use_id=use_id, reader_schema=reader_schema
+            from_dict=from_dict,
+            use_id=use_id,
+            reader_schema=reader_schema,
+            artifact_id=artifact_id,
+            artifact_resolver=artifact_resolver,
+            use_latest_version=use_latest_version,
         )
         self.registry_client = registry_client
 
@@ -131,6 +234,9 @@ class AvroDeserializer(_BaseAvroDeserializer):
                 to any schema in the registry (FR-010).
             RegistryConnectionError: If the registry is unreachable during
                 schema resolution (FR-012).
+            ResolverError: If ``use_latest_version=True`` with an
+                ``artifact_resolver`` and the resolver raises or returns
+                a non-string value.
         """
         # FR-004: validate minimum length
         if len(data) < 5:
@@ -152,5 +258,10 @@ class AvroDeserializer(_BaseAvroDeserializer):
             schema_dict = self.registry_client.get_schema_by_global_id(schema_id)
         else:
             schema_dict = self.registry_client.get_schema_by_content_id(schema_id)
+
+        if self._use_latest_version and self._parsed_reader_schema is None:
+            effective_id = self._resolve_artifact_id(ctx)
+            cached = self.registry_client.get_schema(effective_id)
+            self._parsed_reader_schema = fastavro.parse_schema(cached.schema)
 
         return self._decode(schema_id, schema_dict, data[5:], ctx)

--- a/src/apicurio_serdes/avro/_serializer.py
+++ b/src/apicurio_serdes/avro/_serializer.py
@@ -61,13 +61,18 @@ class AvroSerializer:
         strict: When ``True``, reject extra fields not in the schema.
         wire_format: The wire format framing mode. Defaults to
                      WireFormat.CONFLUENT_PAYLOAD (FR-003).
+        use_latest_version: Reserved flag for API consistency with
+                            ``AvroDeserializer``. Must not be combined with
+                            ``auto_register=True`` (they are mutually
+                            exclusive). Defaults to ``False``.
 
     Raises:
         ValueError: If both or neither of ``artifact_id`` / ``artifact_resolver``
             are provided; if ``wire_format`` is not a WireFormat enum member;
             if ``use_id`` is not ``"globalId"`` or ``"contentId"``; if
-            ``if_exists`` is not one of the four allowed values; or if
-            ``auto_register=True`` and ``schema`` is not provided.
+            ``if_exists`` is not one of the four allowed values; if
+            ``auto_register=True`` and ``schema`` is not provided; or if
+            ``use_latest_version=True`` and ``auto_register=True``.
 
     Example:
         ```python
@@ -112,6 +117,7 @@ class AvroSerializer:
         use_id: Literal["globalId", "contentId"] = "globalId",
         strict: bool = False,
         wire_format: WireFormat = WireFormat.CONFLUENT_PAYLOAD,
+        use_latest_version: bool = False,
     ) -> None:
         if artifact_id is not None and artifact_resolver is not None:
             raise ValueError(
@@ -135,6 +141,10 @@ class AvroSerializer:
             )
         if auto_register and schema is None:
             raise ValueError("schema must be provided when auto_register=True")
+        if use_latest_version and auto_register:
+            raise ValueError(
+                "use_latest_version and auto_register are mutually exclusive."
+            )
         self.registry_client = registry_client
         self.artifact_id: str | None = artifact_id
         self._artifact_resolver: ArtifactResolver | None = artifact_resolver
@@ -146,6 +156,7 @@ class AvroSerializer:
         self.use_id = use_id
         self.strict = strict
         self.wire_format = wire_format
+        self.use_latest_version = use_latest_version
         self._schema: CachedSchema | None = None
         self._parsed_schema: str | list[Any] | dict[Any, Any] | None = None
 

--- a/src/apicurio_serdes/avro/_strategies.py
+++ b/src/apicurio_serdes/avro/_strategies.py
@@ -33,14 +33,7 @@ class TopicIdStrategy:
     """
 
     def __call__(self, ctx: SerializationContext) -> str:
-        """Return ``"{topic}-{field}"`` for the given context.
-
-        Args:
-            ctx: The serialization context containing the topic and field.
-
-        Returns:
-            Artifact ID string in the form ``"{topic}-{field}"``.
-        """
+        """Return ``"{topic}-{field}"`` for the given context."""
         return f"{ctx.topic}-{ctx.field.value}"
 
 
@@ -62,14 +55,7 @@ class SimpleTopicIdStrategy:
     """
 
     def __call__(self, ctx: SerializationContext) -> str:
-        """Return the topic name for the given context.
-
-        Args:
-            ctx: The serialization context containing the topic.
-
-        Returns:
-            The topic name as the artifact ID.
-        """
+        """Return the topic name for the given context."""
         return ctx.topic
 
 
@@ -115,15 +101,7 @@ class QualifiedRecordIdStrategy:
         self._artifact_id = f"{namespace}.{name}" if namespace else name
 
     def __call__(self, ctx: SerializationContext) -> str:
-        """Return the qualified record name, ignoring context.
-
-        Args:
-            ctx: The serialization context (unused).
-
-        Returns:
-            Artifact ID string in the form ``"{namespace}.{name}"`` or
-            ``"{name}"``.
-        """
+        """Return the qualified record name, ignoring context."""
         return self._artifact_id
 
 
@@ -171,13 +149,5 @@ class TopicRecordIdStrategy:
         self._record_part = f"{namespace}.{name}" if namespace else name
 
     def __call__(self, ctx: SerializationContext) -> str:
-        """Return ``"{topic}-{record}"`` for the given context.
-
-        Args:
-            ctx: The serialization context containing the topic.
-
-        Returns:
-            Artifact ID string in the form ``"{topic}-{namespace}.{name}"``
-            or ``"{topic}-{name}"``.
-        """
+        """Return ``"{topic}-{record}"`` for the given context."""
         return f"{ctx.topic}-{self._record_part}"

--- a/tests/ci/test_ci_workflow.py
+++ b/tests/ci/test_ci_workflow.py
@@ -14,7 +14,8 @@ class TestCITriggers:
     def test_triggers_on_push_to_main(self, ci_workflow: dict[str, Any]) -> None:
         triggers = ci_workflow[True]
         assert "push" in triggers
-        assert triggers["push"]["branches"] == ["main"]
+        assert "main" in triggers["push"]["branches"]
+        assert any(b.startswith("release/") for b in triggers["push"]["branches"])
 
     def test_triggers_on_pull_request(self, ci_workflow: dict[str, Any]) -> None:
         triggers = ci_workflow[True]

--- a/tests/ci/test_ci_workflow.py
+++ b/tests/ci/test_ci_workflow.py
@@ -103,12 +103,13 @@ class TestCIAllJobsPresent:
             "test",
             "docs-build",
             "codeql",
+            "quality",
             "publish-testpypi",
         ):
             assert job_name in jobs, f"Missing job: {job_name}"
 
-    def test_workflow_has_exactly_six_jobs(self, ci_workflow: dict[str, Any]) -> None:
-        assert len(ci_workflow["jobs"]) == 6
+    def test_workflow_has_exactly_seven_jobs(self, ci_workflow: dict[str, Any]) -> None:
+        assert len(ci_workflow["jobs"]) == 7
 
 
 class TestCIStatusBlocking:

--- a/tests/test_async_deserializer.py
+++ b/tests/test_async_deserializer.py
@@ -20,6 +20,7 @@ from tests.conftest import (
     VALID_USER_EVENT,
     WRITER_SCHEMA_EVOLUTION,
     _id_schema_route,
+    _schema_route,
     make_confluent_bytes,
 )
 
@@ -357,4 +358,170 @@ class TestReaderSchema:
             CONTENT_ID, {"userId": "u1"}, schema=WRITER_SCHEMA_EVOLUTION
         )
         with pytest.raises(DeserializationError, match="Avro decode failure"):
+            await deser(data, _ctx())
+
+
+class TestUseLatestVersion:
+    """AsyncAvroDeserializer use_latest_version feature."""
+
+    def test_use_latest_version_without_artifact_raises(self) -> None:
+        """use_latest_version=True without artifact_id or artifact_resolver raises ValueError."""
+        client = AsyncApicurioRegistryClient(url=REGISTRY_URL, group_id=GROUP_ID)
+        with pytest.raises(ValueError, match="artifact_id or artifact_resolver"):
+            AsyncAvroDeserializer(registry_client=client, use_latest_version=True)
+
+    def test_use_latest_version_with_reader_schema_raises(self) -> None:
+        """use_latest_version=True + reader_schema raises ValueError (mutually exclusive)."""
+        client = AsyncApicurioRegistryClient(url=REGISTRY_URL, group_id=GROUP_ID)
+        with pytest.raises(ValueError, match="mutually exclusive"):
+            AsyncAvroDeserializer(
+                registry_client=client,
+                artifact_id="UserEvent",
+                use_latest_version=True,
+                reader_schema=READER_SCHEMA_EVOLUTION,
+            )
+
+    def test_artifact_id_and_resolver_raises(self) -> None:
+        """artifact_id + artifact_resolver raises ValueError (mutually exclusive)."""
+        from apicurio_serdes.avro import SimpleTopicIdStrategy
+
+        client = AsyncApicurioRegistryClient(url=REGISTRY_URL, group_id=GROUP_ID)
+        with pytest.raises(ValueError, match="mutually exclusive"):
+            AsyncAvroDeserializer(
+                registry_client=client,
+                artifact_id="UserEvent",
+                artifact_resolver=SimpleTopicIdStrategy(),
+                use_latest_version=True,
+            )
+
+    def test_artifact_id_without_use_latest_version_raises(self) -> None:
+        """artifact_id without use_latest_version=True raises ValueError."""
+        client = AsyncApicurioRegistryClient(url=REGISTRY_URL, group_id=GROUP_ID)
+        with pytest.raises(ValueError, match="use_latest_version"):
+            AsyncAvroDeserializer(registry_client=client, artifact_id="UserEvent")
+
+    async def test_use_latest_version_with_artifact_id_fills_default(
+        self, mock_registry: respx.MockRouter
+    ) -> None:
+        """use_latest_version=True + artifact_id uses latest schema as reader schema."""
+        _schema_route(mock_registry, "UserEvent", schema=READER_SCHEMA_EVOLUTION)
+        _id_schema_route(
+            mock_registry, "globalId", CONTENT_ID, schema=WRITER_SCHEMA_EVOLUTION
+        )
+        client = AsyncApicurioRegistryClient(url=REGISTRY_URL, group_id=GROUP_ID)
+        deser = AsyncAvroDeserializer(
+            registry_client=client,
+            artifact_id="UserEvent",
+            use_latest_version=True,
+        )
+        data = make_confluent_bytes(
+            CONTENT_ID, {"userId": "u1"}, schema=WRITER_SCHEMA_EVOLUTION
+        )
+        result = await deser(data, _ctx())
+        assert result == {"userId": "u1", "version": "v1"}
+
+    async def test_use_latest_version_with_artifact_resolver_fills_default(
+        self, mock_registry: respx.MockRouter
+    ) -> None:
+        """use_latest_version=True + artifact_resolver uses latest schema as reader schema."""
+        from apicurio_serdes.avro import SimpleTopicIdStrategy
+
+        _schema_route(mock_registry, "test", schema=READER_SCHEMA_EVOLUTION)
+        _id_schema_route(
+            mock_registry, "globalId", CONTENT_ID, schema=WRITER_SCHEMA_EVOLUTION
+        )
+        client = AsyncApicurioRegistryClient(url=REGISTRY_URL, group_id=GROUP_ID)
+        deser = AsyncAvroDeserializer(
+            registry_client=client,
+            artifact_resolver=SimpleTopicIdStrategy(),
+            use_latest_version=True,
+        )
+        data = make_confluent_bytes(
+            CONTENT_ID, {"userId": "u1"}, schema=WRITER_SCHEMA_EVOLUTION
+        )
+        result = await deser(data, _ctx())
+        assert result == {"userId": "u1", "version": "v1"}
+
+    async def test_use_latest_version_reader_schema_cached(
+        self, mock_registry: respx.MockRouter
+    ) -> None:
+        """use_latest_version=True: second call does not re-fetch the latest schema."""
+        schema_route = _schema_route(
+            mock_registry, "UserEvent", schema=READER_SCHEMA_EVOLUTION
+        )
+        _id_schema_route(
+            mock_registry, "globalId", CONTENT_ID, schema=WRITER_SCHEMA_EVOLUTION
+        )
+        client = AsyncApicurioRegistryClient(url=REGISTRY_URL, group_id=GROUP_ID)
+        deser = AsyncAvroDeserializer(
+            registry_client=client,
+            artifact_id="UserEvent",
+            use_latest_version=True,
+        )
+        data = make_confluent_bytes(
+            CONTENT_ID, {"userId": "u1"}, schema=WRITER_SCHEMA_EVOLUTION
+        )
+        await deser(data, _ctx())
+        await deser(data, _ctx())
+        assert schema_route.call_count == 1
+
+    async def test_use_latest_version_false_is_backward_compatible(
+        self, mock_registry: respx.MockRouter
+    ) -> None:
+        """use_latest_version=False (default) with no artifact params works as before."""
+        _id_schema_route(mock_registry, "globalId", CONTENT_ID)
+        client = AsyncApicurioRegistryClient(url=REGISTRY_URL, group_id=GROUP_ID)
+        deser = AsyncAvroDeserializer(registry_client=client)
+        data = make_confluent_bytes(CONTENT_ID, VALID_USER_EVENT)
+        result = await deser(data, _ctx())
+        assert result == VALID_USER_EVENT
+
+    async def test_resolver_raises_wraps_as_resolver_error(
+        self, mock_registry: respx.MockRouter
+    ) -> None:
+        """artifact_resolver that raises is wrapped as ResolverError."""
+        from apicurio_serdes._errors import ResolverError
+
+        _id_schema_route(
+            mock_registry, "globalId", CONTENT_ID, schema=WRITER_SCHEMA_EVOLUTION
+        )
+
+        def bad_resolver(ctx: object) -> str:
+            raise RuntimeError("boom")
+
+        client = AsyncApicurioRegistryClient(url=REGISTRY_URL, group_id=GROUP_ID)
+        deser = AsyncAvroDeserializer(
+            registry_client=client,
+            artifact_resolver=bad_resolver,
+            use_latest_version=True,
+        )
+        data = make_confluent_bytes(
+            CONTENT_ID, {"userId": "u1"}, schema=WRITER_SCHEMA_EVOLUTION
+        )
+        with pytest.raises(ResolverError, match="artifact_resolver raised"):
+            await deser(data, _ctx())
+
+    async def test_resolver_returns_non_string_raises_resolver_error(
+        self, mock_registry: respx.MockRouter
+    ) -> None:
+        """artifact_resolver returning non-string raises ResolverError."""
+        from apicurio_serdes._errors import ResolverError
+
+        _id_schema_route(
+            mock_registry, "globalId", CONTENT_ID, schema=WRITER_SCHEMA_EVOLUTION
+        )
+
+        def bad_resolver(ctx: object) -> str:
+            return 42  # type: ignore[return-value]
+
+        client = AsyncApicurioRegistryClient(url=REGISTRY_URL, group_id=GROUP_ID)
+        deser = AsyncAvroDeserializer(
+            registry_client=client,
+            artifact_resolver=bad_resolver,
+            use_latest_version=True,
+        )
+        data = make_confluent_bytes(
+            CONTENT_ID, {"userId": "u1"}, schema=WRITER_SCHEMA_EVOLUTION
+        )
+        with pytest.raises(ResolverError, match="non-empty str"):
             await deser(data, _ctx())

--- a/tests/test_auth.py
+++ b/tests/test_auth.py
@@ -71,6 +71,10 @@ class TestBearerAuth:
                 client.get(ARTIFACT_URL)
         assert call_count == 2
 
+    def test_empty_token_raises_value_error(self) -> None:
+        with pytest.raises(ValueError, match="non-empty"):
+            BearerAuth(token="")
+
     def test_no_args_raises_value_error(self) -> None:
         with pytest.raises(ValueError, match="exactly one"):
             BearerAuth()

--- a/tests/test_deserializer.py
+++ b/tests/test_deserializer.py
@@ -22,6 +22,7 @@ from tests.conftest import (
     WRITER_SCHEMA_EVOLUTION,
     _id_not_found_route,
     _id_schema_route,
+    _schema_route,
     make_confluent_bytes,
 )
 
@@ -282,4 +283,170 @@ class TestReaderSchema:
             CONTENT_ID, {"userId": "u1"}, schema=WRITER_SCHEMA_EVOLUTION
         )
         with pytest.raises(DeserializationError, match="Avro decode failure"):
+            deser(data, _ctx())
+
+
+class TestUseLatestVersion:
+    """AvroDeserializer use_latest_version feature."""
+
+    def test_use_latest_version_without_artifact_raises(self) -> None:
+        """use_latest_version=True without artifact_id or artifact_resolver raises ValueError."""
+        client = ApicurioRegistryClient(url=REGISTRY_URL, group_id=GROUP_ID)
+        with pytest.raises(ValueError, match="artifact_id or artifact_resolver"):
+            AvroDeserializer(registry_client=client, use_latest_version=True)
+
+    def test_use_latest_version_with_reader_schema_raises(self) -> None:
+        """use_latest_version=True + reader_schema raises ValueError (mutually exclusive)."""
+        client = ApicurioRegistryClient(url=REGISTRY_URL, group_id=GROUP_ID)
+        with pytest.raises(ValueError, match="mutually exclusive"):
+            AvroDeserializer(
+                registry_client=client,
+                artifact_id="UserEvent",
+                use_latest_version=True,
+                reader_schema=READER_SCHEMA_EVOLUTION,
+            )
+
+    def test_artifact_id_and_resolver_raises(self) -> None:
+        """artifact_id + artifact_resolver raises ValueError (mutually exclusive)."""
+        from apicurio_serdes.avro import SimpleTopicIdStrategy
+
+        client = ApicurioRegistryClient(url=REGISTRY_URL, group_id=GROUP_ID)
+        with pytest.raises(ValueError, match="mutually exclusive"):
+            AvroDeserializer(
+                registry_client=client,
+                artifact_id="UserEvent",
+                artifact_resolver=SimpleTopicIdStrategy(),
+                use_latest_version=True,
+            )
+
+    def test_artifact_id_without_use_latest_version_raises(self) -> None:
+        """artifact_id without use_latest_version=True raises ValueError."""
+        client = ApicurioRegistryClient(url=REGISTRY_URL, group_id=GROUP_ID)
+        with pytest.raises(ValueError, match="use_latest_version"):
+            AvroDeserializer(registry_client=client, artifact_id="UserEvent")
+
+    def test_use_latest_version_with_artifact_id_fills_default(
+        self, mock_registry: respx.MockRouter
+    ) -> None:
+        """use_latest_version=True + artifact_id uses latest schema as reader schema."""
+        _schema_route(mock_registry, "UserEvent", schema=READER_SCHEMA_EVOLUTION)
+        _id_schema_route(
+            mock_registry, "globalId", CONTENT_ID, schema=WRITER_SCHEMA_EVOLUTION
+        )
+        client = ApicurioRegistryClient(url=REGISTRY_URL, group_id=GROUP_ID)
+        deser = AvroDeserializer(
+            registry_client=client,
+            artifact_id="UserEvent",
+            use_latest_version=True,
+        )
+        data = make_confluent_bytes(
+            CONTENT_ID, {"userId": "u1"}, schema=WRITER_SCHEMA_EVOLUTION
+        )
+        result = deser(data, _ctx())
+        assert result == {"userId": "u1", "version": "v1"}
+
+    def test_use_latest_version_with_artifact_resolver_fills_default(
+        self, mock_registry: respx.MockRouter
+    ) -> None:
+        """use_latest_version=True + artifact_resolver uses latest schema as reader schema."""
+        from apicurio_serdes.avro import SimpleTopicIdStrategy
+
+        _schema_route(mock_registry, "test", schema=READER_SCHEMA_EVOLUTION)
+        _id_schema_route(
+            mock_registry, "globalId", CONTENT_ID, schema=WRITER_SCHEMA_EVOLUTION
+        )
+        client = ApicurioRegistryClient(url=REGISTRY_URL, group_id=GROUP_ID)
+        deser = AvroDeserializer(
+            registry_client=client,
+            artifact_resolver=SimpleTopicIdStrategy(),
+            use_latest_version=True,
+        )
+        data = make_confluent_bytes(
+            CONTENT_ID, {"userId": "u1"}, schema=WRITER_SCHEMA_EVOLUTION
+        )
+        result = deser(data, _ctx())
+        assert result == {"userId": "u1", "version": "v1"}
+
+    def test_use_latest_version_reader_schema_cached(
+        self, mock_registry: respx.MockRouter
+    ) -> None:
+        """use_latest_version=True: second call does not re-fetch the latest schema."""
+        schema_route = _schema_route(
+            mock_registry, "UserEvent", schema=READER_SCHEMA_EVOLUTION
+        )
+        _id_schema_route(
+            mock_registry, "globalId", CONTENT_ID, schema=WRITER_SCHEMA_EVOLUTION
+        )
+        client = ApicurioRegistryClient(url=REGISTRY_URL, group_id=GROUP_ID)
+        deser = AvroDeserializer(
+            registry_client=client,
+            artifact_id="UserEvent",
+            use_latest_version=True,
+        )
+        data = make_confluent_bytes(
+            CONTENT_ID, {"userId": "u1"}, schema=WRITER_SCHEMA_EVOLUTION
+        )
+        deser(data, _ctx())
+        deser(data, _ctx())
+        assert schema_route.call_count == 1
+
+    def test_use_latest_version_false_is_backward_compatible(
+        self, mock_registry: respx.MockRouter
+    ) -> None:
+        """use_latest_version=False (default) with no artifact params works as before."""
+        _id_schema_route(mock_registry, "globalId", CONTENT_ID)
+        client = ApicurioRegistryClient(url=REGISTRY_URL, group_id=GROUP_ID)
+        deser = AvroDeserializer(registry_client=client)
+        data = make_confluent_bytes(CONTENT_ID, VALID_USER_EVENT)
+        result = deser(data, _ctx())
+        assert result == VALID_USER_EVENT
+
+    def test_resolver_raises_wraps_as_resolver_error(
+        self, mock_registry: respx.MockRouter
+    ) -> None:
+        """artifact_resolver that raises is wrapped as ResolverError."""
+        from apicurio_serdes._errors import ResolverError
+
+        _id_schema_route(
+            mock_registry, "globalId", CONTENT_ID, schema=WRITER_SCHEMA_EVOLUTION
+        )
+
+        def bad_resolver(ctx: object) -> str:
+            raise RuntimeError("boom")
+
+        client = ApicurioRegistryClient(url=REGISTRY_URL, group_id=GROUP_ID)
+        deser = AvroDeserializer(
+            registry_client=client,
+            artifact_resolver=bad_resolver,
+            use_latest_version=True,
+        )
+        data = make_confluent_bytes(
+            CONTENT_ID, {"userId": "u1"}, schema=WRITER_SCHEMA_EVOLUTION
+        )
+        with pytest.raises(ResolverError, match="artifact_resolver raised"):
+            deser(data, _ctx())
+
+    def test_resolver_returns_non_string_raises_resolver_error(
+        self, mock_registry: respx.MockRouter
+    ) -> None:
+        """artifact_resolver returning non-string raises ResolverError."""
+        from apicurio_serdes._errors import ResolverError
+
+        _id_schema_route(
+            mock_registry, "globalId", CONTENT_ID, schema=WRITER_SCHEMA_EVOLUTION
+        )
+
+        def bad_resolver(ctx: object) -> str:
+            return 42  # type: ignore[return-value]
+
+        client = ApicurioRegistryClient(url=REGISTRY_URL, group_id=GROUP_ID)
+        deser = AvroDeserializer(
+            registry_client=client,
+            artifact_resolver=bad_resolver,
+            use_latest_version=True,
+        )
+        data = make_confluent_bytes(
+            CONTENT_ID, {"userId": "u1"}, schema=WRITER_SCHEMA_EVOLUTION
+        )
+        with pytest.raises(ResolverError, match="non-empty str"):
             deser(data, _ctx())

--- a/tests/test_serializer.py
+++ b/tests/test_serializer.py
@@ -990,3 +990,82 @@ class TestAutoRegister:
         ctx = SerializationContext(topic="test", field=MessageField.VALUE)
         result = ser.serialize(VALID_USER_EVENT, ctx)
         assert result.payload[0:1] == b"\x00"
+
+
+class TestUseLatestVersion:
+    """Tests for AvroSerializer use_latest_version feature."""
+
+    def test_use_latest_version_and_auto_register_raises_value_error(self) -> None:
+        """use_latest_version=True + auto_register=True raises ValueError at construction."""
+        client = ApicurioRegistryClient(url=REGISTRY_URL, group_id=GROUP_ID)
+        with pytest.raises(ValueError, match="mutually exclusive"):
+            AvroSerializer(
+                registry_client=client,
+                artifact_id="UserEvent",
+                use_latest_version=True,
+                auto_register=True,
+                schema=USER_EVENT_SCHEMA_JSON,
+            )
+
+    def test_use_latest_version_with_artifact_id_serializes(
+        self, mock_registry: respx.MockRouter
+    ) -> None:
+        """use_latest_version=True with artifact_id fetches latest and serializes."""
+        _schema_route(mock_registry, "UserEvent")
+        client = ApicurioRegistryClient(url=REGISTRY_URL, group_id=GROUP_ID)
+        ser = AvroSerializer(
+            registry_client=client,
+            artifact_id="UserEvent",
+            use_latest_version=True,
+        )
+        ctx = SerializationContext(topic="test", field=MessageField.VALUE)
+        result = ser.serialize(VALID_USER_EVENT, ctx)
+        assert result.payload[0:1] == b"\x00"
+        assert len(result.payload) > 5
+
+    def test_use_latest_version_with_artifact_resolver_serializes(
+        self, mock_registry: respx.MockRouter
+    ) -> None:
+        """use_latest_version=True with artifact_resolver fetches latest and serializes."""
+        from apicurio_serdes.avro import SimpleTopicIdStrategy
+
+        _schema_route(mock_registry, "test")
+        client = ApicurioRegistryClient(url=REGISTRY_URL, group_id=GROUP_ID)
+        ser = AvroSerializer(
+            registry_client=client,
+            artifact_resolver=SimpleTopicIdStrategy(),
+            use_latest_version=True,
+        )
+        ctx = SerializationContext(topic="test", field=MessageField.VALUE)
+        result = ser.serialize(VALID_USER_EVENT, ctx)
+        assert result.payload[0:1] == b"\x00"
+
+    def test_use_latest_version_second_call_is_cache_hit(
+        self, mock_registry: respx.MockRouter
+    ) -> None:
+        """use_latest_version=True: second serialize call is an instance-cache hit."""
+        schema_route = _schema_route(mock_registry, "UserEvent")
+        client = ApicurioRegistryClient(url=REGISTRY_URL, group_id=GROUP_ID)
+        ser = AvroSerializer(
+            registry_client=client,
+            artifact_id="UserEvent",
+            use_latest_version=True,
+        )
+        ctx = SerializationContext(topic="test", field=MessageField.VALUE)
+        ser.serialize(VALID_USER_EVENT, ctx)
+        ser.serialize(VALID_USER_EVENT, ctx)
+        assert schema_route.call_count == 1
+
+    def test_use_latest_version_false_default_is_backward_compatible(
+        self, mock_registry: respx.MockRouter
+    ) -> None:
+        """use_latest_version=False (default) constructs and serializes without error."""
+        _schema_route(mock_registry, "UserEvent")
+        client = ApicurioRegistryClient(url=REGISTRY_URL, group_id=GROUP_ID)
+        ser = AvroSerializer(
+            registry_client=client,
+            artifact_id="UserEvent",
+        )
+        ctx = SerializationContext(topic="test", field=MessageField.VALUE)
+        result = ser.serialize(VALID_USER_EVENT, ctx)
+        assert result.payload[0:1] == b"\x00"

--- a/uv.lock
+++ b/uv.lock
@@ -36,6 +36,8 @@ dev = [
     { name = "pyyaml" },
     { name = "respx" },
     { name = "ruff" },
+    { name = "wily" },
+    { name = "xenon" },
 ]
 docs = [
     { name = "mkdocs" },
@@ -62,12 +64,23 @@ dev = [
     { name = "pyyaml", specifier = ">=6.0" },
     { name = "respx", specifier = ">=0.21.0" },
     { name = "ruff", specifier = ">=0.5.0" },
+    { name = "wily", specifier = ">=1.25.0" },
+    { name = "xenon", specifier = ">=0.9.0" },
 ]
 docs = [
     { name = "mkdocs", specifier = ">=1.6,<2.0" },
     { name = "mkdocs-material", specifier = ">=9.5.0,<10.0" },
     { name = "mkdocs-static-i18n", extras = ["material"], specifier = ">=1.3.0,<2.0" },
     { name = "mkdocstrings", extras = ["python"], specifier = ">=0.25.0" },
+]
+
+[[package]]
+name = "attrs"
+version = "26.1.0"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/9a/8e/82a0fe20a541c03148528be8cac2408564a6c9a0cc7e9171802bc1d26985/attrs-26.1.0.tar.gz", hash = "sha256:d03ceb89cb322a8fd706d4fb91940737b6642aa36998fe130a9bc96c985eff32", size = 952055, upload-time = "2026-03-19T14:22:25.026Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/64/b4/17d4b0b2a2dc85a6df63d1157e028ed19f90d4cd97c36717afef2bc2f395/attrs-26.1.0-py3-none-any.whl", hash = "sha256:c647aa4a12dfbad9333ca4e71fe62ddc36f4e63b2d260a37a8b83d2f043ac309", size = 67548, upload-time = "2026-03-19T14:22:23.645Z" },
 ]
 
 [[package]]
@@ -261,6 +274,18 @@ source = { registry = "https://pypi.org/simple" }
 sdist = { url = "https://files.pythonhosted.org/packages/d8/53/6f443c9a4a8358a93a6792e2acffb9d9d5cb0a5cfd8802644b7b1c9a02e4/colorama-0.4.6.tar.gz", hash = "sha256:08695f5cb7ed6e0531a20572697297273c47b8cae5a63ffc6d6ed5c201be6e44", size = 27697, upload-time = "2022-10-25T02:36:22.414Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/d1/d6/3965ed04c63042e047cb6a3e6ed1a63a35087b6a609aa3a15ed8ac56c221/colorama-0.4.6-py2.py3-none-any.whl", hash = "sha256:4f1d9991f5acc0ca119f9d443620b77f9d6b33703e51011c16baf57afb285fc6", size = 25335, upload-time = "2022-10-25T02:36:20.889Z" },
+]
+
+[[package]]
+name = "colorlog"
+version = "4.8.0"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "colorama", marker = "sys_platform == 'win32'" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/75/32/cdfba08674d72fe7895a8ec7be8f171e8502274999cae9497e4545404873/colorlog-4.8.0.tar.gz", hash = "sha256:59b53160c60902c405cdec28d38356e09d40686659048893e026ecbd589516b1", size = 28770, upload-time = "2021-03-22T11:26:32.319Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/51/62/61449c6bb74c2a3953c415b2cdb488e4f0518ac67b35e2b03a6d543035ca/colorlog-4.8.0-py2.py3-none-any.whl", hash = "sha256:3dd15cb27e8119a24c1a7b5c93f9f3b455855e0f73993b1c25921b2f646f1dcd", size = 10023, upload-time = "2021-03-22T11:26:31.281Z" },
 ]
 
 [[package]]
@@ -466,12 +491,30 @@ wheels = [
 ]
 
 [[package]]
+name = "fastjsonschema"
+version = "2.21.2"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/20/b5/23b216d9d985a956623b6bd12d4086b60f0059b27799f23016af04a74ea1/fastjsonschema-2.21.2.tar.gz", hash = "sha256:b1eb43748041c880796cd077f1a07c3d94e93ae84bba5ed36800a33554ae05de", size = 374130, upload-time = "2025-08-14T18:49:36.666Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/cb/a8/20d0723294217e47de6d9e2e40fd4a9d2f7c4b6ef974babd482a59743694/fastjsonschema-2.21.2-py3-none-any.whl", hash = "sha256:1c797122d0a86c5cace2e54bf4e819c36223b552017172f32c5c024a6b77e463", size = 24024, upload-time = "2025-08-14T18:49:34.776Z" },
+]
+
+[[package]]
 name = "filelock"
 version = "3.25.0"
 source = { registry = "https://pypi.org/simple" }
 sdist = { url = "https://files.pythonhosted.org/packages/77/18/a1fd2231c679dcb9726204645721b12498aeac28e1ad0601038f94b42556/filelock-3.25.0.tar.gz", hash = "sha256:8f00faf3abf9dc730a1ffe9c354ae5c04e079ab7d3a683b7c32da5dd05f26af3", size = 40158, upload-time = "2026-03-01T15:08:45.916Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/f9/0b/de6f54d4a8bedfe8645c41497f3c18d749f0bd3218170c667bf4b81d0cdd/filelock-3.25.0-py3-none-any.whl", hash = "sha256:5ccf8069f7948f494968fc0713c10e5c182a9c9d9eef3a636307a20c2490f047", size = 26427, upload-time = "2026-03-01T15:08:44.593Z" },
+]
+
+[[package]]
+name = "future"
+version = "1.0.0"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/a7/b2/4140c69c6a66432916b26158687e821ba631a4c9273c474343badf84d3ba/future-1.0.0.tar.gz", hash = "sha256:bd2968309307861edae1458a4f8a4f3598c03be43b97521076aebf5d94c07b05", size = 1228490, upload-time = "2024-02-21T11:52:38.461Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/da/71/ae30dadffc90b9006d77af76b393cb9dfbfc9629f339fc1574a1c52e6806/future-1.0.0-py3-none-any.whl", hash = "sha256:929292d34f5872e70396626ef385ec22355a1fae8ad29e1a734c3e43f9fbc216", size = 491326, upload-time = "2024-02-21T11:52:35.956Z" },
 ]
 
 [[package]]
@@ -493,6 +536,30 @@ dependencies = [
 sdist = { url = "https://files.pythonhosted.org/packages/d9/29/d40217cbe2f6b1359e00c6c307bb3fc876ba74068cbab3dde77f03ca0dc4/ghp-import-2.1.0.tar.gz", hash = "sha256:9c535c4c61193c2df8871222567d7fd7e5014d835f97dc7b7439069e2413d343", size = 10943, upload-time = "2022-05-02T15:47:16.11Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/f7/ec/67fbef5d497f86283db54c22eec6f6140243aae73265799baaaa19cd17fb/ghp_import-2.1.0-py3-none-any.whl", hash = "sha256:8337dd7b50877f163d4c0289bc1f1c7f127550241988d568c1db512c4324a619", size = 11034, upload-time = "2022-05-02T15:47:14.552Z" },
+]
+
+[[package]]
+name = "gitdb"
+version = "4.0.12"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "smmap" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/72/94/63b0fc47eb32792c7ba1fe1b694daec9a63620db1e313033d18140c2320a/gitdb-4.0.12.tar.gz", hash = "sha256:5ef71f855d191a3326fcfbc0d5da835f26b13fbcba60c32c21091c349ffdb571", size = 394684, upload-time = "2025-01-02T07:20:46.413Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/a0/61/5c78b91c3143ed5c14207f463aecfc8f9dbb5092fb2869baf37c273b2705/gitdb-4.0.12-py3-none-any.whl", hash = "sha256:67073e15955400952c6565cc3e707c554a4eea2e428946f7a4c162fab9bd9bcf", size = 62794, upload-time = "2025-01-02T07:20:43.624Z" },
+]
+
+[[package]]
+name = "gitpython"
+version = "3.1.46"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "gitdb" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/df/b5/59d16470a1f0dfe8c793f9ef56fd3826093fc52b3bd96d6b9d6c26c7e27b/gitpython-3.1.46.tar.gz", hash = "sha256:400124c7d0ef4ea03f7310ac2fbf7151e09ff97f2a3288d64a440c584a29c37f", size = 215371, upload-time = "2026-01-01T15:37:32.073Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/6a/09/e21df6aef1e1ffc0c816f0522ddc3f6dcded766c3261813131c78a704470/gitpython-3.1.46-py3-none-any.whl", hash = "sha256:79812ed143d9d25b6d176a10bb511de0f9c67b1fa641d82097b0ab90398a2058", size = 208620, upload-time = "2026-01-01T15:37:30.574Z" },
 ]
 
 [[package]]
@@ -568,6 +635,46 @@ dependencies = [
 sdist = { url = "https://files.pythonhosted.org/packages/df/bf/f7da0350254c0ed7c72f3e33cef02e048281fec7ecec5f032d4aac52226b/jinja2-3.1.6.tar.gz", hash = "sha256:0137fb05990d35f1275a587e9aee6d56da821fc83491a0fb838183be43f66d6d", size = 245115, upload-time = "2025-03-05T20:05:02.478Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/62/a1/3d680cbfd5f4b8f15abc1d571870c5fc3e594bb582bc3b64ea099db13e56/jinja2-3.1.6-py3-none-any.whl", hash = "sha256:85ece4451f492d0c13c5dd7c13a64681a86afae63a5f347908daf103ce6d2f67", size = 134899, upload-time = "2025-03-05T20:05:00.369Z" },
+]
+
+[[package]]
+name = "jsonschema"
+version = "4.26.0"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "attrs" },
+    { name = "jsonschema-specifications" },
+    { name = "referencing" },
+    { name = "rpds-py" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/b3/fc/e067678238fa451312d4c62bf6e6cf5ec56375422aee02f9cb5f909b3047/jsonschema-4.26.0.tar.gz", hash = "sha256:0c26707e2efad8aa1bfc5b7ce170f3fccc2e4918ff85989ba9ffa9facb2be326", size = 366583, upload-time = "2026-01-07T13:41:07.246Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/69/90/f63fb5873511e014207a475e2bb4e8b2e570d655b00ac19a9a0ca0a385ee/jsonschema-4.26.0-py3-none-any.whl", hash = "sha256:d489f15263b8d200f8387e64b4c3a75f06629559fb73deb8fdfb525f2dab50ce", size = 90630, upload-time = "2026-01-07T13:41:05.306Z" },
+]
+
+[[package]]
+name = "jsonschema-specifications"
+version = "2025.9.1"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "referencing" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/19/74/a633ee74eb36c44aa6d1095e7cc5569bebf04342ee146178e2d36600708b/jsonschema_specifications-2025.9.1.tar.gz", hash = "sha256:b540987f239e745613c7a9176f3edb72b832a4ac465cf02712288397832b5e8d", size = 32855, upload-time = "2025-09-08T01:34:59.186Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/41/45/1a4ed80516f02155c51f51e8cedb3c1902296743db0bbc66608a0db2814f/jsonschema_specifications-2025.9.1-py3-none-any.whl", hash = "sha256:98802fee3a11ee76ecaca44429fda8a41bff98b00a0f2838151b113f210cc6fe", size = 18437, upload-time = "2025-09-08T01:34:57.871Z" },
+]
+
+[[package]]
+name = "jupyter-core"
+version = "5.9.1"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "platformdirs" },
+    { name = "traitlets" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/02/49/9d1284d0dc65e2c757b74c6687b6d319b02f822ad039e5c512df9194d9dd/jupyter_core-5.9.1.tar.gz", hash = "sha256:4d09aaff303b9566c3ce657f580bd089ff5c91f5f89cf7d8846c3cdf465b5508", size = 89814, upload-time = "2025-10-16T19:19:18.444Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/e7/e7/80988e32bf6f73919a113473a604f5a8f09094de312b9d52b79c2df7612b/jupyter_core-5.9.1-py3-none-any.whl", hash = "sha256:ebf87fdc6073d142e114c72c9e29a9d7ca03fad818c5d300ce2adc1fb0743407", size = 29032, upload-time = "2025-10-16T19:19:16.783Z" },
 ]
 
 [[package]]
@@ -677,6 +784,18 @@ dependencies = [
 sdist = { url = "https://files.pythonhosted.org/packages/9e/38/bd5b78a920a64d708fe6bc8e0a2c075e1389d53bef8413725c63ba041535/mako-1.3.10.tar.gz", hash = "sha256:99579a6f39583fa7e5630a28c3c1f440e4e97a414b80372649c0ce338da2ea28", size = 392474, upload-time = "2025-04-10T12:44:31.16Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/87/fb/99f81ac72ae23375f22b7afdb7642aba97c00a713c217124420147681a2f/mako-1.3.10-py3-none-any.whl", hash = "sha256:baef24a52fc4fc514a0887ac600f9f1cff3d82c61d4d700a1fa84d597b88db59", size = 78509, upload-time = "2025-04-10T12:50:53.297Z" },
+]
+
+[[package]]
+name = "mando"
+version = "0.6.4"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "six" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/8a/fe/1b94ddd9c89c8be761c0b5ca01498029f1253f059a59f03f7be369255e75/mando-0.6.4.tar.gz", hash = "sha256:79feb19dc0f097daa64a1243db578e7674909b75f88ac2220f1c065c10a0d960", size = 214068, upload-time = "2017-06-05T07:02:54.836Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/e6/cc/f6e25247c1493a654785e68cd975e479c311e99dafedd49ed17f8d300e0c/mando-0.6.4-py2.py3-none-any.whl", hash = "sha256:4ce09faec7e5192ffc3c57830e26acba0fd6cd11e1ee81af0d4df0657463bd1c", size = 29276, upload-time = "2017-06-05T07:02:57.728Z" },
 ]
 
 [[package]]
@@ -1057,6 +1176,21 @@ wheels = [
 ]
 
 [[package]]
+name = "nbformat"
+version = "5.10.4"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "fastjsonschema" },
+    { name = "jsonschema" },
+    { name = "jupyter-core" },
+    { name = "traitlets" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/6d/fd/91545e604bc3dad7dca9ed03284086039b294c6b3d75c0d2fa45f9e9caf3/nbformat-5.10.4.tar.gz", hash = "sha256:322168b14f937a5d11362988ecac2a4952d3d8e3a2cbeb2319584631226d5b3a", size = 142749, upload-time = "2024-04-04T11:20:37.371Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/a9/82/0340caa499416c78e5d8f5f05947ae4bc3cba53c9f038ab6e9ed964e22f1/nbformat-5.10.4-py3-none-any.whl", hash = "sha256:3b48d6c8fbca4b299bf3982ea7db1af21580e4fec269ad087b9e81588891200b", size = 78454, upload-time = "2024-04-04T11:20:34.895Z" },
+]
+
+[[package]]
 name = "packageurl-python"
 version = "0.17.6"
 source = { registry = "https://pypi.org/simple" }
@@ -1179,12 +1313,34 @@ wheels = [
 ]
 
 [[package]]
+name = "plotly"
+version = "5.24.1"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "packaging" },
+    { name = "tenacity" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/79/4f/428f6d959818d7425a94c190a6b26fbc58035cbef40bf249be0b62a9aedd/plotly-5.24.1.tar.gz", hash = "sha256:dbc8ac8339d248a4bcc36e08a5659bacfe1b079390b8953533f4eb22169b4bae", size = 9479398, upload-time = "2024-09-12T15:36:31.068Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/e5/ae/580600f441f6fc05218bd6c9d5794f4aef072a7d9093b291f1c50a9db8bc/plotly-5.24.1-py3-none-any.whl", hash = "sha256:f67073a1e637eb0dc3e46324d9d51e2fe76e9727c892dde64ddf1e1b51f29089", size = 19054220, upload-time = "2024-09-12T15:36:24.08Z" },
+]
+
+[[package]]
 name = "pluggy"
 version = "1.6.0"
 source = { registry = "https://pypi.org/simple" }
 sdist = { url = "https://files.pythonhosted.org/packages/f9/e2/3e91f31a7d2b083fe6ef3fa267035b518369d9511ffab804f839851d2779/pluggy-1.6.0.tar.gz", hash = "sha256:7dcc130b76258d33b90f61b658791dede3486c3e6bfb003ee5c9bfb396dd22f3", size = 69412, upload-time = "2025-05-15T12:30:07.975Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/54/20/4d324d65cc6d9205fabedc306948156824eb9f0ee1633355a8f7ec5c66bf/pluggy-1.6.0-py3-none-any.whl", hash = "sha256:e920276dd6813095e9377c0bc5566d94c932c33b27a3e3945d8389c374dd4746", size = 20538, upload-time = "2025-05-15T12:30:06.134Z" },
+]
+
+[[package]]
+name = "progress"
+version = "1.6.1"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/ac/26/3b086f0c5d6c1c18c2430d6fac3a99d79553884ca6cdf759cf256dd43b7d/progress-1.6.1.tar.gz", hash = "sha256:c1ba719f862ce885232a759eab47971fe74dfc7bb76ab8a51ef5940bad35086c", size = 7164, upload-time = "2025-07-01T05:50:43.33Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/42/59/123aee44a039b212cfb8d90be1adf06496a99b313ee1683aadf90b3d9799/progress-1.6.1-py3-none-any.whl", hash = "sha256:5239f22f305c12fdc8ce6e0e47f70f21622a935e16eafc4535617112e7c7ea0b", size = 9761, upload-time = "2025-07-01T05:50:40.963Z" },
 ]
 
 [[package]]
@@ -1383,6 +1539,34 @@ wheels = [
 ]
 
 [[package]]
+name = "radon"
+version = "5.1.0"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "colorama" },
+    { name = "future" },
+    { name = "mando" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/f5/37/737fb1a1786d9daed92e3ce1b8fe484c10d2a51078febffddd14ffdc0081/radon-5.1.0.tar.gz", hash = "sha256:cb1d8752e5f862fb9e20d82b5f758cbc4fb1237c92c9a66450ea0ea7bf29aeee", size = 1873643, upload-time = "2021-08-08T13:25:23.754Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/c0/0f/25c8256018b6e90265f440651ec60311818c01a008564c0f106b7d915b60/radon-5.1.0-py2.py3-none-any.whl", hash = "sha256:fa74e018197f1fcb54578af0f675d8b8e2342bd8e0b72bef8197bc4c9e645f36", size = 52143, upload-time = "2021-08-08T13:25:20.919Z" },
+]
+
+[[package]]
+name = "referencing"
+version = "0.37.0"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "attrs" },
+    { name = "rpds-py" },
+    { name = "typing-extensions", marker = "python_full_version < '3.13'" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/22/f5/df4e9027acead3ecc63e50fe1e36aca1523e1719559c499951bb4b53188f/referencing-0.37.0.tar.gz", hash = "sha256:44aefc3142c5b842538163acb373e24cce6632bd54bdb01b21ad5863489f50d8", size = 78036, upload-time = "2025-10-13T15:30:48.871Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/2c/58/ca301544e1fa93ed4f80d724bf5b194f6e4b945841c5bfd555878eea9fcb/referencing-0.37.0-py3-none-any.whl", hash = "sha256:381329a9f99628c9069361716891d34ad94af76e461dcb0335825aecc7692231", size = 26766, upload-time = "2025-10-13T15:30:47.625Z" },
+]
+
+[[package]]
 name = "requests"
 version = "2.32.5"
 source = { registry = "https://pypi.org/simple" }
@@ -1423,6 +1607,128 @@ wheels = [
 ]
 
 [[package]]
+name = "rpds-py"
+version = "0.30.0"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/20/af/3f2f423103f1113b36230496629986e0ef7e199d2aa8392452b484b38ced/rpds_py-0.30.0.tar.gz", hash = "sha256:dd8ff7cf90014af0c0f787eea34794ebf6415242ee1d6fa91eaba725cc441e84", size = 69469, upload-time = "2025-11-30T20:24:38.837Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/06/0c/0c411a0ec64ccb6d104dcabe0e713e05e153a9a2c3c2bd2b32ce412166fe/rpds_py-0.30.0-cp310-cp310-macosx_10_12_x86_64.whl", hash = "sha256:679ae98e00c0e8d68a7fda324e16b90fd5260945b45d3b824c892cec9eea3288", size = 370490, upload-time = "2025-11-30T20:21:33.256Z" },
+    { url = "https://files.pythonhosted.org/packages/19/6a/4ba3d0fb7297ebae71171822554abe48d7cab29c28b8f9f2c04b79988c05/rpds_py-0.30.0-cp310-cp310-macosx_11_0_arm64.whl", hash = "sha256:4cc2206b76b4f576934f0ed374b10d7ca5f457858b157ca52064bdfc26b9fc00", size = 359751, upload-time = "2025-11-30T20:21:34.591Z" },
+    { url = "https://files.pythonhosted.org/packages/cd/7c/e4933565ef7f7a0818985d87c15d9d273f1a649afa6a52ea35ad011195ea/rpds_py-0.30.0-cp310-cp310-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:389a2d49eded1896c3d48b0136ead37c48e221b391c052fba3f4055c367f60a6", size = 389696, upload-time = "2025-11-30T20:21:36.122Z" },
+    { url = "https://files.pythonhosted.org/packages/5e/01/6271a2511ad0815f00f7ed4390cf2567bec1d4b1da39e2c27a41e6e3b4de/rpds_py-0.30.0-cp310-cp310-manylinux_2_17_armv7l.manylinux2014_armv7l.whl", hash = "sha256:32c8528634e1bf7121f3de08fa85b138f4e0dc47657866630611b03967f041d7", size = 403136, upload-time = "2025-11-30T20:21:37.728Z" },
+    { url = "https://files.pythonhosted.org/packages/55/64/c857eb7cd7541e9b4eee9d49c196e833128a55b89a9850a9c9ac33ccf897/rpds_py-0.30.0-cp310-cp310-manylinux_2_17_ppc64le.manylinux2014_ppc64le.whl", hash = "sha256:f207f69853edd6f6700b86efb84999651baf3789e78a466431df1331608e5324", size = 524699, upload-time = "2025-11-30T20:21:38.92Z" },
+    { url = "https://files.pythonhosted.org/packages/9c/ed/94816543404078af9ab26159c44f9e98e20fe47e2126d5d32c9d9948d10a/rpds_py-0.30.0-cp310-cp310-manylinux_2_17_s390x.manylinux2014_s390x.whl", hash = "sha256:67b02ec25ba7a9e8fa74c63b6ca44cf5707f2fbfadae3ee8e7494297d56aa9df", size = 412022, upload-time = "2025-11-30T20:21:40.407Z" },
+    { url = "https://files.pythonhosted.org/packages/61/b5/707f6cf0066a6412aacc11d17920ea2e19e5b2f04081c64526eb35b5c6e7/rpds_py-0.30.0-cp310-cp310-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:0c0e95f6819a19965ff420f65578bacb0b00f251fefe2c8b23347c37174271f3", size = 390522, upload-time = "2025-11-30T20:21:42.17Z" },
+    { url = "https://files.pythonhosted.org/packages/13/4e/57a85fda37a229ff4226f8cbcf09f2a455d1ed20e802ce5b2b4a7f5ed053/rpds_py-0.30.0-cp310-cp310-manylinux_2_31_riscv64.whl", hash = "sha256:a452763cc5198f2f98898eb98f7569649fe5da666c2dc6b5ddb10fde5a574221", size = 404579, upload-time = "2025-11-30T20:21:43.769Z" },
+    { url = "https://files.pythonhosted.org/packages/f9/da/c9339293513ec680a721e0e16bf2bac3db6e5d7e922488de471308349bba/rpds_py-0.30.0-cp310-cp310-manylinux_2_5_i686.manylinux1_i686.whl", hash = "sha256:e0b65193a413ccc930671c55153a03ee57cecb49e6227204b04fae512eb657a7", size = 421305, upload-time = "2025-11-30T20:21:44.994Z" },
+    { url = "https://files.pythonhosted.org/packages/f9/be/522cb84751114f4ad9d822ff5a1aa3c98006341895d5f084779b99596e5c/rpds_py-0.30.0-cp310-cp310-musllinux_1_2_aarch64.whl", hash = "sha256:858738e9c32147f78b3ac24dc0edb6610000e56dc0f700fd5f651d0a0f0eb9ff", size = 572503, upload-time = "2025-11-30T20:21:46.91Z" },
+    { url = "https://files.pythonhosted.org/packages/a2/9b/de879f7e7ceddc973ea6e4629e9b380213a6938a249e94b0cdbcc325bb66/rpds_py-0.30.0-cp310-cp310-musllinux_1_2_i686.whl", hash = "sha256:da279aa314f00acbb803da1e76fa18666778e8a8f83484fba94526da5de2cba7", size = 598322, upload-time = "2025-11-30T20:21:48.709Z" },
+    { url = "https://files.pythonhosted.org/packages/48/ac/f01fc22efec3f37d8a914fc1b2fb9bcafd56a299edbe96406f3053edea5a/rpds_py-0.30.0-cp310-cp310-musllinux_1_2_x86_64.whl", hash = "sha256:7c64d38fb49b6cdeda16ab49e35fe0da2e1e9b34bc38bd78386530f218b37139", size = 560792, upload-time = "2025-11-30T20:21:50.024Z" },
+    { url = "https://files.pythonhosted.org/packages/e2/da/4e2b19d0f131f35b6146425f846563d0ce036763e38913d917187307a671/rpds_py-0.30.0-cp310-cp310-win32.whl", hash = "sha256:6de2a32a1665b93233cde140ff8b3467bdb9e2af2b91079f0333a0974d12d464", size = 221901, upload-time = "2025-11-30T20:21:51.32Z" },
+    { url = "https://files.pythonhosted.org/packages/96/cb/156d7a5cf4f78a7cc571465d8aec7a3c447c94f6749c5123f08438bcf7bc/rpds_py-0.30.0-cp310-cp310-win_amd64.whl", hash = "sha256:1726859cd0de969f88dc8673bdd954185b9104e05806be64bcd87badbe313169", size = 235823, upload-time = "2025-11-30T20:21:52.505Z" },
+    { url = "https://files.pythonhosted.org/packages/4d/6e/f964e88b3d2abee2a82c1ac8366da848fce1c6d834dc2132c3fda3970290/rpds_py-0.30.0-cp311-cp311-macosx_10_12_x86_64.whl", hash = "sha256:a2bffea6a4ca9f01b3f8e548302470306689684e61602aa3d141e34da06cf425", size = 370157, upload-time = "2025-11-30T20:21:53.789Z" },
+    { url = "https://files.pythonhosted.org/packages/94/ba/24e5ebb7c1c82e74c4e4f33b2112a5573ddc703915b13a073737b59b86e0/rpds_py-0.30.0-cp311-cp311-macosx_11_0_arm64.whl", hash = "sha256:dc4f992dfe1e2bc3ebc7444f6c7051b4bc13cd8e33e43511e8ffd13bf407010d", size = 359676, upload-time = "2025-11-30T20:21:55.475Z" },
+    { url = "https://files.pythonhosted.org/packages/84/86/04dbba1b087227747d64d80c3b74df946b986c57af0a9f0c98726d4d7a3b/rpds_py-0.30.0-cp311-cp311-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:422c3cb9856d80b09d30d2eb255d0754b23e090034e1deb4083f8004bd0761e4", size = 389938, upload-time = "2025-11-30T20:21:57.079Z" },
+    { url = "https://files.pythonhosted.org/packages/42/bb/1463f0b1722b7f45431bdd468301991d1328b16cffe0b1c2918eba2c4eee/rpds_py-0.30.0-cp311-cp311-manylinux_2_17_armv7l.manylinux2014_armv7l.whl", hash = "sha256:07ae8a593e1c3c6b82ca3292efbe73c30b61332fd612e05abee07c79359f292f", size = 402932, upload-time = "2025-11-30T20:21:58.47Z" },
+    { url = "https://files.pythonhosted.org/packages/99/ee/2520700a5c1f2d76631f948b0736cdf9b0acb25abd0ca8e889b5c62ac2e3/rpds_py-0.30.0-cp311-cp311-manylinux_2_17_ppc64le.manylinux2014_ppc64le.whl", hash = "sha256:12f90dd7557b6bd57f40abe7747e81e0c0b119bef015ea7726e69fe550e394a4", size = 525830, upload-time = "2025-11-30T20:21:59.699Z" },
+    { url = "https://files.pythonhosted.org/packages/e0/ad/bd0331f740f5705cc555a5e17fdf334671262160270962e69a2bdef3bf76/rpds_py-0.30.0-cp311-cp311-manylinux_2_17_s390x.manylinux2014_s390x.whl", hash = "sha256:99b47d6ad9a6da00bec6aabe5a6279ecd3c06a329d4aa4771034a21e335c3a97", size = 412033, upload-time = "2025-11-30T20:22:00.991Z" },
+    { url = "https://files.pythonhosted.org/packages/f8/1e/372195d326549bb51f0ba0f2ecb9874579906b97e08880e7a65c3bef1a99/rpds_py-0.30.0-cp311-cp311-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:33f559f3104504506a44bb666b93a33f5d33133765b0c216a5bf2f1e1503af89", size = 390828, upload-time = "2025-11-30T20:22:02.723Z" },
+    { url = "https://files.pythonhosted.org/packages/ab/2b/d88bb33294e3e0c76bc8f351a3721212713629ffca1700fa94979cb3eae8/rpds_py-0.30.0-cp311-cp311-manylinux_2_31_riscv64.whl", hash = "sha256:946fe926af6e44f3697abbc305ea168c2c31d3e3ef1058cf68f379bf0335a78d", size = 404683, upload-time = "2025-11-30T20:22:04.367Z" },
+    { url = "https://files.pythonhosted.org/packages/50/32/c759a8d42bcb5289c1fac697cd92f6fe01a018dd937e62ae77e0e7f15702/rpds_py-0.30.0-cp311-cp311-manylinux_2_5_i686.manylinux1_i686.whl", hash = "sha256:495aeca4b93d465efde585977365187149e75383ad2684f81519f504f5c13038", size = 421583, upload-time = "2025-11-30T20:22:05.814Z" },
+    { url = "https://files.pythonhosted.org/packages/2b/81/e729761dbd55ddf5d84ec4ff1f47857f4374b0f19bdabfcf929164da3e24/rpds_py-0.30.0-cp311-cp311-musllinux_1_2_aarch64.whl", hash = "sha256:d9a0ca5da0386dee0655b4ccdf46119df60e0f10da268d04fe7cc87886872ba7", size = 572496, upload-time = "2025-11-30T20:22:07.713Z" },
+    { url = "https://files.pythonhosted.org/packages/14/f6/69066a924c3557c9c30baa6ec3a0aa07526305684c6f86c696b08860726c/rpds_py-0.30.0-cp311-cp311-musllinux_1_2_i686.whl", hash = "sha256:8d6d1cc13664ec13c1b84241204ff3b12f9bb82464b8ad6e7a5d3486975c2eed", size = 598669, upload-time = "2025-11-30T20:22:09.312Z" },
+    { url = "https://files.pythonhosted.org/packages/5f/48/905896b1eb8a05630d20333d1d8ffd162394127b74ce0b0784ae04498d32/rpds_py-0.30.0-cp311-cp311-musllinux_1_2_x86_64.whl", hash = "sha256:3896fa1be39912cf0757753826bc8bdc8ca331a28a7c4ae46b7a21280b06bb85", size = 561011, upload-time = "2025-11-30T20:22:11.309Z" },
+    { url = "https://files.pythonhosted.org/packages/22/16/cd3027c7e279d22e5eb431dd3c0fbc677bed58797fe7581e148f3f68818b/rpds_py-0.30.0-cp311-cp311-win32.whl", hash = "sha256:55f66022632205940f1827effeff17c4fa7ae1953d2b74a8581baaefb7d16f8c", size = 221406, upload-time = "2025-11-30T20:22:13.101Z" },
+    { url = "https://files.pythonhosted.org/packages/fa/5b/e7b7aa136f28462b344e652ee010d4de26ee9fd16f1bfd5811f5153ccf89/rpds_py-0.30.0-cp311-cp311-win_amd64.whl", hash = "sha256:a51033ff701fca756439d641c0ad09a41d9242fa69121c7d8769604a0a629825", size = 236024, upload-time = "2025-11-30T20:22:14.853Z" },
+    { url = "https://files.pythonhosted.org/packages/14/a6/364bba985e4c13658edb156640608f2c9e1d3ea3c81b27aa9d889fff0e31/rpds_py-0.30.0-cp311-cp311-win_arm64.whl", hash = "sha256:47b0ef6231c58f506ef0b74d44e330405caa8428e770fec25329ed2cb971a229", size = 229069, upload-time = "2025-11-30T20:22:16.577Z" },
+    { url = "https://files.pythonhosted.org/packages/03/e7/98a2f4ac921d82f33e03f3835f5bf3a4a40aa1bfdc57975e74a97b2b4bdd/rpds_py-0.30.0-cp312-cp312-macosx_10_12_x86_64.whl", hash = "sha256:a161f20d9a43006833cd7068375a94d035714d73a172b681d8881820600abfad", size = 375086, upload-time = "2025-11-30T20:22:17.93Z" },
+    { url = "https://files.pythonhosted.org/packages/4d/a1/bca7fd3d452b272e13335db8d6b0b3ecde0f90ad6f16f3328c6fb150c889/rpds_py-0.30.0-cp312-cp312-macosx_11_0_arm64.whl", hash = "sha256:6abc8880d9d036ecaafe709079969f56e876fcf107f7a8e9920ba6d5a3878d05", size = 359053, upload-time = "2025-11-30T20:22:19.297Z" },
+    { url = "https://files.pythonhosted.org/packages/65/1c/ae157e83a6357eceff62ba7e52113e3ec4834a84cfe07fa4b0757a7d105f/rpds_py-0.30.0-cp312-cp312-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:ca28829ae5f5d569bb62a79512c842a03a12576375d5ece7d2cadf8abe96ec28", size = 390763, upload-time = "2025-11-30T20:22:21.661Z" },
+    { url = "https://files.pythonhosted.org/packages/d4/36/eb2eb8515e2ad24c0bd43c3ee9cd74c33f7ca6430755ccdb240fd3144c44/rpds_py-0.30.0-cp312-cp312-manylinux_2_17_armv7l.manylinux2014_armv7l.whl", hash = "sha256:a1010ed9524c73b94d15919ca4d41d8780980e1765babf85f9a2f90d247153dd", size = 408951, upload-time = "2025-11-30T20:22:23.408Z" },
+    { url = "https://files.pythonhosted.org/packages/d6/65/ad8dc1784a331fabbd740ef6f71ce2198c7ed0890dab595adb9ea2d775a1/rpds_py-0.30.0-cp312-cp312-manylinux_2_17_ppc64le.manylinux2014_ppc64le.whl", hash = "sha256:f8d1736cfb49381ba528cd5baa46f82fdc65c06e843dab24dd70b63d09121b3f", size = 514622, upload-time = "2025-11-30T20:22:25.16Z" },
+    { url = "https://files.pythonhosted.org/packages/63/8e/0cfa7ae158e15e143fe03993b5bcd743a59f541f5952e1546b1ac1b5fd45/rpds_py-0.30.0-cp312-cp312-manylinux_2_17_s390x.manylinux2014_s390x.whl", hash = "sha256:d948b135c4693daff7bc2dcfc4ec57237a29bd37e60c2fabf5aff2bbacf3e2f1", size = 414492, upload-time = "2025-11-30T20:22:26.505Z" },
+    { url = "https://files.pythonhosted.org/packages/60/1b/6f8f29f3f995c7ffdde46a626ddccd7c63aefc0efae881dc13b6e5d5bb16/rpds_py-0.30.0-cp312-cp312-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:47f236970bccb2233267d89173d3ad2703cd36a0e2a6e92d0560d333871a3d23", size = 394080, upload-time = "2025-11-30T20:22:27.934Z" },
+    { url = "https://files.pythonhosted.org/packages/6d/d5/a266341051a7a3ca2f4b750a3aa4abc986378431fc2da508c5034d081b70/rpds_py-0.30.0-cp312-cp312-manylinux_2_31_riscv64.whl", hash = "sha256:2e6ecb5a5bcacf59c3f912155044479af1d0b6681280048b338b28e364aca1f6", size = 408680, upload-time = "2025-11-30T20:22:29.341Z" },
+    { url = "https://files.pythonhosted.org/packages/10/3b/71b725851df9ab7a7a4e33cf36d241933da66040d195a84781f49c50490c/rpds_py-0.30.0-cp312-cp312-manylinux_2_5_i686.manylinux1_i686.whl", hash = "sha256:a8fa71a2e078c527c3e9dc9fc5a98c9db40bcc8a92b4e8858e36d329f8684b51", size = 423589, upload-time = "2025-11-30T20:22:31.469Z" },
+    { url = "https://files.pythonhosted.org/packages/00/2b/e59e58c544dc9bd8bd8384ecdb8ea91f6727f0e37a7131baeff8d6f51661/rpds_py-0.30.0-cp312-cp312-musllinux_1_2_aarch64.whl", hash = "sha256:73c67f2db7bc334e518d097c6d1e6fed021bbc9b7d678d6cc433478365d1d5f5", size = 573289, upload-time = "2025-11-30T20:22:32.997Z" },
+    { url = "https://files.pythonhosted.org/packages/da/3e/a18e6f5b460893172a7d6a680e86d3b6bc87a54c1f0b03446a3c8c7b588f/rpds_py-0.30.0-cp312-cp312-musllinux_1_2_i686.whl", hash = "sha256:5ba103fb455be00f3b1c2076c9d4264bfcb037c976167a6047ed82f23153f02e", size = 599737, upload-time = "2025-11-30T20:22:34.419Z" },
+    { url = "https://files.pythonhosted.org/packages/5c/e2/714694e4b87b85a18e2c243614974413c60aa107fd815b8cbc42b873d1d7/rpds_py-0.30.0-cp312-cp312-musllinux_1_2_x86_64.whl", hash = "sha256:7cee9c752c0364588353e627da8a7e808a66873672bcb5f52890c33fd965b394", size = 563120, upload-time = "2025-11-30T20:22:35.903Z" },
+    { url = "https://files.pythonhosted.org/packages/6f/ab/d5d5e3bcedb0a77f4f613706b750e50a5a3ba1c15ccd3665ecc636c968fd/rpds_py-0.30.0-cp312-cp312-win32.whl", hash = "sha256:1ab5b83dbcf55acc8b08fc62b796ef672c457b17dbd7820a11d6c52c06839bdf", size = 223782, upload-time = "2025-11-30T20:22:37.271Z" },
+    { url = "https://files.pythonhosted.org/packages/39/3b/f786af9957306fdc38a74cef405b7b93180f481fb48453a114bb6465744a/rpds_py-0.30.0-cp312-cp312-win_amd64.whl", hash = "sha256:a090322ca841abd453d43456ac34db46e8b05fd9b3b4ac0c78bcde8b089f959b", size = 240463, upload-time = "2025-11-30T20:22:39.021Z" },
+    { url = "https://files.pythonhosted.org/packages/f3/d2/b91dc748126c1559042cfe41990deb92c4ee3e2b415f6b5234969ffaf0cc/rpds_py-0.30.0-cp312-cp312-win_arm64.whl", hash = "sha256:669b1805bd639dd2989b281be2cfd951c6121b65e729d9b843e9639ef1fd555e", size = 230868, upload-time = "2025-11-30T20:22:40.493Z" },
+    { url = "https://files.pythonhosted.org/packages/ed/dc/d61221eb88ff410de3c49143407f6f3147acf2538c86f2ab7ce65ae7d5f9/rpds_py-0.30.0-cp313-cp313-macosx_10_12_x86_64.whl", hash = "sha256:f83424d738204d9770830d35290ff3273fbb02b41f919870479fab14b9d303b2", size = 374887, upload-time = "2025-11-30T20:22:41.812Z" },
+    { url = "https://files.pythonhosted.org/packages/fd/32/55fb50ae104061dbc564ef15cc43c013dc4a9f4527a1f4d99baddf56fe5f/rpds_py-0.30.0-cp313-cp313-macosx_11_0_arm64.whl", hash = "sha256:e7536cd91353c5273434b4e003cbda89034d67e7710eab8761fd918ec6c69cf8", size = 358904, upload-time = "2025-11-30T20:22:43.479Z" },
+    { url = "https://files.pythonhosted.org/packages/58/70/faed8186300e3b9bdd138d0273109784eea2396c68458ed580f885dfe7ad/rpds_py-0.30.0-cp313-cp313-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:2771c6c15973347f50fece41fc447c054b7ac2ae0502388ce3b6738cd366e3d4", size = 389945, upload-time = "2025-11-30T20:22:44.819Z" },
+    { url = "https://files.pythonhosted.org/packages/bd/a8/073cac3ed2c6387df38f71296d002ab43496a96b92c823e76f46b8af0543/rpds_py-0.30.0-cp313-cp313-manylinux_2_17_armv7l.manylinux2014_armv7l.whl", hash = "sha256:0a59119fc6e3f460315fe9d08149f8102aa322299deaa5cab5b40092345c2136", size = 407783, upload-time = "2025-11-30T20:22:46.103Z" },
+    { url = "https://files.pythonhosted.org/packages/77/57/5999eb8c58671f1c11eba084115e77a8899d6e694d2a18f69f0ba471ec8b/rpds_py-0.30.0-cp313-cp313-manylinux_2_17_ppc64le.manylinux2014_ppc64le.whl", hash = "sha256:76fec018282b4ead0364022e3c54b60bf368b9d926877957a8624b58419169b7", size = 515021, upload-time = "2025-11-30T20:22:47.458Z" },
+    { url = "https://files.pythonhosted.org/packages/e0/af/5ab4833eadc36c0a8ed2bc5c0de0493c04f6c06de223170bd0798ff98ced/rpds_py-0.30.0-cp313-cp313-manylinux_2_17_s390x.manylinux2014_s390x.whl", hash = "sha256:692bef75a5525db97318e8cd061542b5a79812d711ea03dbc1f6f8dbb0c5f0d2", size = 414589, upload-time = "2025-11-30T20:22:48.872Z" },
+    { url = "https://files.pythonhosted.org/packages/b7/de/f7192e12b21b9e9a68a6d0f249b4af3fdcdff8418be0767a627564afa1f1/rpds_py-0.30.0-cp313-cp313-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:9027da1ce107104c50c81383cae773ef5c24d296dd11c99e2629dbd7967a20c6", size = 394025, upload-time = "2025-11-30T20:22:50.196Z" },
+    { url = "https://files.pythonhosted.org/packages/91/c4/fc70cd0249496493500e7cc2de87504f5aa6509de1e88623431fec76d4b6/rpds_py-0.30.0-cp313-cp313-manylinux_2_31_riscv64.whl", hash = "sha256:9cf69cdda1f5968a30a359aba2f7f9aa648a9ce4b580d6826437f2b291cfc86e", size = 408895, upload-time = "2025-11-30T20:22:51.87Z" },
+    { url = "https://files.pythonhosted.org/packages/58/95/d9275b05ab96556fefff73a385813eb66032e4c99f411d0795372d9abcea/rpds_py-0.30.0-cp313-cp313-manylinux_2_5_i686.manylinux1_i686.whl", hash = "sha256:a4796a717bf12b9da9d3ad002519a86063dcac8988b030e405704ef7d74d2d9d", size = 422799, upload-time = "2025-11-30T20:22:53.341Z" },
+    { url = "https://files.pythonhosted.org/packages/06/c1/3088fc04b6624eb12a57eb814f0d4997a44b0d208d6cace713033ff1a6ba/rpds_py-0.30.0-cp313-cp313-musllinux_1_2_aarch64.whl", hash = "sha256:5d4c2aa7c50ad4728a094ebd5eb46c452e9cb7edbfdb18f9e1221f597a73e1e7", size = 572731, upload-time = "2025-11-30T20:22:54.778Z" },
+    { url = "https://files.pythonhosted.org/packages/d8/42/c612a833183b39774e8ac8fecae81263a68b9583ee343db33ab571a7ce55/rpds_py-0.30.0-cp313-cp313-musllinux_1_2_i686.whl", hash = "sha256:ba81a9203d07805435eb06f536d95a266c21e5b2dfbf6517748ca40c98d19e31", size = 599027, upload-time = "2025-11-30T20:22:56.212Z" },
+    { url = "https://files.pythonhosted.org/packages/5f/60/525a50f45b01d70005403ae0e25f43c0384369ad24ffe46e8d9068b50086/rpds_py-0.30.0-cp313-cp313-musllinux_1_2_x86_64.whl", hash = "sha256:945dccface01af02675628334f7cf49c2af4c1c904748efc5cf7bbdf0b579f95", size = 563020, upload-time = "2025-11-30T20:22:58.2Z" },
+    { url = "https://files.pythonhosted.org/packages/0b/5d/47c4655e9bcd5ca907148535c10e7d489044243cc9941c16ed7cd53be91d/rpds_py-0.30.0-cp313-cp313-win32.whl", hash = "sha256:b40fb160a2db369a194cb27943582b38f79fc4887291417685f3ad693c5a1d5d", size = 223139, upload-time = "2025-11-30T20:23:00.209Z" },
+    { url = "https://files.pythonhosted.org/packages/f2/e1/485132437d20aa4d3e1d8b3fb5a5e65aa8139f1e097080c2a8443201742c/rpds_py-0.30.0-cp313-cp313-win_amd64.whl", hash = "sha256:806f36b1b605e2d6a72716f321f20036b9489d29c51c91f4dd29a3e3afb73b15", size = 240224, upload-time = "2025-11-30T20:23:02.008Z" },
+    { url = "https://files.pythonhosted.org/packages/24/95/ffd128ed1146a153d928617b0ef673960130be0009c77d8fbf0abe306713/rpds_py-0.30.0-cp313-cp313-win_arm64.whl", hash = "sha256:d96c2086587c7c30d44f31f42eae4eac89b60dabbac18c7669be3700f13c3ce1", size = 230645, upload-time = "2025-11-30T20:23:03.43Z" },
+    { url = "https://files.pythonhosted.org/packages/ff/1b/b10de890a0def2a319a2626334a7f0ae388215eb60914dbac8a3bae54435/rpds_py-0.30.0-cp313-cp313t-macosx_10_12_x86_64.whl", hash = "sha256:eb0b93f2e5c2189ee831ee43f156ed34e2a89a78a66b98cadad955972548be5a", size = 364443, upload-time = "2025-11-30T20:23:04.878Z" },
+    { url = "https://files.pythonhosted.org/packages/0d/bf/27e39f5971dc4f305a4fb9c672ca06f290f7c4e261c568f3dea16a410d47/rpds_py-0.30.0-cp313-cp313t-macosx_11_0_arm64.whl", hash = "sha256:922e10f31f303c7c920da8981051ff6d8c1a56207dbdf330d9047f6d30b70e5e", size = 353375, upload-time = "2025-11-30T20:23:06.342Z" },
+    { url = "https://files.pythonhosted.org/packages/40/58/442ada3bba6e8e6615fc00483135c14a7538d2ffac30e2d933ccf6852232/rpds_py-0.30.0-cp313-cp313t-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:cdc62c8286ba9bf7f47befdcea13ea0e26bf294bda99758fd90535cbaf408000", size = 383850, upload-time = "2025-11-30T20:23:07.825Z" },
+    { url = "https://files.pythonhosted.org/packages/14/14/f59b0127409a33c6ef6f5c1ebd5ad8e32d7861c9c7adfa9a624fc3889f6c/rpds_py-0.30.0-cp313-cp313t-manylinux_2_17_armv7l.manylinux2014_armv7l.whl", hash = "sha256:47f9a91efc418b54fb8190a6b4aa7813a23fb79c51f4bb84e418f5476c38b8db", size = 392812, upload-time = "2025-11-30T20:23:09.228Z" },
+    { url = "https://files.pythonhosted.org/packages/b3/66/e0be3e162ac299b3a22527e8913767d869e6cc75c46bd844aa43fb81ab62/rpds_py-0.30.0-cp313-cp313t-manylinux_2_17_ppc64le.manylinux2014_ppc64le.whl", hash = "sha256:1f3587eb9b17f3789ad50824084fa6f81921bbf9a795826570bda82cb3ed91f2", size = 517841, upload-time = "2025-11-30T20:23:11.186Z" },
+    { url = "https://files.pythonhosted.org/packages/3d/55/fa3b9cf31d0c963ecf1ba777f7cf4b2a2c976795ac430d24a1f43d25a6ba/rpds_py-0.30.0-cp313-cp313t-manylinux_2_17_s390x.manylinux2014_s390x.whl", hash = "sha256:39c02563fc592411c2c61d26b6c5fe1e51eaa44a75aa2c8735ca88b0d9599daa", size = 408149, upload-time = "2025-11-30T20:23:12.864Z" },
+    { url = "https://files.pythonhosted.org/packages/60/ca/780cf3b1a32b18c0f05c441958d3758f02544f1d613abf9488cd78876378/rpds_py-0.30.0-cp313-cp313t-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:51a1234d8febafdfd33a42d97da7a43f5dcb120c1060e352a3fbc0c6d36e2083", size = 383843, upload-time = "2025-11-30T20:23:14.638Z" },
+    { url = "https://files.pythonhosted.org/packages/82/86/d5f2e04f2aa6247c613da0c1dd87fcd08fa17107e858193566048a1e2f0a/rpds_py-0.30.0-cp313-cp313t-manylinux_2_31_riscv64.whl", hash = "sha256:eb2c4071ab598733724c08221091e8d80e89064cd472819285a9ab0f24bcedb9", size = 396507, upload-time = "2025-11-30T20:23:16.105Z" },
+    { url = "https://files.pythonhosted.org/packages/4b/9a/453255d2f769fe44e07ea9785c8347edaf867f7026872e76c1ad9f7bed92/rpds_py-0.30.0-cp313-cp313t-manylinux_2_5_i686.manylinux1_i686.whl", hash = "sha256:6bdfdb946967d816e6adf9a3d8201bfad269c67efe6cefd7093ef959683c8de0", size = 414949, upload-time = "2025-11-30T20:23:17.539Z" },
+    { url = "https://files.pythonhosted.org/packages/a3/31/622a86cdc0c45d6df0e9ccb6becdba5074735e7033c20e401a6d9d0e2ca0/rpds_py-0.30.0-cp313-cp313t-musllinux_1_2_aarch64.whl", hash = "sha256:c77afbd5f5250bf27bf516c7c4a016813eb2d3e116139aed0096940c5982da94", size = 565790, upload-time = "2025-11-30T20:23:19.029Z" },
+    { url = "https://files.pythonhosted.org/packages/1c/5d/15bbf0fb4a3f58a3b1c67855ec1efcc4ceaef4e86644665fff03e1b66d8d/rpds_py-0.30.0-cp313-cp313t-musllinux_1_2_i686.whl", hash = "sha256:61046904275472a76c8c90c9ccee9013d70a6d0f73eecefd38c1ae7c39045a08", size = 590217, upload-time = "2025-11-30T20:23:20.885Z" },
+    { url = "https://files.pythonhosted.org/packages/6d/61/21b8c41f68e60c8cc3b2e25644f0e3681926020f11d06ab0b78e3c6bbff1/rpds_py-0.30.0-cp313-cp313t-musllinux_1_2_x86_64.whl", hash = "sha256:4c5f36a861bc4b7da6516dbdf302c55313afa09b81931e8280361a4f6c9a2d27", size = 555806, upload-time = "2025-11-30T20:23:22.488Z" },
+    { url = "https://files.pythonhosted.org/packages/f9/39/7e067bb06c31de48de3eb200f9fc7c58982a4d3db44b07e73963e10d3be9/rpds_py-0.30.0-cp313-cp313t-win32.whl", hash = "sha256:3d4a69de7a3e50ffc214ae16d79d8fbb0922972da0356dcf4d0fdca2878559c6", size = 211341, upload-time = "2025-11-30T20:23:24.449Z" },
+    { url = "https://files.pythonhosted.org/packages/0a/4d/222ef0b46443cf4cf46764d9c630f3fe4abaa7245be9417e56e9f52b8f65/rpds_py-0.30.0-cp313-cp313t-win_amd64.whl", hash = "sha256:f14fc5df50a716f7ece6a80b6c78bb35ea2ca47c499e422aa4463455dd96d56d", size = 225768, upload-time = "2025-11-30T20:23:25.908Z" },
+    { url = "https://files.pythonhosted.org/packages/86/81/dad16382ebbd3d0e0328776d8fd7ca94220e4fa0798d1dc5e7da48cb3201/rpds_py-0.30.0-cp314-cp314-macosx_10_12_x86_64.whl", hash = "sha256:68f19c879420aa08f61203801423f6cd5ac5f0ac4ac82a2368a9fcd6a9a075e0", size = 362099, upload-time = "2025-11-30T20:23:27.316Z" },
+    { url = "https://files.pythonhosted.org/packages/2b/60/19f7884db5d5603edf3c6bce35408f45ad3e97e10007df0e17dd57af18f8/rpds_py-0.30.0-cp314-cp314-macosx_11_0_arm64.whl", hash = "sha256:ec7c4490c672c1a0389d319b3a9cfcd098dcdc4783991553c332a15acf7249be", size = 353192, upload-time = "2025-11-30T20:23:29.151Z" },
+    { url = "https://files.pythonhosted.org/packages/bf/c4/76eb0e1e72d1a9c4703c69607cec123c29028bff28ce41588792417098ac/rpds_py-0.30.0-cp314-cp314-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:f251c812357a3fed308d684a5079ddfb9d933860fc6de89f2b7ab00da481e65f", size = 384080, upload-time = "2025-11-30T20:23:30.785Z" },
+    { url = "https://files.pythonhosted.org/packages/72/87/87ea665e92f3298d1b26d78814721dc39ed8d2c74b86e83348d6b48a6f31/rpds_py-0.30.0-cp314-cp314-manylinux_2_17_armv7l.manylinux2014_armv7l.whl", hash = "sha256:ac98b175585ecf4c0348fd7b29c3864bda53b805c773cbf7bfdaffc8070c976f", size = 394841, upload-time = "2025-11-30T20:23:32.209Z" },
+    { url = "https://files.pythonhosted.org/packages/77/ad/7783a89ca0587c15dcbf139b4a8364a872a25f861bdb88ed99f9b0dec985/rpds_py-0.30.0-cp314-cp314-manylinux_2_17_ppc64le.manylinux2014_ppc64le.whl", hash = "sha256:3e62880792319dbeb7eb866547f2e35973289e7d5696c6e295476448f5b63c87", size = 516670, upload-time = "2025-11-30T20:23:33.742Z" },
+    { url = "https://files.pythonhosted.org/packages/5b/3c/2882bdac942bd2172f3da574eab16f309ae10a3925644e969536553cb4ee/rpds_py-0.30.0-cp314-cp314-manylinux_2_17_s390x.manylinux2014_s390x.whl", hash = "sha256:4e7fc54e0900ab35d041b0601431b0a0eb495f0851a0639b6ef90f7741b39a18", size = 408005, upload-time = "2025-11-30T20:23:35.253Z" },
+    { url = "https://files.pythonhosted.org/packages/ce/81/9a91c0111ce1758c92516a3e44776920b579d9a7c09b2b06b642d4de3f0f/rpds_py-0.30.0-cp314-cp314-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:47e77dc9822d3ad616c3d5759ea5631a75e5809d5a28707744ef79d7a1bcfcad", size = 382112, upload-time = "2025-11-30T20:23:36.842Z" },
+    { url = "https://files.pythonhosted.org/packages/cf/8e/1da49d4a107027e5fbc64daeab96a0706361a2918da10cb41769244b805d/rpds_py-0.30.0-cp314-cp314-manylinux_2_31_riscv64.whl", hash = "sha256:b4dc1a6ff022ff85ecafef7979a2c6eb423430e05f1165d6688234e62ba99a07", size = 399049, upload-time = "2025-11-30T20:23:38.343Z" },
+    { url = "https://files.pythonhosted.org/packages/df/5a/7ee239b1aa48a127570ec03becbb29c9d5a9eb092febbd1699d567cae859/rpds_py-0.30.0-cp314-cp314-manylinux_2_5_i686.manylinux1_i686.whl", hash = "sha256:4559c972db3a360808309e06a74628b95eaccbf961c335c8fe0d590cf587456f", size = 415661, upload-time = "2025-11-30T20:23:40.263Z" },
+    { url = "https://files.pythonhosted.org/packages/70/ea/caa143cf6b772f823bc7929a45da1fa83569ee49b11d18d0ada7f5ee6fd6/rpds_py-0.30.0-cp314-cp314-musllinux_1_2_aarch64.whl", hash = "sha256:0ed177ed9bded28f8deb6ab40c183cd1192aa0de40c12f38be4d59cd33cb5c65", size = 565606, upload-time = "2025-11-30T20:23:42.186Z" },
+    { url = "https://files.pythonhosted.org/packages/64/91/ac20ba2d69303f961ad8cf55bf7dbdb4763f627291ba3d0d7d67333cced9/rpds_py-0.30.0-cp314-cp314-musllinux_1_2_i686.whl", hash = "sha256:ad1fa8db769b76ea911cb4e10f049d80bf518c104f15b3edb2371cc65375c46f", size = 591126, upload-time = "2025-11-30T20:23:44.086Z" },
+    { url = "https://files.pythonhosted.org/packages/21/20/7ff5f3c8b00c8a95f75985128c26ba44503fb35b8e0259d812766ea966c7/rpds_py-0.30.0-cp314-cp314-musllinux_1_2_x86_64.whl", hash = "sha256:46e83c697b1f1c72b50e5ee5adb4353eef7406fb3f2043d64c33f20ad1c2fc53", size = 553371, upload-time = "2025-11-30T20:23:46.004Z" },
+    { url = "https://files.pythonhosted.org/packages/72/c7/81dadd7b27c8ee391c132a6b192111ca58d866577ce2d9b0ca157552cce0/rpds_py-0.30.0-cp314-cp314-win32.whl", hash = "sha256:ee454b2a007d57363c2dfd5b6ca4a5d7e2c518938f8ed3b706e37e5d470801ed", size = 215298, upload-time = "2025-11-30T20:23:47.696Z" },
+    { url = "https://files.pythonhosted.org/packages/3e/d2/1aaac33287e8cfb07aab2e6b8ac1deca62f6f65411344f1433c55e6f3eb8/rpds_py-0.30.0-cp314-cp314-win_amd64.whl", hash = "sha256:95f0802447ac2d10bcc69f6dc28fe95fdf17940367b21d34e34c737870758950", size = 228604, upload-time = "2025-11-30T20:23:49.501Z" },
+    { url = "https://files.pythonhosted.org/packages/e8/95/ab005315818cc519ad074cb7784dae60d939163108bd2b394e60dc7b5461/rpds_py-0.30.0-cp314-cp314-win_arm64.whl", hash = "sha256:613aa4771c99f03346e54c3f038e4cc574ac09a3ddfb0e8878487335e96dead6", size = 222391, upload-time = "2025-11-30T20:23:50.96Z" },
+    { url = "https://files.pythonhosted.org/packages/9e/68/154fe0194d83b973cdedcdcc88947a2752411165930182ae41d983dcefa6/rpds_py-0.30.0-cp314-cp314t-macosx_10_12_x86_64.whl", hash = "sha256:7e6ecfcb62edfd632e56983964e6884851786443739dbfe3582947e87274f7cb", size = 364868, upload-time = "2025-11-30T20:23:52.494Z" },
+    { url = "https://files.pythonhosted.org/packages/83/69/8bbc8b07ec854d92a8b75668c24d2abcb1719ebf890f5604c61c9369a16f/rpds_py-0.30.0-cp314-cp314t-macosx_11_0_arm64.whl", hash = "sha256:a1d0bc22a7cdc173fedebb73ef81e07faef93692b8c1ad3733b67e31e1b6e1b8", size = 353747, upload-time = "2025-11-30T20:23:54.036Z" },
+    { url = "https://files.pythonhosted.org/packages/ab/00/ba2e50183dbd9abcce9497fa5149c62b4ff3e22d338a30d690f9af970561/rpds_py-0.30.0-cp314-cp314t-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:0d08f00679177226c4cb8c5265012eea897c8ca3b93f429e546600c971bcbae7", size = 383795, upload-time = "2025-11-30T20:23:55.556Z" },
+    { url = "https://files.pythonhosted.org/packages/05/6f/86f0272b84926bcb0e4c972262f54223e8ecc556b3224d281e6598fc9268/rpds_py-0.30.0-cp314-cp314t-manylinux_2_17_armv7l.manylinux2014_armv7l.whl", hash = "sha256:5965af57d5848192c13534f90f9dd16464f3c37aaf166cc1da1cae1fd5a34898", size = 393330, upload-time = "2025-11-30T20:23:57.033Z" },
+    { url = "https://files.pythonhosted.org/packages/cb/e9/0e02bb2e6dc63d212641da45df2b0bf29699d01715913e0d0f017ee29438/rpds_py-0.30.0-cp314-cp314t-manylinux_2_17_ppc64le.manylinux2014_ppc64le.whl", hash = "sha256:9a4e86e34e9ab6b667c27f3211ca48f73dba7cd3d90f8d5b11be56e5dbc3fb4e", size = 518194, upload-time = "2025-11-30T20:23:58.637Z" },
+    { url = "https://files.pythonhosted.org/packages/ee/ca/be7bca14cf21513bdf9c0606aba17d1f389ea2b6987035eb4f62bd923f25/rpds_py-0.30.0-cp314-cp314t-manylinux_2_17_s390x.manylinux2014_s390x.whl", hash = "sha256:e5d3e6b26f2c785d65cc25ef1e5267ccbe1b069c5c21b8cc724efee290554419", size = 408340, upload-time = "2025-11-30T20:24:00.2Z" },
+    { url = "https://files.pythonhosted.org/packages/c2/c7/736e00ebf39ed81d75544c0da6ef7b0998f8201b369acf842f9a90dc8fce/rpds_py-0.30.0-cp314-cp314t-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:626a7433c34566535b6e56a1b39a7b17ba961e97ce3b80ec62e6f1312c025551", size = 383765, upload-time = "2025-11-30T20:24:01.759Z" },
+    { url = "https://files.pythonhosted.org/packages/4a/3f/da50dfde9956aaf365c4adc9533b100008ed31aea635f2b8d7b627e25b49/rpds_py-0.30.0-cp314-cp314t-manylinux_2_31_riscv64.whl", hash = "sha256:acd7eb3f4471577b9b5a41baf02a978e8bdeb08b4b355273994f8b87032000a8", size = 396834, upload-time = "2025-11-30T20:24:03.687Z" },
+    { url = "https://files.pythonhosted.org/packages/4e/00/34bcc2565b6020eab2623349efbdec810676ad571995911f1abdae62a3a0/rpds_py-0.30.0-cp314-cp314t-manylinux_2_5_i686.manylinux1_i686.whl", hash = "sha256:fe5fa731a1fa8a0a56b0977413f8cacac1768dad38d16b3a296712709476fbd5", size = 415470, upload-time = "2025-11-30T20:24:05.232Z" },
+    { url = "https://files.pythonhosted.org/packages/8c/28/882e72b5b3e6f718d5453bd4d0d9cf8df36fddeb4ddbbab17869d5868616/rpds_py-0.30.0-cp314-cp314t-musllinux_1_2_aarch64.whl", hash = "sha256:74a3243a411126362712ee1524dfc90c650a503502f135d54d1b352bd01f2404", size = 565630, upload-time = "2025-11-30T20:24:06.878Z" },
+    { url = "https://files.pythonhosted.org/packages/3b/97/04a65539c17692de5b85c6e293520fd01317fd878ea1995f0367d4532fb1/rpds_py-0.30.0-cp314-cp314t-musllinux_1_2_i686.whl", hash = "sha256:3e8eeb0544f2eb0d2581774be4c3410356eba189529a6b3e36bbbf9696175856", size = 591148, upload-time = "2025-11-30T20:24:08.445Z" },
+    { url = "https://files.pythonhosted.org/packages/85/70/92482ccffb96f5441aab93e26c4d66489eb599efdcf96fad90c14bbfb976/rpds_py-0.30.0-cp314-cp314t-musllinux_1_2_x86_64.whl", hash = "sha256:dbd936cde57abfee19ab3213cf9c26be06d60750e60a8e4dd85d1ab12c8b1f40", size = 556030, upload-time = "2025-11-30T20:24:10.956Z" },
+    { url = "https://files.pythonhosted.org/packages/20/53/7c7e784abfa500a2b6b583b147ee4bb5a2b3747a9166bab52fec4b5b5e7d/rpds_py-0.30.0-cp314-cp314t-win32.whl", hash = "sha256:dc824125c72246d924f7f796b4f63c1e9dc810c7d9e2355864b3c3a73d59ade0", size = 211570, upload-time = "2025-11-30T20:24:12.735Z" },
+    { url = "https://files.pythonhosted.org/packages/d0/02/fa464cdfbe6b26e0600b62c528b72d8608f5cc49f96b8d6e38c95d60c676/rpds_py-0.30.0-cp314-cp314t-win_amd64.whl", hash = "sha256:27f4b0e92de5bfbc6f86e43959e6edd1425c33b5e69aab0984a72047f2bcf1e3", size = 226532, upload-time = "2025-11-30T20:24:14.634Z" },
+    { url = "https://files.pythonhosted.org/packages/69/71/3f34339ee70521864411f8b6992e7ab13ac30d8e4e3309e07c7361767d91/rpds_py-0.30.0-pp311-pypy311_pp73-macosx_10_12_x86_64.whl", hash = "sha256:c2262bdba0ad4fc6fb5545660673925c2d2a5d9e2e0fb603aad545427be0fc58", size = 372292, upload-time = "2025-11-30T20:24:16.537Z" },
+    { url = "https://files.pythonhosted.org/packages/57/09/f183df9b8f2d66720d2ef71075c59f7e1b336bec7ee4c48f0a2b06857653/rpds_py-0.30.0-pp311-pypy311_pp73-macosx_11_0_arm64.whl", hash = "sha256:ee6af14263f25eedc3bb918a3c04245106a42dfd4f5c2285ea6f997b1fc3f89a", size = 362128, upload-time = "2025-11-30T20:24:18.086Z" },
+    { url = "https://files.pythonhosted.org/packages/7a/68/5c2594e937253457342e078f0cc1ded3dd7b2ad59afdbf2d354869110a02/rpds_py-0.30.0-pp311-pypy311_pp73-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:3adbb8179ce342d235c31ab8ec511e66c73faa27a47e076ccc92421add53e2bb", size = 391542, upload-time = "2025-11-30T20:24:20.092Z" },
+    { url = "https://files.pythonhosted.org/packages/49/5c/31ef1afd70b4b4fbdb2800249f34c57c64beb687495b10aec0365f53dfc4/rpds_py-0.30.0-pp311-pypy311_pp73-manylinux_2_17_armv7l.manylinux2014_armv7l.whl", hash = "sha256:250fa00e9543ac9b97ac258bd37367ff5256666122c2d0f2bc97577c60a1818c", size = 404004, upload-time = "2025-11-30T20:24:22.231Z" },
+    { url = "https://files.pythonhosted.org/packages/e3/63/0cfbea38d05756f3440ce6534d51a491d26176ac045e2707adc99bb6e60a/rpds_py-0.30.0-pp311-pypy311_pp73-manylinux_2_17_ppc64le.manylinux2014_ppc64le.whl", hash = "sha256:9854cf4f488b3d57b9aaeb105f06d78e5529d3145b1e4a41750167e8c213c6d3", size = 527063, upload-time = "2025-11-30T20:24:24.302Z" },
+    { url = "https://files.pythonhosted.org/packages/42/e6/01e1f72a2456678b0f618fc9a1a13f882061690893c192fcad9f2926553a/rpds_py-0.30.0-pp311-pypy311_pp73-manylinux_2_17_s390x.manylinux2014_s390x.whl", hash = "sha256:993914b8e560023bc0a8bf742c5f303551992dcb85e247b1e5c7f4a7d145bda5", size = 413099, upload-time = "2025-11-30T20:24:25.916Z" },
+    { url = "https://files.pythonhosted.org/packages/b8/25/8df56677f209003dcbb180765520c544525e3ef21ea72279c98b9aa7c7fb/rpds_py-0.30.0-pp311-pypy311_pp73-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:58edca431fb9b29950807e301826586e5bbf24163677732429770a697ffe6738", size = 392177, upload-time = "2025-11-30T20:24:27.834Z" },
+    { url = "https://files.pythonhosted.org/packages/4a/b4/0a771378c5f16f8115f796d1f437950158679bcd2a7c68cf251cfb00ed5b/rpds_py-0.30.0-pp311-pypy311_pp73-manylinux_2_31_riscv64.whl", hash = "sha256:dea5b552272a944763b34394d04577cf0f9bd013207bc32323b5a89a53cf9c2f", size = 406015, upload-time = "2025-11-30T20:24:29.457Z" },
+    { url = "https://files.pythonhosted.org/packages/36/d8/456dbba0af75049dc6f63ff295a2f92766b9d521fa00de67a2bd6427d57a/rpds_py-0.30.0-pp311-pypy311_pp73-manylinux_2_5_i686.manylinux1_i686.whl", hash = "sha256:ba3af48635eb83d03f6c9735dfb21785303e73d22ad03d489e88adae6eab8877", size = 423736, upload-time = "2025-11-30T20:24:31.22Z" },
+    { url = "https://files.pythonhosted.org/packages/13/64/b4d76f227d5c45a7e0b796c674fd81b0a6c4fbd48dc29271857d8219571c/rpds_py-0.30.0-pp311-pypy311_pp73-musllinux_1_2_aarch64.whl", hash = "sha256:dff13836529b921e22f15cb099751209a60009731a68519630a24d61f0b1b30a", size = 573981, upload-time = "2025-11-30T20:24:32.934Z" },
+    { url = "https://files.pythonhosted.org/packages/20/91/092bacadeda3edf92bf743cc96a7be133e13a39cdbfd7b5082e7ab638406/rpds_py-0.30.0-pp311-pypy311_pp73-musllinux_1_2_i686.whl", hash = "sha256:1b151685b23929ab7beec71080a8889d4d6d9fa9a983d213f07121205d48e2c4", size = 599782, upload-time = "2025-11-30T20:24:35.169Z" },
+    { url = "https://files.pythonhosted.org/packages/d1/b7/b95708304cd49b7b6f82fdd039f1748b66ec2b21d6a45180910802f1abf1/rpds_py-0.30.0-pp311-pypy311_pp73-musllinux_1_2_x86_64.whl", hash = "sha256:ac37f9f516c51e5753f27dfdef11a88330f04de2d564be3991384b2f3535d02e", size = 562191, upload-time = "2025-11-30T20:24:36.853Z" },
+]
+
+[[package]]
 name = "ruff"
 version = "0.15.5"
 source = { registry = "https://pypi.org/simple" }
@@ -1457,6 +1763,15 @@ wheels = [
 ]
 
 [[package]]
+name = "smmap"
+version = "5.0.3"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/1f/ea/49c993d6dfdd7338c9b1000a0f36817ed7ec84577ae2e52f890d1a4ff909/smmap-5.0.3.tar.gz", hash = "sha256:4d9debb8b99007ae47165abc08670bd74cb74b5227dda7f643eccc4e9eb5642c", size = 22506, upload-time = "2026-03-09T03:43:26.1Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/c1/d4/59e74daffcb57a07668852eeeb6035af9f32cbfd7a1d2511f17d2fe6a738/smmap-5.0.3-py3-none-any.whl", hash = "sha256:c106e05d5a61449cf6ba9a1e650227ecfb141590d2a98412103ff35d89fc7b2f", size = 24390, upload-time = "2026-03-09T03:43:24.361Z" },
+]
+
+[[package]]
 name = "sortedcontainers"
 version = "2.4.0"
 source = { registry = "https://pypi.org/simple" }
@@ -1472,6 +1787,24 @@ source = { registry = "https://pypi.org/simple" }
 sdist = { url = "https://files.pythonhosted.org/packages/a2/6d/90764092216fa560f6587f83bb70113a8ba510ba436c6476a2b47359057c/stevedore-5.7.0.tar.gz", hash = "sha256:31dd6fe6b3cbe921e21dcefabc9a5f1cf848cf538a1f27543721b8ca09948aa3", size = 516200, upload-time = "2026-02-20T13:27:06.765Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/69/06/36d260a695f383345ab5bbc3fd447249594ae2fa8dfd19c533d5ae23f46b/stevedore-5.7.0-py3-none-any.whl", hash = "sha256:fd25efbb32f1abb4c9e502f385f0018632baac11f9ee5d1b70f88cc5e22ad4ed", size = 54483, upload-time = "2026-02-20T13:27:05.561Z" },
+]
+
+[[package]]
+name = "tabulate"
+version = "0.10.0"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/46/58/8c37dea7bbf769b20d58e7ace7e5edfe65b849442b00ffcdd56be88697c6/tabulate-0.10.0.tar.gz", hash = "sha256:e2cfde8f79420f6deeffdeda9aaec3b6bc5abce947655d17ac662b126e48a60d", size = 91754, upload-time = "2026-03-04T18:55:34.402Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/99/55/db07de81b5c630da5cbf5c7df646580ca26dfaefa593667fc6f2fe016d2e/tabulate-0.10.0-py3-none-any.whl", hash = "sha256:f0b0622e567335c8fabaaa659f1b33bcb6ddfe2e496071b743aa113f8774f2d3", size = 39814, upload-time = "2026-03-04T18:55:31.284Z" },
+]
+
+[[package]]
+name = "tenacity"
+version = "9.1.4"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/47/c6/ee486fd809e357697ee8a44d3d69222b344920433d3b6666ccd9b374630c/tenacity-9.1.4.tar.gz", hash = "sha256:adb31d4c263f2bd041081ab33b498309a57c77f9acf2db65aadf0898179cf93a", size = 49413, upload-time = "2026-02-07T10:45:33.841Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/d7/c1/eb8f9debc45d3b7918a32ab756658a0904732f75e555402972246b0b8e71/tenacity-9.1.4-py3-none-any.whl", hash = "sha256:6095a360c919085f28c6527de529e76a06ad89b23659fa881ae0649b867a9d55", size = 28926, upload-time = "2026-02-07T10:45:32.24Z" },
 ]
 
 [[package]]
@@ -1538,6 +1871,15 @@ wheels = [
 ]
 
 [[package]]
+name = "traitlets"
+version = "5.14.3"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/eb/79/72064e6a701c2183016abbbfedaba506d81e30e232a68c9f0d6f6fcd1574/traitlets-5.14.3.tar.gz", hash = "sha256:9ed0579d3502c94b4b3732ac120375cda96f923114522847de4b3bb98b96b6b7", size = 161621, upload-time = "2024-04-19T11:11:49.746Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/00/c0/8f5d070730d7836adc9c9b6408dec68c6ced86b304a9b26a14df072a6e8c/traitlets-5.14.3-py3-none-any.whl", hash = "sha256:b74e89e397b1ed28cc831db7aea759ba6640cb3de13090ca145426688ff1ac4f", size = 85359, upload-time = "2024-04-19T11:11:46.763Z" },
+]
+
+[[package]]
 name = "typing-extensions"
 version = "4.15.0"
 source = { registry = "https://pypi.org/simple" }
@@ -1585,4 +1927,37 @@ wheels = [
     { url = "https://files.pythonhosted.org/packages/07/f6/d0e5b343768e8bcb4cda79f0f2f55051bf26177ecd5651f84c07567461cf/watchdog-6.0.0-py3-none-win32.whl", hash = "sha256:07df1fdd701c5d4c8e55ef6cf55b8f0120fe1aef7ef39a1c6fc6bc2e606d517a", size = 79065, upload-time = "2024-11-01T14:07:09.525Z" },
     { url = "https://files.pythonhosted.org/packages/db/d9/c495884c6e548fce18a8f40568ff120bc3a4b7b99813081c8ac0c936fa64/watchdog-6.0.0-py3-none-win_amd64.whl", hash = "sha256:cbafb470cf848d93b5d013e2ecb245d4aa1c8fd0504e863ccefa32445359d680", size = 79070, upload-time = "2024-11-01T14:07:10.686Z" },
     { url = "https://files.pythonhosted.org/packages/33/e8/e40370e6d74ddba47f002a32919d91310d6074130fe4e17dabcafc15cbf1/watchdog-6.0.0-py3-none-win_ia64.whl", hash = "sha256:a1914259fa9e1454315171103c6a30961236f508b9b623eae470268bbcc6a22f", size = 79067, upload-time = "2024-11-01T14:07:11.845Z" },
+]
+
+[[package]]
+name = "wily"
+version = "1.25.0"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "click" },
+    { name = "colorlog" },
+    { name = "gitpython" },
+    { name = "nbformat" },
+    { name = "plotly" },
+    { name = "progress" },
+    { name = "radon" },
+    { name = "tabulate" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/d0/b9/bc2e31a2f416f2e8b04333569325bd7bd20bf0a6db3d53ca83bc5f73b5b3/wily-1.25.0.tar.gz", hash = "sha256:b63e85be5855aa3bfdd17db9b27475624539adc3bc1c8265805437ed5256a581", size = 1855966, upload-time = "2023-10-11T03:49:10.44Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/b9/80/68448bb3ac5c41414f395a4ebfc0c134ef90be0571261243f5a3a0e4859e/wily-1.25.0-py3-none-any.whl", hash = "sha256:c8f6333c77fad438f646d49225409b4fb5336474834a52beea18097205d09204", size = 69251, upload-time = "2023-10-11T03:48:57.016Z" },
+]
+
+[[package]]
+name = "xenon"
+version = "0.9.3"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "pyyaml" },
+    { name = "radon" },
+    { name = "requests" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/c4/7c/2b341eaeec69d514b635ea18481885a956d196a74322a4b0942ef0c31691/xenon-0.9.3.tar.gz", hash = "sha256:4a7538d8ba08aa5d79055fb3e0b2393c0bd6d7d16a4ab0fcdef02ef1f10a43fa", size = 9883, upload-time = "2024-10-21T10:27:53.722Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/6f/5d/29ff8665b129cafd147d90b86e92babee32e116e3c84447107da3e77f8fb/xenon-0.9.3-py2.py3-none-any.whl", hash = "sha256:6e2c2c251cc5e9d01fe984e623499b13b2140fcbf74d6c03a613fa43a9347097", size = 8966, upload-time = "2024-10-21T10:27:51.121Z" },
 ]


### PR DESCRIPTION
## Summary

- **feat: `use_latest_version` parameter** (#40, PR #99) — allows deserializers to fetch the latest schema version from the registry instead of using the writer's schema ID
- **feat: client authentication — `BearerAuth` and `KeycloakAuth`** (#38, PR #92) — static token, callable provider, and Keycloak client-credentials with threshold-based auto-refresh
- **chore: Xenon complexity CI gate and Wily trend tracking** (#69, PR #82) — hard CI gate on cyclomatic complexity + informational trend analysis
- **fix(ci): pin SLSA generator to commit SHA** (#81)
- **fix(ci): run CI on push to release branches** (#87)
- **chore: address non-blocking code review notes from v0.4.0** (#80)

## Issues closed by this release

Closes #40
Closes #69

## Test plan

- [x] All CI checks green on all included PRs
- [ ] Full CI passes on the release PR itself
- [ ] 100% test coverage maintained

🤖 Generated with [Claude Code](https://claude.com/claude-code)